### PR TITLE
luajit: Fix lua.hpp path detection, especially for vcpkg

### DIFF
--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -21,7 +21,11 @@
 
 #include "otpch.h"
 
+#if __has_include("luajit/lua.hpp")
+#include <luajit/lua.hpp>
+#else
 #include <lua.hpp>
+#endif
 
 #include "configmanager.h"
 #include "game.h"

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -22,7 +22,11 @@
 #ifndef OT_SRC_LUASCRIPT_H_
 #define OT_SRC_LUASCRIPT_H_
 
-#include <lua.hpp>
+#if __has_include("luajit/lua.hpp")
+	#include <luajit/lua.hpp>
+#else
+	#include <lua.hpp>
+#endif
 
 #if LUA_VERSION_NUM >= 502
 #ifndef LUA_COMPAT_ALL


### PR DESCRIPTION
This fixes the problem on windows that lua.hpp cannot be found, because vcpkg by default installs luajit, which results in <luajit/lua.hpp>

Signed-off-by: Renato Foot Guimarães Costallat <costallat@hotmail.com>