### PR TITLE
Fix next reward countdown time

### DIFF
--- a/data/modules/scripts/dailyreward/dailyreward.lua
+++ b/data/modules/scripts/dailyreward/dailyreward.lua
@@ -60,7 +60,7 @@ local DAILY_REWARD_STATUS_PREMIUM = 1
 
 DailyReward = {
   testMode = false,
-  serverTimeThreshold = (4 * 60),
+  serverTimeThreshold = (24 * 60 * 60), -- Counting down 24hours from last server save
 
   storages = {
     -- Player


### PR DESCRIPTION
It fixes countdown time to next server save (24 hours from previous one).
I think it was set like this for testing purposes.
Along with #679 it fixes #257.
![daily](https://user-images.githubusercontent.com/29408915/67643588-65dd2080-f919-11e9-95d1-5ea097095698.png)
