### PR TITLE
FIX Summons breaking house items

### DIFF
--- a/data/monster/Summons/Emberwing.xml
+++ b/data/monster/Summons/Emberwing.xml
@@ -12,7 +12,7 @@
 		<flag illusionable="0" />
 		<flag convinceable="0" />
 		<flag pushable="1" />
-		<flag canpushitems="1" />
+		<flag canpushitems="0" />
 		<flag canpushcreatures="1" />
 		<flag staticattack="98" />
 		<flag targetdistance="2" />

--- a/data/monster/Summons/Grovebeast.xml
+++ b/data/monster/Summons/Grovebeast.xml
@@ -12,7 +12,7 @@
 		<flag illusionable="0"/>
 		<flag convinceable="0"/>
 		<flag pushable="1"/>
-		<flag canpushitems="1"/>
+		<flag canpushitems="0"/>
 		<flag canpushcreatures="1"/>
 		<flag staticattack="98"/>
 		<flag targetdistance="0"/>

--- a/data/monster/Summons/Skullfrost.xml
+++ b/data/monster/Summons/Skullfrost.xml
@@ -12,7 +12,7 @@
 		<flag illusionable="0" />
 		<flag convinceable="0" />
 		<flag pushable="1" />
-		<flag canpushitems="1" />
+		<flag canpushitems="0" />
 		<flag canpushcreatures="1" />
 		<flag staticattack="98" />
 		<flag targetdistance="3" />

--- a/data/monster/Summons/Thundergiant.xml
+++ b/data/monster/Summons/Thundergiant.xml
@@ -12,7 +12,7 @@
 		<flag illusionable="0" />
 		<flag convinceable="1" />
 		<flag pushable="1" />
-		<flag canpushitems="1" />
+		<flag canpushitems="0" />
 		<flag canpushcreatures="1" />
 		<flag staticattack="98" />
 		<flag targetdistance="0" />


### PR DESCRIPTION
Since it's already set in the source, summons will walk through any house item, box and etc, not breaking it when theres no other free sqm.

This doesn't fix summons walking through house walls