### PR TITLE
Fix issue #874 and removed the check of imbue equipped item.

### DIFF
--- a/data/events/events.xml
+++ b/data/events/events.xml
@@ -24,7 +24,7 @@
 	<event class="Player" method="onReportRuleViolation" enabled="1" />
 	<event class="Player" method="onTurn" enabled="1" />					<!-- move with ( ctrl + arrows ) like to TFS 0.3.x : 0.4 -->
 	<event class="Player" method="onTradeRequest" enabled="1" /> 			<!-- move with ( ctrl + arrows ) like to TFS 0.3.x : 0.4 -->
-	<event class="Player" method="onTradeAccept" enabled="0" />
+	<event class="Player" method="onTradeAccept" enabled="1" />
 	<event class="Player" method="onGainExperience" enabled="1" />
 	<event class="Player" method="onLoseExperience" enabled="0" />
 	<event class="Player" method="onGainSkillTries" enabled="1" />

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -644,6 +644,7 @@ function Player:onTradeRequest(target, item)
 end
 
 function Player:onTradeAccept(target, item, targetItem)
+	self:closeImbuementWindow(target)
 	return true
 end
 

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -644,7 +644,7 @@ function Player:onTradeRequest(target, item)
 end
 
 function Player:onTradeAccept(target, item, targetItem)
-	self:closeImbuementWindow(target)
+	target:closeImbuementWindow(self)
 	return true
 end
 

--- a/data/lib/core/imbuements.lua
+++ b/data/lib/core/imbuements.lua
@@ -144,6 +144,12 @@ function Player.sendImbuementResult(self, errorType, message)
 	return
 end
 
+function Player.closeImbuementWindow(self)
+	local msg = NetworkMessage()
+	msg:addByte(0xEC)
+	msg:sendToPlayer(self)
+end
+
 -- Items functions
 function Item.getImbuementDuration(self, slot)
 	local info = 0

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -549,7 +549,7 @@ bool enterMarket(Player* player, Item*, const Position&, Thing*, const Position&
 	return true;
 }
 
-bool useImbueShrine(Player* player, Item*, const Position&, Thing* target, bool)
+bool useImbueShrine(Player* player, Item*, const Position&, Thing* target, const Position& toPos, bool)
 {
 	Item* item = target ? target->getItem() : nullptr;
 	if (!item) {
@@ -566,6 +566,11 @@ bool useImbueShrine(Player* player, Item*, const Position&, Thing* target, bool)
 	if (item->getTopParent() != player) {
 		player->sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have to pick up the item to imbue it.");
 		return false;
+	}
+	
+	if (!(toPos.y & 0x40)) {
+		player->sendImbuementWindow(target->getItem());
+		return true;
 	}
 
 	player->sendImbuementWindow(target->getItem());

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -549,7 +549,7 @@ bool enterMarket(Player* player, Item*, const Position&, Thing*, const Position&
 	return true;
 }
 
-bool useImbueShrine(Player* player, Item*, const Position&, Thing* target, const Position& toPos, bool)
+bool useImbueShrine(Player* player, Item*, const Position&, Thing* target, bool)
 {
 	Item* item = target ? target->getItem() : nullptr;
 	if (!item) {

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -568,11 +568,6 @@ bool useImbueShrine(Player* player, Item*, const Position&, Thing* target, const
 		return false;
 	}
 
-	if (!(toPos.y & 0x40)) {
-		player->sendTextMessage(MESSAGE_EVENT_ADVANCE, "You cannot imbue an equipped item.");
-		return false;
-	}
-
 	player->sendImbuementWindow(target->getItem());
 	return true;
 }


### PR DESCRIPTION
This PR fix the issue #874 and and remove the check to imbue the equipped item (global it is possible to imbue).

The imbuement window will close when players accept the trade, making it impossible to execute the bug (global, the imbue window also closes when giving trade).

![gif2](https://user-images.githubusercontent.com/8551443/75152088-01737780-56e7-11ea-8f36-ed3e893ae3bf.gif)

Thanks for @gpedro for help with script logic.