### PR TITLE
Incorrect double speed value on monsters

### DIFF
--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -799,7 +799,7 @@ MonsterType* Monsters::loadMonster(const std::string& file, const std::string& m
 	}
 
 	if ((attr = monsterNode.attribute("speed"))) {
-		mType->info.baseSpeed = pugi::cast<int32_t>(attr.value()) * 2.55;
+		mType->info.baseSpeed = pugi::cast<int32_t>(attr.value());
 	}
 
 	if ((attr = monsterNode.attribute("manacost"))) {


### PR DESCRIPTION
New monsters should be created with double speed, as it is made with items and other speed formulas.
In game speed is already been halfed, so we need to always set it doubled on monsters.

For example:
https://tibia.fandom.com/wiki/Retching_Horror
This creature has an speed of 180, therefore, it's speed value on the XML file should be doubled to 360 and NOT 180.
So we double it on XML instead of the source, because it is going to affect all old monsters correctly created.

Other infos:
Mount speed is doubled as it should be: https://github.com/opentibiabr/otservbr-global/blob/develop/data/XML/mounts.xml
Boots of haste has speed of 40
Server send halfed speed to the client (real speed): 
https://github.com/opentibiabr/otservbr-global/blob/25bea350f45225d6568ddb727f6033672988a318/src/protocolgame.cpp#L2596
https://github.com/opentibiabr/otservbr-global/blob/25bea350f45225d6568ddb727f6033672988a318/src/protocolgame.cpp#L3577