### PR TITLE
Include some CUSTOMS to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -368,6 +368,8 @@ theforgottenserver.exe
 data/world/otservbr.otbm
 config.lua
 tfs.exe
+tfs
+build/*
 
 # SFTP for Sublime
 sftp-config.json


### PR DESCRIPTION
I'm adding these two lines to make it easier for anyone working directly on Linux. It is usually compiled in the folder name: build. So I added this folder as well as the server startup file (tfs)