### PR TITLE
Fix Bone Fiddle

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -40727,6 +40727,7 @@
 	<item id="33276" article="a" name="bone fiddle">
 		<attribute key="weight" value="3800" />
 		<attribute key="absorbPercentLifeDrain" value="5" />
+		<attribute key="slotType" value="ammo" />
 		<attribute key="showattributes" value="1" />
 	</item>
 	<item id="33277" article="a" name="silver chimes">


### PR DESCRIPTION
Added slotType with value "ammo" for item ID 33276 (Bone Fiddle).