### PR TITLE
patch droploot

### DIFF
--- a/data/creaturescripts/scripts/others/droploot.lua
+++ b/data/creaturescripts/scripts/others/droploot.lua
@@ -17,7 +17,7 @@ function onDeath(player, corpse, killer, mostDamage, unjustified, mostDamage_unj
 			end
 		end
 
-		if not isPlayer or not player:hasBlessing(5) then
+		if not isPlayer or not player:hasBlessing(6) then
 			player:removeItem(ITEM_AMULETOFLOSS, 1, -1, false)
 		end
 	else


### PR DESCRIPTION
Since NPC blessings go from 1,6 (Inquisition and other blessing NPCs), the check for blessing has to be the same value, otherwise the player is going to lose inventory items.