### PR TITLE
Include in .gitignore: client_assertions.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -370,6 +370,7 @@ config.lua
 tfs.exe
 tfs
 build/*
+client_assertions.txt
 
 # SFTP for Sublime
 sftp-config.json


### PR DESCRIPTION
Added on .gitignore the client_assertions.txt. File generate from game.cpp to move debug assertions to database