### PR TITLE
[revscriptsys] call clear() on action/movement vectors 

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -16111,6 +16111,9 @@ int LuaScriptInterface::luaActionRegister(lua_State* L)
 			return 1;
 		}
 		pushBoolean(L, g_actions->registerLuaEvent(action));
+		action->getActionIdRange().clear();
+		action->getItemIdRange().clear();
+		action->getUniqueIdRange().clear();
 	} else {
 		lua_pushnil(L);
 	}
@@ -16426,6 +16429,10 @@ int LuaScriptInterface::luaMoveEventRegister(lua_State* L)
 			return 1;
 		}
 		pushBoolean(L, g_moveEvents->registerLuaEvent(moveevent));
+		moveevent->getItemIdRange().clear();
+		moveevent->getActionIdRange().clear();
+		moveevent->getUniqueIdRange().clear();
+		moveevent->getPosList().clear();
 	} else {
 		lua_pushnil(L);
 	}


### PR DESCRIPTION
- this will clear the temp vectors used to store the id/aid/uid/pos for the actions/movements after calling the register() method.

Signed-off-by: Renato Foot <costallat@hotmail.com>