### PR TITLE
fix a problem with exercise weapons and a server crash

### DIFF
--- a/data/actions/scripts/others/objects/exerciseTraining.lua
+++ b/data/actions/scripts/others/objects/exerciseTraining.lua
@@ -15,7 +15,6 @@ local skills = {
 
 local dummies = {32142, 32143, 32144, 32145, 32146, 32147, 32148, 32149}
 local skillRate = 1*configManager.getNumber(configKeys.RATE_SKILL)
-local isTraining = 37
 -- skillRate = 1.1*30 = 30 + 3 (10%) = 33x
 
 local function start_train(pid,start_pos,itemid,fpos)
@@ -65,8 +64,10 @@ local function start_train(pid,start_pos,itemid,fpos)
 		end
 	else
 		stopEvent(training)
-		player:sendCancelMessage("Your training has stopped.")
-		player:setStorageValue(isTraining,0)
+		if player then -- verificar se o player ainda existe (logado), caso esteja, enviar mensagem de erro e parar treino. isso evita erros no console
+			player:sendCancelMessage("Your training has stopped.")
+			player:setStorageValue(isTraining,0)
+		end
 	end
 	return true
 end

--- a/data/actions/scripts/others/objects/exerciseTraining.lua
+++ b/data/actions/scripts/others/objects/exerciseTraining.lua
@@ -47,12 +47,12 @@ local function start_train(pid,start_pos,itemid,fpos)
 								return true
 							end
 							local training = addEvent(start_train, voc:getAttackSpeed(), pid,start_pos,itemid,fpos)
-							player:setStorageValue(isTraining,1)
+							player:setStorageValue(Storage.isTraining,1)
 						else
 							exercise:remove(1)
 							player:sendCancelMessage("Your training weapon vanished.")
 							stopEvent(training)
-							player:setStorageValue(isTraining,0)
+							player:setStorageValue(Storage.isTraining,0)
 						end
 					end
 				end
@@ -60,13 +60,13 @@ local function start_train(pid,start_pos,itemid,fpos)
 		else
 			player:sendCancelMessage("Your training has stopped.")
 			stopEvent(training)
-			player:setStorageValue(isTraining,0)
+			player:setStorageValue(Storage.isTraining,0)
 		end
 	else
 		stopEvent(training)
 		if player then -- verificar se o player ainda existe (logado), caso esteja, enviar mensagem de erro e parar treino. isso evita erros no console
 			player:sendCancelMessage("Your training has stopped.")
-			player:setStorageValue(isTraining,0)
+			player:setStorageValue(Storage.isTraining,0)
 		end
 	end
 	return true
@@ -81,7 +81,7 @@ function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 				stopEvent(training)
 				return false
 			end
-			if player:getStorageValue(isTraining) == 1 then
+			if player:getStorageValue(Storage.isTraining) == 1 then
 				player:sendCancelMessage("You are already training.")
 				return false
 			end

--- a/data/creaturescripts/scripts/others/login.lua
+++ b/data/creaturescripts/scripts/others/login.lua
@@ -218,8 +218,8 @@ function onLogin(player)
 		player:sendTibiaTime(hours, minutes)
 	end
 	
-	if player:getStorageValue(isTraining) == 1 then -- redefinir storage de exercise weapon
-		player:setStorageValue(isTraining,0)
+	if player:getStorageValue(Storage.isTraining) == 1 then -- redefinir storage de exercise weapon
+		player:setStorageValue(Storage.isTraining,0)
 	end
     return true
 end

--- a/data/creaturescripts/scripts/others/login.lua
+++ b/data/creaturescripts/scripts/others/login.lua
@@ -217,5 +217,9 @@ function onLogin(player)
 		local minutes = worldTime % 60
 		player:sendTibiaTime(hours, minutes)
 	end
+	
+	if player:getStorageValue(isTraining) == 1 then -- redefinir storage de exercise weapon
+		player:setStorageValue(isTraining,0)
+	end
     return true
 end

--- a/data/global.lua
+++ b/data/global.lua
@@ -1,7 +1,5 @@
 dofile('data/lib/libs.lua')
 
-isTraining = 37
-
 NOT_MOVEABLE_ACTION = 8000
 PARTY_PROTECTION = 1 -- Set to 0 to disable.
 ADVANCED_SECURE_MODE = 1 -- Set to 0 to disable.

--- a/data/global.lua
+++ b/data/global.lua
@@ -1,5 +1,7 @@
 dofile('data/lib/libs.lua')
 
+isTraining = 37
+
 NOT_MOVEABLE_ACTION = 8000
 PARTY_PROTECTION = 1 -- Set to 0 to disable.
 ADVANCED_SECURE_MODE = 1 -- Set to 0 to disable.

--- a/data/lib/miscellaneous/051-storages.lua
+++ b/data/lib/miscellaneous/051-storages.lua
@@ -1492,6 +1492,7 @@ GlobalStorage = {
 	NaginataStone = 50058,
 	ExpBoost = 51052,
 	SwordOfFury = 5635,
-	XpDisplayMode = 5634
+	XpDisplayMode = 5634,
+	isTraining = 37
 
 }

--- a/src/rsa.cpp
+++ b/src/rsa.cpp
@@ -31,9 +31,12 @@ static CryptoPP::AutoSeededRandomPool prng;
 
 void RSA::decrypt(char* msg) const
 {
-	CryptoPP::Integer m{reinterpret_cast<uint8_t*>(msg), 128};
-	auto c = pk.CalculateInverse(prng, m);
-	c.Encode(reinterpret_cast<uint8_t*>(msg), 128);
+	try {
+		CryptoPP::Integer m{reinterpret_cast<uint8_t*>(msg), 128};
+		auto c = pk.CalculateInverse(prng, m);
+		c.Encode(reinterpret_cast<uint8_t*>(msg), 128);
+	} catch (const CryptoPP::Exception& e) {
+	}
 }
 
 static const std::string header = "-----BEGIN RSA PRIVATE KEY-----";


### PR DESCRIPTION
Fixes a problem when a player logout while training with exercise weapons, which prevent the player to start training again.

Fix a server crash when the client trying to login uses another RSA key that is not expected by the server.