### PR TITLE
Writing and product type correction

### DIFF
--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -1,6 +1,6 @@
 -- Internal Use
 STONE_SKIN_AMULET = 2197
-GOLD_POUNCH = 26377
+GOLD_POUCH = 26377
 ITEM_STORE_INBOX = 26052
 CONTAINER_WEIGHT = 100000 -- 10k = 10000 oz | this function is only for containers, item below the weight determined here can be moved inside the container, for others items look game.cpp at the src
 -- exercise_ids
@@ -444,8 +444,8 @@ function Player:onMoveItem(item, count, fromPosition, toPosition, fromCylinder, 
 			self:sendCancelMessage(RETURNVALUE_CONTAINERNOTENOUGHROOM)
 			return false
 		end
-		-- Gold Pounch
-		if (containerTo:getId() == GOLD_POUNCH) then
+		-- Gold Pouch
+		if (containerTo:getId() == GOLD_POUCH) then
 			if (not (item:getId() == ITEM_CRYSTAL_COIN or item:getId() == ITEM_PLATINUM_COIN or item:getId() == ITEM_GOLD_COIN)) then
 				self:sendCancelMessage("You can move only money to this container.")
 				return false
@@ -453,8 +453,8 @@ function Player:onMoveItem(item, count, fromPosition, toPosition, fromCylinder, 
 		end
 	end
 
-	-- No move gold pounch
-	if item:getId() == GOLD_POUNCH then
+	-- No move gold pouch
+	if item:getId() == GOLD_POUCH then
 		self:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
 		return false
 	end

--- a/data/modules/scripts/gamestore/gamestore.lua
+++ b/data/modules/scripts/gamestore/gamestore.lua
@@ -5,7 +5,7 @@
   OFFER_TYPE_ALLBLESSINGS (it was not a non-item) then:
   1) If the offer's name didn't exist in items.xml then the offer has been removed.
     These items were removed from the shop because the name didn't exist in items.xml
-    [ "Alchemistic Scales", "Alchemist Table", "Pile of Alchemist Books", "Alchemist Cup Board", "Torch of Change", "Ferumbras Bust", "Queen Eloise Bust", "Arrival At Thais Painting", "Tibia Street Painting", "Ferumbras Portrait", "SupremeHealth Potion", "Health Keg", "Strong Health Keg", "Great Health Keg", "Ultimate Health Keg", "Supreme Health Keg", "Mana Keg", "Strong Mana Keg", "Great Mana Keg", "Ultimate Mana Keg", "Ultimate Spirit Keg", "Disintegrate Rune", "Paralyse Rune", "Alchemistic Scales", "Alchemist Table", "Pile of Alchemist Books", "Alchemist Cup Board", "Torch of Change", "Ferumbras Bust", "Queen Eloise Bust", "Arrival At Thais Painting", "Tibia Street Painting", "Ferumbras Portrait", "Demon Pit", "Venoream Table Clock", "StoneTiles", "Bath Tube", "Daily Reward Shrine", "Health Cask", "Strong Health Cask", "Great Health Cask", "Ultimate Health Cask", "Supreme Health Cask", "Mana Cask", "Strong Mana Cask", "Great Mana Cask", "Ultimate Mana Cask", "Great Spirit Cask", "Ultimate Spirit Cask", "Skull Lamp", "Fish Tank", "Lit Protectress Lamp", "Lit Predator Lamp", "LordlyTapestry", "All-Seeing Tapestry", "Gold Pounch" ]
+    [ "Alchemistic Scales", "Alchemist Table", "Pile of Alchemist Books", "Alchemist Cup Board", "Torch of Change", "Ferumbras Bust", "Queen Eloise Bust", "Arrival At Thais Painting", "Tibia Street Painting", "Ferumbras Portrait", "SupremeHealth Potion", "Health Keg", "Strong Health Keg", "Great Health Keg", "Ultimate Health Keg", "Supreme Health Keg", "Mana Keg", "Strong Mana Keg", "Great Mana Keg", "Ultimate Mana Keg", "Ultimate Spirit Keg", "Disintegrate Rune", "Paralyse Rune", "Alchemistic Scales", "Alchemist Table", "Pile of Alchemist Books", "Alchemist Cup Board", "Torch of Change", "Ferumbras Bust", "Queen Eloise Bust", "Arrival At Thais Painting", "Tibia Street Painting", "Ferumbras Portrait", "Demon Pit", "Venoream Table Clock", "StoneTiles", "Bath Tube", "Daily Reward Shrine", "Health Cask", "Strong Health Cask", "Great Health Cask", "Ultimate Health Cask", "Supreme Health Cask", "Mana Cask", "Strong Mana Cask", "Great Mana Cask", "Ultimate Mana Cask", "Great Spirit Cask", "Ultimate Spirit Cask", "Skull Lamp", "Fish Tank", "Lit Protectress Lamp", "Lit Predator Lamp", "LordlyTapestry", "All-Seeing Tapestry", "Gold Pouch" ]
   2) If the offer's name did exist in items.xml then the thingId of the offer has been updated
      so that it matches the item id in items.xml.
 ]]
