### PR TITLE
Fix Unique Loot & Gold Pouch

### DIFF
--- a/data/modules/scripts/gamestore/gamestore.lua
+++ b/data/modules/scripts/gamestore/gamestore.lua
@@ -3724,7 +3724,7 @@ GameStore.Categories = {
 			number = 1,
 			price = 900,
 			description = "Carries as many gold, platinum or crystal coins as your capacity allows, however, no other items.\n\n\n- only usable by purchasing character\n- will be sent to your Store inbox and can only be stored there and in depot box\n- can only be purchased once\n- use it to open it\n- always placed on the first position of your Store inbox",
-			type = GameStore.OfferTypes.OFFER_TYPE_ITEM,
+			type = GameStore.OfferTypes.OFFER_TYPE_POUCH,
 		},
 		{
 			icons = { "Instant_Reward_Access.png" },

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -965,7 +965,7 @@ void LuaScriptInterface::pushLoot(lua_State* L, const std::vector<LootBlock>& lo
 
 	int index = 0;
 	for (const auto& lootBlock : lootList) {
-		lua_createtable(L, 0, 7);
+		lua_createtable(L, 0, 8);
 
 		setField(L, "itemId", lootBlock.id);
 		setField(L, "chance", lootBlock.chance);
@@ -973,6 +973,8 @@ void LuaScriptInterface::pushLoot(lua_State* L, const std::vector<LootBlock>& lo
 		setField(L, "maxCount", lootBlock.countmax);
 		setField(L, "actionId", lootBlock.actionId);
 		setField(L, "text", lootBlock.text);
+		pushBoolean(L, lootBlock.unique);
+		lua_setfield(L, -2, "unique");
 
 		pushLoot(L, lootBlock.childLoot);
 		lua_setfield(L, -2, "childLoot");


### PR DESCRIPTION
- This should fix the unique loot drop from bosses (only one item per boss)
- Fix gold pouch beeing possible to buy more than 1 for each character (thanks to @Lycanzito for the fix)

Closes #902, #916 