### PR TITLE
Fix itemID Mysterious Scroll

### DIFF
--- a/data/actions/actions.xml
+++ b/data/actions/actions.xml
@@ -220,7 +220,7 @@
 	<action uniqueid="9534" script="quests/ferumbras ascendant/ratLever.lua" />
 	<action fromuid="9535" touid="9538" script="quests/ferumbras ascendant/theshattererLevers.lua" />
 	<action uniqueid="9540" script="quests/ferumbras ascendant/reward.lua" />
-	<action itemid="25521" script="quests/ferumbras ascendant/mysteriousScroll.lua" />
+	<action itemid="34784" script="quests/ferumbras ascendant/mysteriousScroll.lua" />
 
 	<!-- Forgotten Knowledge -->
 	<action itemid="26402" script="quests/forgotten knowledge/lantern.lua"/>

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -42173,6 +42173,10 @@
 		<attribute key="corpseType" value="blood" />
 	</item>
 	<item id="34783" name="unknown item" />
+	<item id="34784" article="a" name="mysterious scroll">
+		<attribute key="description" value="Strange symbols hard to decrypt. You wonder if one of the symbols looks like a foreign and mysterious creature." />
+		<attribute key="weight" value="850" />
+	</item>
 	<item id="34785" article="a" name="recipe for magical paint">
 		<attribute key="weight" value="100" />
 		<attribute key="description" value="It says: Mix sun fruit juice with sapphire dust and dream essence to create magical paint. This paint may transform imagination into reality." />

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -37806,7 +37806,7 @@
 		<attribute key="attack" value="5" />
 		<attribute key="weaponType" value="club" />
 	</item>
-	<item id="29211" article="a" name="moon mirror" >
+	<item id="29211" article="a" name="lit moon mirror" >
 		<attribute key="weight" value="200" />
 		<attribute key="slotType" value="ammo" />
 		<attribute key="absorbPercentDeath" value="5" />
@@ -42773,12 +42773,6 @@
 	</item>
 	<item id="35150" article="a" name="rainbow necklace">
 		<attribute key="weight" value="490" />
-		<attribute key="armor" value="2" />
-		<attribute key="slotType" value="necklace" />
-		<attribute key="absorbPercentFire" value="6" />
-		<attribute key="absorbPercentPhysical" value="3" />
-		<attribute key="absorbPercentIce" value="-5" />
-		<attribute key="showattributes" value="1" />
 	</item>
 	<item id="35151" article="a" name="bright bell">
 		<attribute key="weight" value="220" />

--- a/data/monster/Quests/Ferumbras Ascendant/Bosses/ferumbras mortal shell.xml
+++ b/data/monster/Quests/Ferumbras Ascendant/Bosses/ferumbras mortal shell.xml
@@ -101,7 +101,7 @@
 		<item id="7418" chance="600"/><!--nightmare blade -->
 		<item id="2539" chance="800"/><!--phoenix shield -->
 		<item id="2520" chance="800"/><!-- demon shield-->
-		<item id="25521" chance="150"/><!--mysterious scroll -->
+		<item id="34784" chance="150"/><!--mysterious scroll -->
 		<item id="2148" countmax="100" chance="100000"/><!-- gold coin -->
 		<item id="7896" chance="800"/><!-- glacier kilt-->
 		<item id="2472" chance="400"/><!--Magic plate armor -->

--- a/data/movements/movements.xml
+++ b/data/movements/movements.xml
@@ -3263,8 +3263,4 @@
 		<vocation name="Royal Paladin" showInDescription="0" />
 	</movevent>
 	<movevent event="DeEquip" itemid="34981" slot="necklace" function="onDeEquipItem" />
-
-	<movevent event="Equip" itemid="35150" slot="necklace" level="220" function="onEquipItem" > <!-- Rainbow Necklace -->
-	</movevent>
-	<movevent event="DeEquip" itemid="35150" slot="necklace" function="onDeEquipItem" />
 </movements>


### PR DESCRIPTION
The itemID being used was from another quest (https://www.tibiawiki.com.br/wiki/Translation_Scroll). I changed it to a similar sprite that was dont use.