@@ -3264,15 +3264,13 @@ GameStore.Categories = {
         }
   ]]
  --[[         {
-                icons = { "Gold_Pounch.png" },
-                name = "Gold Pounch",
-                id = 29020,
-                count = 500,
-                number = 1,
-                type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
+                name = "Gold Pouch",
+                id = 26377,
+                count = 1,
+                type = GameStore.OfferTypes.OFFER_TYPE_POUCH,
                 price = 900,
-                icons = { "Product_UsefulThings_MagicConverter.png" },
-                description = "Carries as many gold, platinum or crystal coins as your capacity allows, however, no other items.\n\n\n- only usable by purchasing character\n- will be sent to your Store inbox and can only be stored there and in depot box\n- can only be purchased once\n- use it to open it\n- always placed on the first position of your Store inbox" 
+                icons = { "Product_MagicCoinPurse.png" },
+                description = "With Gold Pouch you can carry the amount of gold without having to keep many knapsacks in the backpack, this product allows you to be charged as much gold as your ability allows."
         }
   ]]
  --[[         {

--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -24,7 +24,7 @@ GameStore.OfferTypes = {
   OFFER_TYPE_TEMPLE = 13,
   OFFER_TYPE_BLESSINGS = 14,
   OFFER_TYPE_PREMIUM = 15,
-  OFFER_TYPE_POUNCH = 16,
+  OFFER_TYPE_POUCH = 16,
   OFFER_TYPE_ALLBLESSINGS = 17
 }
 
@@ -273,7 +273,7 @@ function parseBuyStoreOffer(playerId, msg)
           offer.type ~= GameStore.OfferTypes.OFFER_TYPE_PREYSLOT and
           offer.type ~= GameStore.OfferTypes.OFFER_TYPE_TEMPLE and
           offer.type ~= GameStore.OfferTypes.OFFER_TYPE_SEXCHANGE and
-          offer.type ~= GameStore.OfferTypes.OFFER_TYPE_POUNCH and
+          offer.type ~= GameStore.OfferTypes.OFFER_TYPE_POUCH and
           not offer.id) then
     return queueSendStoreAlertToUser("This offer is unavailable [1]", 350, playerId, GameStore.StoreErrors.STORE_ERROR_INFORMATION)
   end
@@ -289,8 +289,8 @@ function parseBuyStoreOffer(playerId, msg)
   -- Handled errors are thrown to indicate that the purchase has failed;
   -- Handled errors have a code index and unhandled errors do not
   local pcallOk, pcallError = pcall(function()
-    if offer.type == GameStore.OfferTypes.OFFER_TYPE_ITEM               then GameStore.processItemPurchase(player, offer.id, offer.count)
-      elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_POUNCH         then GameStore.processItemPurchase(player, offer.id, offer.count)
+    if offer.type == GameStore.OfferTypes.OFFER_TYPE_ITEM                 then GameStore.processItemPurchase(player, offer.id, offer.count)
+      elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_POUCH          then GameStore.processItemPurchase(player, offer.id, offer.count)
       elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_BLESSINGS      then GameStore.processSignleBlessingPurchase(player, offer.id)
       elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_ALLBLESSINGS   then GameStore.processAllBlessingsPurchase(player)
       elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_PREMIUM        then GameStore.processPremiumPurchase(player, offer.id)
@@ -481,7 +481,7 @@ function sendShowStoreOffers(playerId, category)
           offer.type ~= GameStore.OfferTypes.OFFER_TYPE_PREYBONUS and
           offer.type ~= GameStore.OfferTypes.OFFER_TYPE_TEMPLE and
           offer.type ~= GameStore.OfferTypes.OFFER_TYPE_SEXCHANGE and
-          offer.type ~= GameStore.OfferTypes.OFFER_TYPE_POUNCH and
+          offer.type ~= GameStore.OfferTypes.OFFER_TYPE_POUCH and
           not offer.id then
         disabled = 1
       end
@@ -492,11 +492,11 @@ function sendShowStoreOffers(playerId, category)
       end
 
       if disabled ~= 1 then
-        if offer.type == GameStore.OfferTypes.OFFER_TYPE_POUNCH then
-          local pounch = player:getItemById(26377, true)
-          if pounch then
+        if offer.type == GameStore.OfferTypes.OFFER_TYPE_POUCH then
+          local pouch = player:getItemById(26377, true)
+          if pouch then
             disabled = 1
-            disabledReason = "You already have Gold Pounch."
+            disabledReason = "You already have Gold Pouch."
           end
         elseif offer.type == GameStore.OfferTypes.OFFER_TYPE_BLESSINGS then
           if player:hasBlessing(offer.id) and offer.id < 9 then


### PR DESCRIPTION
Correction that allows the normal use of gold pouch and also correction in the item name.

The code itself works 100% according to my tests, it can be used immediately by simply revolving the comment.