### PR TITLE
doCheckHouses commented out

### DIFF
--- a/data/globalevents/globalevents.xml
+++ b/data/globalevents/globalevents.xml
@@ -59,7 +59,7 @@
 	<globalevent type="startup" name="rashid" script="rashid.lua"/>
 	<globalevent type="startup" name="yasir" script="worldchanges/yasir.lua"/>
 
-	<globalevent type="startup" name="doCheckHouses" script="others/doCheckHouses.lua" />
+	<!-- <globalevent type="startup" name="doCheckHouses" script="others/doCheckHouses.lua" /> -->
 	<globalevent name="checkInbox" interval="30000" script="others/checkInbox.lua"/>
 	<globalevent interval="100000" name="GuildWar" script="guildwar.lua"/>
 </globalevents>


### PR DESCRIPTION
I've commented out the doCheckHouses line in globalevents.xml
This is a useful script that we should retain, but do not want enabled by default.

I think it is okay to just leave it commented out.