### PR TITLE
Adjust exercise weapons and kegs capacity check

### DIFF
--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -1084,7 +1084,7 @@ function GameStore.processStackablePurchase(player, offerId, offerCount, offerNa
     return ((itemId >= ITEM_KEG_START and itemId <= ITEM_KEG_END) or (itemId >= ITEM_EXERCISE_START and itemId <= ITEM_EXERCISE_END))
   end
 
-  if (isKegExerciseItem(offerId) and player:getFreeCapacity() < ItemType(offerId):getWeight(1)) or player:getFreeCapacity() < ItemType(offerId):getWeight(offerCount)then
+  if (isKegExerciseItem(offerId) and player:getFreeCapacity() < ItemType(offerId):getWeight(1)) then
     return error({code = 0, message = "Please make sure you have free capacity to hold this item."})
   end
 


### PR DESCRIPTION
Removed a piece of code that was calculating cap based on offercount (item charges) instead of item count (which is 1)