### PR TITLE
Fix NPC Walking radius

### DIFF
--- a/data/globalevents/scripts/server/npcsSpawn.lua
+++ b/data/globalevents/scripts/server/npcsSpawn.lua
@@ -3,8 +3,10 @@ local function _spawnNPCs()
     local npc = mapNpcs[i]
 
     if npc and npc.name and npc.pos then
-      local customNpc = Game.createNpc(npc.name, npc.pos)
-
+		local spawn = Game.createNpc(npc.name, npc.pos)
+		if spawn then
+		spawn:setMasterPos(npc.pos)
+		end
     end
   end
   return true
@@ -15,3 +17,4 @@ function onStartup()
     print('Advanced NPC spawn system | All NPCs will be loaded trough lib, instead of spawn.xml. Keep in mind, all your NPCs should be working, neighter the system will have a breakpoint..')
     return true
 end
+--https://github.com/opentibiabr/OTServBR-Global

--- a/data/globalevents/scripts/server/npcsSpawn.lua
+++ b/data/globalevents/scripts/server/npcsSpawn.lua
@@ -5,7 +5,7 @@ local function _spawnNPCs()
     if npc and npc.name and npc.pos then
 		local spawn = Game.createNpc(npc.name, npc.pos)
 		if spawn then
-		spawn:setMasterPos(npc.pos)
+			spawn:setMasterPos(npc.pos)
 		end
     end
   end
@@ -14,7 +14,7 @@ end
 
 function onStartup()
     addEvent(_spawnNPCs, 1 * 1000)
-    print('Advanced NPC spawn system | All NPCs will be loaded trough lib, instead of spawn.xml. Keep in mind, all your NPCs should be working, neighter the system will have a breakpoint..')
+    print('Advanced NPC spawn system | All NPCs will be loaded trough lib, instead of spawn.xml. Keep in mind, all your NPCs should be working, neighter the system will have a breakpoint.')
     return true
 end
 --https://github.com/opentibiabr/OTServBR-Global

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -161,6 +161,8 @@ bool Npc::loadFromXml()
 
 	if ((attr = npcNode.attribute("walkradius"))) {
 		masterRadius = pugi::cast<int32_t>(attr.value());
+	} else {
+		masterRadius = 2;
 	}
 
 	if ((attr = npcNode.attribute("ignoreheight"))) {


### PR DESCRIPTION
Set NPC default walking radius when there is no one set on NPC XML file.
Set NPC masterpos on spawn. Walking radius will respect the masterpos reference.

Define walking radius on NPC file with tag
> walkradius="3"
