### PR TITLE
Fix Twist of Fate and Unfair Fight

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2017,27 +2017,31 @@ void Player::death(Creature* lastHitCreature)
 	loginPosition = town->getTemplePosition();
 
 	if (skillLoss) {
-		uint8_t unfairFightReduction = 50;
-		bool lastHitPlayer = Player::lastHitIsPlayer(lastHitCreature);
-
-		if (lastHitPlayer) {
+		uint8_t unfairFightReduction = 100;
+		int playerDmg = 0;
+		int othersDmg = 0;
 			uint32_t sumLevels = 0;
-			uint32_t inFightTicks = g_config.getNumber(ConfigManager::PZ_LOCKED);
+			uint32_t inFightTicks = 5 * 60 * 1000;
 			for (const auto& it : damageMap) {
 				CountBlock_t cb = it.second;
 				if ((OTSYS_TIME() - cb.ticks) <= inFightTicks) {
 					Player* damageDealer = g_game.getPlayerByID(it.first);
 					if (damageDealer) {
+						playerDmg += cb.total;
 						sumLevels += damageDealer->getLevel();
 					}
+					else{
+						othersDmg += cb.total;
+					}
+					}
 				}
-			}
-
-			if (sumLevels > level) {
+		if(playerDmg > 0 || othersDmg > 0){
+		bool pvpDeath = (Player::lastHitIsPlayer(lastHitCreature) || playerDmg / (playerDmg + static_cast<double>(othersDmg)) >= 0.05);
+		}
+			if (pvpDeath && sumLevels > level) {
 				double reduce = level / static_cast<double>(sumLevels);
 				unfairFightReduction = std::max<uint8_t>(20, std::floor((reduce * 100) + 0.5));
 			}
-		}
 
 		//Magic level loss
 		uint64_t sumMana = 0;
@@ -2132,7 +2136,7 @@ void Player::death(Creature* lastHitCreature)
 
 		uint8_t maxBlessing = 8;
 		if (hasBlessing(6)) {
-			if (lastHitPlayer && hasBlessing(1)) {
+			if (pvpDeath && hasBlessing(1)) {
 				removeBlessing(1, 1);
 			} else {
 				for (int i = 2; i <= maxBlessing; i++) {
@@ -2141,7 +2145,7 @@ void Player::death(Creature* lastHitCreature)
 			}
 			setDropLoot(false);
 		} else {
-			if (lastHitPlayer && hasBlessing(1)) {
+			if (pvpDeath && hasBlessing(1)) {
 				removeBlessing(1, 1);
 			} else {
 				for (int i = 2; i <= maxBlessing; i++) {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2035,8 +2035,9 @@ void Player::death(Creature* lastHitCreature)
 					}
 					}
 				}
+		bool pvpDeath = false;
 		if(playerDmg > 0 || othersDmg > 0){
-		bool pvpDeath = (Player::lastHitIsPlayer(lastHitCreature) || playerDmg / (playerDmg + static_cast<double>(othersDmg)) >= 0.05);
+		pvpDeath = (Player::lastHitIsPlayer(lastHitCreature) || playerDmg / (playerDmg + static_cast<double>(othersDmg)) >= 0.05);
 		}
 			if (pvpDeath && sumLevels > level) {
 				double reduce = level / static_cast<double>(sumLevels);


### PR DESCRIPTION
Right now, the twist of fate is only being calculated when you are last hitted by a player, when in global is :
"When you die, at least 5% of the damage dealt within the last 5 minutes, or the last fatal strike must have been made by a character or its summons."

And the damage map is being calculated for the pz locked time, when in global it is for 5 minutes.

Additionally, the actual default value for unfairFightReduction is 50, making ALWAYS half the total amount of exp loss, even when no players present.

With this fix, the ToF will work as it should and the players will lose the totalexp, not half of it as default.