### PR TITLE
Save attributes and characters in a certain period of time

### DIFF
--- a/data/globalevents/globalevents.xml
+++ b/data/globalevents/globalevents.xml
@@ -53,6 +53,7 @@
 	<globalevent type="startup" name="ServerStartup" script="startup.lua" />
 	<globalevent type="record" name="PlayerRecord" script="record.lua" />
 	<globalevent name="ServerSave" time="05:55:00" script="serversave.lua" />
+	<globalevent name="SavePlayer" interval="1800000" script="saveplayer.lua" />
 	<globalevent type="startup" name="rashid" script="rashid.lua"/>
 	<globalevent type="startup" name="yasir" script="worldchanges/yasir.lua"/>
 	

--- a/data/globalevents/scripts/saveplayer.lua
+++ b/data/globalevents/scripts/saveplayer.lua
@@ -1,0 +1,13 @@
+local cleanMapAtSave = false
+local function serverSave(interval)
+    if cleanMapAtSave then
+        cleanMap()
+    end
+
+    saveServer()
+end
+
+function onThink(interval)
+    addEvent(serverSave, 60000, interval)
+    return true
+end


### PR DESCRIPTION
The script originally existed, but for some reason I don't know, it was removed.
What currently happens is that if the server crashes or is closed without saving it will return to the last server save, as there is no script that saves every time, this can be configured for every 30 minutes or one hour, according to the particularity of each user, but I recommend that it is every 30 minutes.