### PR TITLE
Increase Dispatcher throughput by no longer clearing spectator cache after every call 

### DIFF
--- a/src/tasks.cpp
+++ b/src/tasks.cpp
@@ -60,8 +60,6 @@ void Dispatcher::threadMain()
 				++dispatcherCycle;
 				// execute it
 				(*task)();
-
-				g_game.map.clearSpectatorCache();
 			}
 			delete task;
 		} else {


### PR DESCRIPTION
Increase Dispatcher throughput by no longer clearing spectator cache after every call.

https://github.com/otland/forgottenserver/pull/2693