### PR TITLE
Workaroud for RSA server crash

### DIFF
--- a/src/rsa.cpp
+++ b/src/rsa.cpp
@@ -31,9 +31,12 @@ static CryptoPP::AutoSeededRandomPool prng;
 
 void RSA::decrypt(char* msg) const
 {
-	CryptoPP::Integer m{reinterpret_cast<uint8_t*>(msg), 128};
-	auto c = pk.CalculateInverse(prng, m);
-	c.Encode(reinterpret_cast<uint8_t*>(msg), 128);
+	try {
+		CryptoPP::Integer m{reinterpret_cast<uint8_t*>(msg), 128};
+		auto c = pk.CalculateInverse(prng, m);
+		c.Encode(reinterpret_cast<uint8_t*>(msg), 128);
+		} catch (const CryptoPP::Exception& e) {
+	}
 }
 
 static const std::string header = "-----BEGIN RSA PRIVATE KEY-----";


### PR DESCRIPTION
Workaround to prevent the server to crash by logging in with a RSA key that is not expected by the server.