### PR TITLE
Double respawn bug #461

### DIFF
--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -293,14 +293,8 @@ void Spawn::cleanup()
 		uint32_t spawnId = it->first;
 		Monster* monster = it->second;
 		if (monster->isRemoved()) {
-			if (spawnId != 0) {
-				spawnMap[spawnId].lastSpawn = OTSYS_TIME();
-			}
-
+			spawnMap[spawnId].lastSpawn = OTSYS_TIME();
 			monster->decrementReferenceCounter();
-			it = spawnedMap.erase(it);
-		} else if (!isInSpawnZone(monster->getPosition()) && spawnId != 0) {
-			spawnedMap.insert(spawned_pair(0, monster));
 			it = spawnedMap.erase(it);
 		} else {
 			++it;


### PR DESCRIPTION
This is an attempt to fix the issue described on #461.

As discussed on #502, increasing the radius of all monsters is not a good approach. It wouldn't be feasible to implement this solution plus it is not the purpose of the radius; Therefore, we should try to fix the problem at the source code level. I reverted that change on this PR.

**Things to consider:**

- The code that I removed [here](https://github.com/opentibiabr/OTServBR-Global/compare/develop...newacc12:bug/double-respawn?expand=1#diff-eecbbd78a76c67f252961d084417115aL302-L304) doesn't make any sense to me. It seems pointless to move a monster to spawn id 0 as there is no other place in the code checking for this condition (to the best of my knowledge). In my opinion, this code is doing nothing other than cause the issue with the double respawn.

- I tested the respawn and the anti-lure system and both seems to be working as it was before this PR.

Hopefully the community can roughly test it before making a decision to merge it. Unfortunately, I am not knowledge enough about the source code to guarantee that this will not break some existing functionality.