### PR TITLE
Small Fix: Container/Item Weight

### DIFF
--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -3,8 +3,8 @@ STONE_SKIN_AMULET = 2197
 GOLD_POUCH = 26377
 ITEM_STORE_INBOX = 26052
 
-DISABLE_CONTAINER_WEIGHT = 0 -- 0 = YES, ENABLE | 1 = NO, DISABLE
-CONTAINER_WEIGHT = 100000 -- 10k = 10000 oz | this function is only for containers, item below the weight determined here can be moved inside the container, for others items look game.cpp at the src
+DISABLE_CONTAINER_WEIGHT = 0 -- 0 = ENABLE CONTAINER WEIGHT CHECK | 1 = DISABLE CONTAINER WEIGHT CHECK
+CONTAINER_WEIGHT = 1000000 -- 1000000 = 10k = 10000.00 oz | this function is only for containers, item below the weight determined here can be moved inside the container, for others items look game.cpp at the src
 
 -- Items sold on the store that should not be moved off the store container
 local storeItemID = {32384,32385,32386,32387,32388,32389,32124,32125,32126,32127,32128,32129,32109,33299,26378,29020}
@@ -289,6 +289,12 @@ function Player:onMoveItem(item, count, fromPosition, toPosition, fromCylinder, 
 		return false
 	end
 
+	-- No move parcel very heavy
+	if DISABLE_CONTAINER_WEIGHT == 0 and ItemType(item:getId()):isContainer() and item:getWeight() > CONTAINER_WEIGHT then
+        self:sendCancelMessage("Your cannot move this item too heavy.")
+        return false
+    end
+
 	-- Loot Analyser apenas 11.x+
 	if self:getClient().os == CLIENTOS_NEW_WINDOWS then
     	local t = Tile(fromCylinder:getPosition())
@@ -531,14 +537,6 @@ function Player:onMoveItem(item, count, fromPosition, toPosition, fromCylinder, 
 			return false
 		end
 	end
-
-
-	-- No move parcel very heavy
-	if DISABLE_CONTAINER_WEIGHT == 0 and ItemType(item:getId()):isContainer() and item:getWeight() > CONTAINER_WEIGHT then
-        self:sendCancelMessage("Your cannot move this item too heavy.")
-        return false
-    end
-
 
 	if tile and tile:getItemById(370) then -- Trapdoor
 		self:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -170,8 +170,9 @@ bool Container::unserializeItemNode(OTB::Loader& loader, const OTB::Node& node, 
 void Container::updateItemWeight(int32_t diff)
 {
 	totalWeight += diff;
-	if (Container* parentContainer = getParentContainer()) {
-		parentContainer->updateItemWeight(diff);
+	Container* parentContainer = this;	// credits: SaiyansKing
+	while ((parentContainer = parentContainer->getParentContainer()) != nullptr) {
+		parentContainer->totalWeight += diff;
 	}
 }
 

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -630,12 +630,6 @@ ReturnValue Tile::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t tileF
 			return RETURNVALUE_NOTPOSSIBLE;
 		}
 
-		if (hasFlag(TILESTATE_PROTECTIONZONE) || !hasFlag(TILESTATE_PROTECTIONZONE)) {
-			if (item->getWeight() >= 1000000) {
-				return RETURNVALUE_NOTPOSSIBLE;
-			}
-		}
-
 		if (hasBitSet(FLAG_NOLIMIT, tileFlags)) {
 			return RETURNVALUE_NOERROR;
 		}
@@ -851,12 +845,6 @@ void Tile::addThing(int32_t, Thing* thing)
 		TileItemVector* items = getItemList();
 		if (items && items->size() >= 0xFFFF) {
 			return /*RETURNVALUE_NOTPOSSIBLE*/;
-		}
-
-		if (hasFlag(TILESTATE_PROTECTIONZONE) || !hasFlag(TILESTATE_PROTECTIONZONE)) {
-			if (item->getWeight() >= 1000000) {
-				return /*RETURNVALUE_NOTPOSSIBLE*/;
-			}
 		}
 
 		item->setParent(this);
@@ -1467,12 +1455,6 @@ void Tile::internalAddThing(uint32_t, Thing* thing)
 		TileItemVector* items = makeItemList();
 		if (items->size() >= 0xFFFF) {
 			return /*RETURNVALUE_NOTPOSSIBLE*/;
-		}
-
-		if (hasFlag(TILESTATE_PROTECTIONZONE) || !hasFlag(TILESTATE_PROTECTIONZONE)) {
-			if (item->getWeight() >= 1000000) {
-				return /*RETURNVALUE_NOTPOSSIBLE*/;
-			}
 		}
 
 		if (itemType.alwaysOnTop) {


### PR DESCRIPTION
- Small fix in player.lua about blocking container movement when overweight;
- I also removed this lock from tile.cpp (the function did the same thing);
- Optimization of container.cpp