### PR TITLE
Update description column in guilds table

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -270,7 +270,7 @@ CREATE TABLE IF NOT EXISTS `guilds` (
   `creationdata` int(11) NOT NULL,
   `motd` varchar(255) NOT NULL DEFAULT '',
   `residence` int(11) NOT NULL DEFAULT '0',
-  `description` text NOT NULL,
+  `description` text NOT NULL DEFAULT '',
   `balance` bigint(20) UNSIGNED NOT NULL DEFAULT '0',
   CONSTRAINT `guilds_pk` PRIMARY KEY (`id`),
   CONSTRAINT `guilds_name_unique` UNIQUE (`name`),


### PR DESCRIPTION
This is not a standard TFS 1.x column, and breaks inherent guild creation. (on etc Znote AAC). 
The solution is to simply give it a blank value if not set. 
Adding a guild description for a newly created guild should not be a requirement. 

https://github.com/Znote/ZnoteAAC/issues/385