### PR TITLE
Quicklooting fixes and updates

### DIFF
--- a/src/items.cpp
+++ b/src/items.cpp
@@ -606,7 +606,7 @@ void Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id)
 				it.quickLootCategory = LOOT_WEAPON_SWORD;
 			} else if (tmpStrValue == "weaponwand") {
 				it.quickLootCategory = LOOT_WEAPON_WAND;
-			} else if (tmpStrValue == "weaponstashretrieve") {
+			} else if (tmpStrValue == "stashretrieve") {
 				it.quickLootCategory = LOOT_STASH_RETRIEVE;
 			} else {
 				std::cout << "[Warning - Items::parseItemNode] Unknown quickLootCategory: " << valueAttribute.as_string() << std::endl;

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2427,6 +2427,8 @@ void LuaScriptInterface::registerFunctions()
 
 	registerMethod("Player", "getFreeCapacity", LuaScriptInterface::luaPlayerGetFreeCapacity);
 
+	registerMethod("Player", "canOpenCorpse", LuaScriptInterface::luaPlayerCanOpenCorpse);
+
 	registerMethod("Player", "getKills", LuaScriptInterface::luaPlayerGetKills);
 	registerMethod("Player", "setKills", LuaScriptInterface::luaPlayerSetKills);
 
@@ -8518,6 +8520,24 @@ int LuaScriptInterface::luaPlayerGetFreeCapacity(lua_State* L)
 	if (player) {
 		lua_pushnumber(L, player->getFreeCapacity());
 	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaPlayerCanOpenCorpse(lua_State* L)
+{
+	// player:canOpenCorpse(corpseOwner)
+	Player* player = getUserdata<Player>(L, 1);
+	if (!player) {
+		lua_pushnil(L);
+		return 1;
+	}
+	if (player) {
+		uint32_t corpseOwner = getNumber<uint32_t>(L, 2);
+		pushBoolean(L, player->canOpenCorpse(corpseOwner));
+	}
+	else {
 		lua_pushnil(L);
 	}
 	return 1;

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -854,6 +854,8 @@ class LuaScriptInterface
 		static int luaPlayerGetCapacity(lua_State* L);
 		static int luaPlayerSetCapacity(lua_State* L);
 
+		static int luaPlayerCanOpenCorpse(lua_State* L);
+
 		static int luaPlayerGetKills(lua_State* L);
 		static int luaPlayerSetKills(lua_State* L);
 


### PR DESCRIPTION
This fixes some things like adding the main bp as fallback or searching for other able bps.

TODO add spam protection
TODO make player move to the loot before quicklooting, else it will grab from distance the loot
TODO add sendContainer when user clicks on the backpack inside manage loot container
TODO save quick loot list as a string in storage