### PR TITLE
Include on .gitignore sftp-config.json for Sublime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -368,3 +368,6 @@ theforgottenserver.exe
 data/world/otservbr.otbm
 config.lua
 tfs.exe
+
+# SFTP for Sublime
+sftp-config.json


### PR DESCRIPTION
Sublime Text users need SFTP to test on remote servers. For ease, has been added in the .gitignore the default file name (sftp-config.json) that Sublime Text creates for SFTP connection.