### PR TITLE
Update dailyreward.lua

### DIFF
--- a/data/modules/scripts/dailyreward/dailyreward.lua
+++ b/data/modules/scripts/dailyreward/dailyreward.lua
@@ -515,7 +515,7 @@ function Player.selectDailyReward(self, msg)
   end
 
   if (dailyTable.type == DAILY_REWARD_TYPE_PREY_REROLL) then
-    self:setPreyBonusRerolls(reward.rerollCount)
+    self:setPreyBonusRerolls(self:getPreyBonusRerolls() + reward.rerollCount)
     DailyReward.insertHistory(self:getGuid(), self:getDayStreak(), "Claimed reward no. " .. self:getDayStreak() + 1 .. ". Picked reward: " .. reward.rerollCount .. "x Prey bonus reroll(s)")
     DailyReward.processReward(playerId, source)
   end


### PR DESCRIPTION
Currently when the player gets the re-roll rewards from daily rewards the script is setting that count to 2, instead of getting the current amount the player has, and adding 2 to that amount. this fixes that problem.