### PR TITLE
Game Store - Fix buying item in Shopping Bags

### DIFF
--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -7,7 +7,7 @@ DISABLE_CONTAINER_WEIGHT = 0 -- 0 = ENABLE CONTAINER WEIGHT CHECK | 1 = DISABLE 
 CONTAINER_WEIGHT = 1000000 -- 1000000 = 10k = 10000.00 oz | this function is only for containers, item below the weight determined here can be moved inside the container, for others items look game.cpp at the src
 
 -- Items sold on the store that should not be moved off the store container
-local storeItemID = {32384,32385,32386,32387,32388,32389,32124,32125,32126,32127,32128,32129,32109,33299,26378,29020}
+local storeItemID = {32384,32385,32386,32387,32388,32389,32124,32125,32126,32127,32128,32129,32109,33299,26378,29020,32109}
 
 -- No move/trade items with actionID 8000
 BLOCK_ITEM_WITH_ACTION = 8000

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -7,7 +7,7 @@ DISABLE_CONTAINER_WEIGHT = 0 -- 0 = ENABLE CONTAINER WEIGHT CHECK | 1 = DISABLE 
 CONTAINER_WEIGHT = 1000000 -- 1000000 = 10k = 10000.00 oz | this function is only for containers, item below the weight determined here can be moved inside the container, for others items look game.cpp at the src
 
 -- Items sold on the store that should not be moved off the store container
-local storeItemID = {32384,32385,32386,32387,32388,32389,32124,32125,32126,32127,32128,32129,32109,33299,26378,29020,32109}
+local storeItemID = {32384,32385,32386,32387,32388,32389,32124,32125,32126,32127,32128,32129,32109,33299,26378,29020}
 
 -- No move/trade items with actionID 8000
 BLOCK_ITEM_WITH_ACTION = 8000

--- a/data/modules/scripts/gamestore/gamestore.lua
+++ b/data/modules/scripts/gamestore/gamestore.lua
@@ -3714,7 +3714,7 @@ GameStore.Categories = {
 			number = 1,
 			price = 5,
 			description = "Changes either a stack of 100 gold pieces into 1 platinum coin, or a stack of 100 platinum coins into 1 crystal coin!\n\n\n- only usable by purchasing character\n- will be sent to your Store inbox and can only be stored there and in depot box\n- use it on a stack of 100 to change it to the superior currency\n- usable 500 times a piece",
-			type = GameStore.OfferTypes.OFFER_TYPE_ITEM,
+			type = GameStore.OfferTypes.OFFER_TYPE_STACKABLE,
 		},
 		{
 			icons = { "Gold_Pouch.png" },

--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -1110,50 +1110,34 @@ function GameStore.processStackablePurchase(player, offerId, offerCount, offerNa
   if inbox and inbox:getEmptySlots() > 0 then
     if (isKegExerciseItem(offerId)) then
       if (offerCount >= 500) then
-        local parcel = Item(inbox:addItem(23782, 1):getUniqueId())
-        local function changeParcel(parcel)
-          local packagename = '' .. offerCount .. 'x ' .. offerName .. ' package.'
-          if parcel then
-            parcel:setAttribute(ITEM_ATTRIBUTE_NAME, packagename)
-            local pendingCount = offerCount
-            while (pendingCount > 0) do
-              local pack
-              if (pendingCount > 500) then
-                pack = 500
-              else
-                pack = pendingCount
-              end
-              local kegExerciseItem = parcel:addItem(offerId, 1)
-              kegExerciseItem:setAttribute(ITEM_ATTRIBUTE_CHARGES, pack)
-              pendingCount = pendingCount - pack
-            end
-          end
+		local pendingCount = offerCount
+		while (pendingCount > 0) do
+			local pack
+			if (pendingCount > 500) then
+				pack = 500
+			else
+				pack = pendingCount
+			end
+			local kegExerciseItem = inbox:addItem(offerId, 1)
+            kegExerciseItem:setAttribute(ITEM_ATTRIBUTE_CHARGES, pack)
+			pendingCount = pendingCount - pack
         end
-        addEvent(function() changeParcel(parcel) end, 250)
       else
         local kegExerciseItem = inbox:addItem(offerId, 1)
         kegExerciseItem:setAttribute(ITEM_ATTRIBUTE_CHARGES, offerCount)
       end
     elseif (offerCount > 100) then
-      local parcel = Item(inbox:addItem(23782, 1):getUniqueId())
-      local function changeParcel(parcel)
-        local packagename = '' .. offerCount .. 'x ' .. offerName .. ' package.'
-        if parcel then
-          parcel:setAttribute(ITEM_ATTRIBUTE_NAME, packagename)
-          local pendingCount = offerCount
-          while (pendingCount > 0) do
-            local pack
-            if (pendingCount > 100) then
-              pack = 100
-            else
-              pack = pendingCount
-            end
-            parcel:addItem(offerId, pack)
-            pendingCount = pendingCount - pack
-          end
+		local pendingCount = offerCount
+		while (pendingCount > 0) do
+			local pack
+			if (pendingCount > 100) then
+				pack = 100
+			else
+				pack = pendingCount
+			end
+			inbox:addItem(offerId, pack)
+			pendingCount = pendingCount - pack
         end
-      end
-      addEvent(function() changeParcel(parcel) end, 250)
     else
       inbox:addItem(offerId, offerCount)
     end


### PR DESCRIPTION
This changes fix when buying from store where items with charges came out with shopping bags or it appeared that you can't hold them because of no slots left.

If you have an item that's getting splitted each 100 charges, check the function `isKegExerciseItem`. You might need to add the item ID to this check or change the type of the offer to `OFFER_TYPE_STACKABLE`.

Also, added magic gold converter to the item list which can't be moved out from store inbox.