### PR TITLE
Fix walk delay of creatures

### DIFF
--- a/src/creature.h
+++ b/src/creature.h
@@ -72,7 +72,7 @@ class Item;
 class Tile;
 
 static constexpr int32_t EVENT_CREATURECOUNT = 10;
-static constexpr int32_t EVENT_CREATURE_THINK_INTERVAL = 1000;
+static constexpr int32_t EVENT_CREATURE_THINK_INTERVAL = 200;
 static constexpr int32_t EVENT_CHECK_CREATURE_INTERVAL = (EVENT_CREATURE_THINK_INTERVAL / EVENT_CREATURECOUNT);
 
 class FrozenPathingConditionCall


### PR DESCRIPTION
Creatures as White Deer that must run of players have a biggest delay to walk, making too easy catch them. Since I didn't find any monster related walking interval, I assumed that the problem was in creatures "thinking" interval and changed it from 1000 to 200. I haven't studied how much this affects in the server performance, but fixed the problem and all looks fine.