### PR TITLE
Fix party loot in Loot channel

### DIFF
--- a/data/lib/core/party.lua
+++ b/data/lib/core/party.lua
@@ -1,10 +1,10 @@
 function Party.broadcastPartyLoot(self, text)
-	self:getLeader():sendTextMessage(MESSAGE_INFO_DESCR, text)
+	self:getLeader():sendTextMessage(MESSAGE_LOOT, text)
 	local membersList = self:getMembers()
 	for i = 1, #membersList do
 		local player = membersList[i]
 		if player then
-			player:sendTextMessage(MESSAGE_INFO_DESCR, text)
+			player:sendTextMessage(MESSAGE_LOOT, text)
 		end
 	end
 end


### PR DESCRIPTION
`MESSAGE_LOOT` automatically switches to "Loot" channel if this channel is open, else it broadcasts in "Server Log". Without this change party members always get loot info in "Server Log", even when "Loot" channel is open.
![loot](https://user-images.githubusercontent.com/29408915/68235315-576ec300-0003-11ea-83c4-de4b3b4214fe.png)
