### PR TITLE
Add mutex to control reload process

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -64,7 +64,7 @@ std::multimap<ScriptEnvironment*, Item*> ScriptEnvironment::tempItems;
 
 LuaEnvironment g_luaEnvironment;
 
-std::mutex m;
+std::mutex mutexReload;
 
 ScriptEnvironment::ScriptEnvironment()
 {
@@ -495,16 +495,16 @@ void LuaScriptInterface::reportError(const char* function, const std::string& er
 
 bool LuaScriptInterface::pushFunction(int32_t functionId)
 {
-	m.lock();
+	mutexReload.lock();
 	lua_rawgeti(luaState, LUA_REGISTRYINDEX, eventTableRef);
 	if (!isTable(luaState, -1)) {
-		m.unlock();
+		mutexReload.unlock();
 		return false;
 	}
 
 	lua_rawgeti(luaState, -1, functionId);
 	lua_replace(luaState, -2);
-	m.unlock();
+	mutexReload.unlock();
 	return isFunction(luaState, -1);
 }
 
@@ -4821,11 +4821,11 @@ int LuaScriptInterface::luaGameGetClientVersion(lua_State* L)
 int LuaScriptInterface::luaGameReload(lua_State* L)
 {
 	// Game.reload(reloadType)
-	m.lock();
+	mutexReload.lock();
 	ReloadTypes_t reloadType = getNumber<ReloadTypes_t>(L, 1);
 	if (!reloadType) {
 		lua_pushnil(L);
-		m.unlock();
+		mutexReload.unlock();
 		return 1;
 	}
 
@@ -4836,7 +4836,7 @@ int LuaScriptInterface::luaGameReload(lua_State* L)
 		pushBoolean(L, g_game.reload(reloadType));
 	}
 	lua_gc(g_luaEnvironment.getLuaState(), LUA_GCCOLLECT, 0);
-	m.unlock();
+	mutexReload.unlock();
 	return 1;
 }
 


### PR DESCRIPTION
The server allows to run several reloads command but there are no control of when it finishes, so when we run the second reload, it will clean the same context that the first command is reading, and that will make the server crash.

To avoid that it was added an mutex to control the reload process and not let a second process to start before the first finish.


Tested here: Ubuntu 18.04