### PR TITLE
Update spdlog to last version

### DIFF
--- a/docker/server-only/build-env/Dockerfile.build
+++ b/docker/server-only/build-env/Dockerfile.build
@@ -14,7 +14,7 @@ RUN apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/test
   pugixml-dev \
   git
 
-RUN git clone https://github.com/LIU-Yinyi/spdlog.git /tmp/spdlog \
+RUN git clone https://github.com/gabime/spdlog.git /tmp/spdlog \
  && mkdir /tmp/spdlog/build && cd /tmp/spdlog/build \
  && cmake .. && make && make install
 

--- a/docker/server-only/build-env/Dockerfile.build
+++ b/docker/server-only/build-env/Dockerfile.build
@@ -12,7 +12,11 @@ RUN apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/test
   make \
   mariadb-connector-c-dev \
   pugixml-dev \
-  spdlog-dev
+  git
+
+RUN git clone https://github.com/LIU-Yinyi/spdlog.git /tmp/spdlog \
+ && mkdir /tmp/spdlog/build && cd /tmp/spdlog/build \
+ && cmake .. && make && make install
 
 ENTRYPOINT cd /tmp/otserver && mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DDEBUG_LOG=ON .. && make -j`nproc`
 


### PR DESCRIPTION
This workaround is for issue #702 , installing the last version of spdlog from git repository.