### PR TITLE
fix: schema.sql table field without default value

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -526,7 +526,7 @@ CREATE TABLE `players` (
   `signature` varchar(255) NOT NULL DEFAULT '',
   `marriage_spouse` int(11) NOT NULL DEFAULT '-1',
   `loyalty_ranking` tinyint(1) NOT NULL DEFAULT '0',
-  `bonus_rerolls` bigint(21) NOT NULL
+  `bonus_rerolls` bigint(21) NOT NULL DEFAULT '0'
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 --


### PR DESCRIPTION
Table 'players' field 'bonus_rerolls' was without default value and that was making 'myaac' website not being able to create players.
