### PR TITLE
Update description column in guilds table

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -270,7 +270,7 @@ CREATE TABLE IF NOT EXISTS `guilds` (
   `creationdata` int(11) NOT NULL,
   `motd` varchar(255) NOT NULL DEFAULT '',
   `residence` int(11) NOT NULL DEFAULT '0',
-  `description` text NOT NULL DEFAULT '',
+  `description` VARCHAR(2000) NOT NULL DEFAULT '',
   `balance` bigint(20) UNSIGNED NOT NULL DEFAULT '0',
   CONSTRAINT `guilds_pk` PRIMARY KEY (`id`),
   CONSTRAINT `guilds_name_unique` UNIQUE (`name`),


### PR DESCRIPTION
Following #924 @slawkens mentioned that the TEXT column doesn't properly support default value in some mysql windows configurations. 

So as a compatibility workaround, we identified that this column is only used by Gesior, and so the column was changed to fit those parameters better in the form of the varchar column type. Which also properly supports default values.