### PR TITLE
Remove "No move parcel very heavy"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -368,3 +368,4 @@ theforgottenserver.exe
 data/world/otservbr.otbm
 config.lua
 tfs.exe
+sftp-config.json

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -530,6 +530,14 @@ function Player:onMoveItem(item, count, fromPosition, toPosition, fromCylinder, 
 		end
 	end
 
+
+	-- No move parcel very heavy
+	if ItemType(item:getId()):isContainer() and item:getWeight() > CONTAINER_WEIGHT then
+        self:sendCancelMessage("Your cannot move this item too heavy.")
+        return false
+    end
+
+
 	if tile and tile:getItemById(370) then -- Trapdoor
 		self:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
 		self:getPosition():sendMagicEffect(CONST_ME_POFF)

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -530,14 +530,6 @@ function Player:onMoveItem(item, count, fromPosition, toPosition, fromCylinder, 
 		end
 	end
 
-
-	-- No move parcel very heavy
-	if ItemType(item:getId()):isContainer() and item:getWeight() > CONTAINER_WEIGHT then
-        self:sendCancelMessage("Your cannot move this item too heavy.")
-        return false
-    end
-
-
 	if tile and tile:getItemById(370) then -- Trapdoor
 		self:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
 		self:getPosition():sendMagicEffect(CONST_ME_POFF)

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -48,7 +48,7 @@ extern Imbuements* g_imbuements;
 
 MuteCountMap Player::muteCountMap;
 
-uint32_t Player::playerAutoID = 0x10000000;
+uint32_t Player::playerAutoID = 0x10010000;
 
 Player::Player(ProtocolGame_ptr p) :
 	Creature(), lastPing(OTSYS_TIME()), lastPong(lastPing), inbox(new Inbox(ITEM_INBOX)), client(std::move(p))

--- a/src/player.h
+++ b/src/player.h
@@ -142,7 +142,9 @@ class Player final : public Creature, public Cylinder
 
 		void setID() final {
 			if (id == 0) {
-				id = playerAutoID++;
+				if (guid != 0) {
+					id = 0x10000000 + guid;
+				}
 			}
 		}
 


### PR DESCRIPTION
What is the need to prevent the player from moving a parcel/container's if it has 1000oz+? This only gets in the way, as it is normal a player move much more than that.

[![](https://image.prntscr.com/image/D6UfYoxlRFKdiad6noaSaw.png)][![](https://image.prntscr.com/image/aQIyGgO1Tpq6BIHs3LRg9A.png)]