### PR TITLE
Twist of Fate and Equip Drop

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2139,7 +2139,7 @@ void Player::death(Creature* lastHitCreature)
 					removeBlessing(i, 1);
 				}
 			}
-			setDropLoot(false)
+			setDropLoot(false);
 		} else {
 			if (lastHitPlayer && hasBlessing(1)) {
 				removeBlessing(1, 1);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2130,18 +2130,23 @@ void Player::death(Creature* lastHitCreature)
 			}
 		}
 
-		if (hasBlessing(8)) {
+		uint8_t maxBlessing = 8;
+		if (hasBlessing(6)) {
 			if (lastHitPlayer && hasBlessing(1)) {
 				removeBlessing(1, 1);
 			} else {
-				for (int i = 2; i <= 8; i++) {
+				for (int i = 2; i <= maxBlessing; i++) {
 					removeBlessing(i, 1);
 				}
 			}
+			setDropLoot(false)
 		} else {
-			uint8_t maxBlessing = (operatingSystem == CLIENTOS_NEW_WINDOWS) ? 8 : 6;
-			for (int i = 1; i <= maxBlessing; i++) {
-				removeBlessing(i, 1);
+			if (lastHitPlayer && hasBlessing(1)) {
+				removeBlessing(1, 1);
+			} else {
+				for (int i = 2; i <= maxBlessing; i++) {
+					removeBlessing(i, 1);
+				}
 			}
 		}
 


### PR DESCRIPTION
We are removing Twist of Fate only if there were last hit by a player.
We need to setDropLoot to false when we have all basic blessings