### PR TITLE
fix:daily reward history schema, resolves #39

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -152,15 +152,17 @@ CREATE TABLE `blessings_history` (
 
 CREATE TABLE `daily_reward_history` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `streak` smallint(2) NOT NULL DEFAULT 0,
+  `daystreak` smallint(2) NOT NULL DEFAULT '0',
   `event` varchar(255) DEFAULT NULL,
-  `time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP(),
-  `instant` tinyint(3) unsigned NOT NULL DEFAULT 0,
+  `time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `instant` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `player_id` int(11) NOT NULL,
   `timestamp` int(11) NOT NULL,
+  `streak` smallint(2) NOT NULL,
+  `description` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `player_id` (`player_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 AUTO_INCREMENT=1 ;
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
 
 
 -- --------------------------------------------------------

--- a/schema.sql
+++ b/schema.sql
@@ -151,18 +151,15 @@ CREATE TABLE `blessings_history` (
 --
 
 CREATE TABLE `daily_reward_history` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `daystreak` smallint(2) NOT NULL DEFAULT '0',
-  `event` varchar(255) DEFAULT NULL,
-  `time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `instant` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `id` int(11) NOT NULL,
+  `daystreak` smallint(2) NOT NULL DEFAULT 0,
   `player_id` int(11) NOT NULL,
-  `timestamp` int(11) NOT NULL,
+  `timestamp` int(11) NOT NULL CURRENT_TIMESTAMP,
   `streak` smallint(2) NOT NULL,
   `description` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `player_id` (`player_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 
 -- --------------------------------------------------------
@@ -1385,6 +1382,11 @@ ALTER TABLE `accounts`
 -- AUTO_INCREMENT for table `account_ban_history`
 --
 ALTER TABLE `account_ban_history`
+  MODIFY `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT;
+--
+-- AUTO_INCREMENT for table `daily_reward_history`
+--
+ALTER TABLE `daily_reward_history`
   MODIFY `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT;
 --
 -- AUTO_INCREMENT for table `guilds`


### PR DESCRIPTION
- removed unused columns: `time`, `instant` and `streak`
- add missing column: `daystreak`
- fix default value for `timestamp`

reference: https://github.com/opentibiabr/OTServBR-Global/blob/06078a3314780a8c15402058c7b00208e3896372/data/modules/scripts/dailyreward/dailyreward.lua#L217-L242