### PR TITLE
Continued work in bestiary and charms

### DIFF
--- a/data/modules/scripts/bestiary/assets.lua
+++ b/data/modules/scripts/bestiary/assets.lua
@@ -1,5 +1,10 @@
 Bestiary.Storage = {
-	PLAYER_CHARM_POINTS = 61301000
+	PLAYER_CHARM_POINTS = 61301000,
+	PLAYER_CHARM_RUNE_AMOUNT = 61302001,
+	PLAYER_CHARM_SLOT_EXPANSION = 61302002,
+	PLAYER_CHARM_RUNE_BIT = 61302003,
+	PLAYER_CHARM_RUNE_BASE = 61303000,
+	PLAYER_CHARM_RUNE_MONSTER_BASE = 61304000
 }
 
 
@@ -139,23 +144,43 @@ Bestiary.MonstersOccurrency = {
 
 
 Bestiary.Charms = {
-	[0] = { name = 'Wound', description = "Triggers on a creature with a certain chance and deals 5% of its initial hit points as physical damage once.", type = Bestiary.CharmsTypes.CHARM_OFFENSIVE, points = 600, },
-    [1] = { name = 'Enflame', description = "Triggers on a creature with a certain chance and deals 5% of its initial hit points as fire damage once.", type = Bestiary.CharmsTypes.CHARM_OFFENSIVE, points = 1000},
-    [2] = { name = 'Poison', description = "Triggers on a creature with a certain chance and deals 5% of its initial hit points as earth damage once.", type = Bestiary.CharmsTypes.CHARM_OFFENSIVE, points = 600},
-    [3] = { name = 'Freeze', description = "Triggers on a creature with a certain chance and deals 5% of its initial hit points as ice damage once.", type = Bestiary.CharmsTypes.CHARM_OFFENSIVE, points = 800},
-    [4] = { name = 'Zap', description = "Triggers on a creature with a certain chance and deals 5% of its initial hit points as energy damage once.", type = Bestiary.CharmsTypes.CHARM_OFFENSIVE, points = 800},
-    [5] = { name = 'Curse', description = "Triggers on a creature with a certain chance and deals 5% of its initial hit points as death damage once.", type = Bestiary.CharmsTypes.CHARM_OFFENSIVE, points = 900},
-    [6] = { name = 'Cripple', description = "Cripples the creature with a certain chance and paralyses it for 10 seconds.", type = Bestiary.CharmsTypes.CHARM_OFFENSIVE, points = 500},
-    [7] = { name = 'Parry', description = "Any damage taken is reflected to the aggressor with a certain chance.", type = Bestiary.CharmsTypes.CHARM_DEFENSIVE, points = 1000},
-    [8] = { name = 'Dodge', description = "Dodges an attack with a certain chance without taking any damage at all.", type = Bestiary.CharmsTypes.CHARM_DEFENSIVE, points = 600},
-    [9] = { name = 'Adrenaline Burst', description = "Bursts of adrenaline enhance your reflexes with a certain chance after you get hit and let you move faster for 10 seconds.", type = Bestiary.CharmsTypes.CHARM_DEFENSIVE, points = 500},
-    [10] = { name = 'Numb', description = "Numbs the creature with a certain chance after its attack and paralyses the creature for 10 seconds.", type = Bestiary.CharmsTypes.CHARM_DEFENSIVE, points = 500},
-    [11] = { name = 'Cleanse', description = "Cleanses you from within with a certain chance after you get hit and removes one random active negative status effect and temporarily makes you immune against it.", type = Bestiary.CharmsTypes.CHARM_DEFENSIVE, points = 700},
-    [12] = { name = 'Bless', description = "Blesses you and reduces skill and experience loss by 3% when killed by the chosen creature.", type = Bestiary.CharmsTypes.CHARM_PASSIVE, points = 2000},
-    [13] = { name = 'Scavenge', description = "Enhances your chances to successfully skin/dust a skinnable/dustable creature.", type = Bestiary.CharmsTypes.CHARM_PASSIVE, points = 1500},
-    [14] = { name = 'Gut', description = "Gutting the creature yields 10% more creature products.", type = Bestiary.CharmsTypes.CHARM_PASSIVE, points = 2000},
-    [15] = { name = 'Low Blow', description = "Adds 8% critical hit chance to attacks with critical hit weapons.", type = Bestiary.CharmsTypes.CHARM_PASSIVE, points = 2000}
+	[0] = { name = 'Wound', id = 0, storage = Bestiary.Storage.PLAYER_CHARM_RUNE_BASE + 0, storageMonster = Bestiary.Storage.PLAYER_CHARM_RUNE_MONSTER_BASE + 0, damageType = COMBAT_PHYSICALDAMAGE, message = "You wounded the monster.", description = "Triggers on a creature with a certain chance and deals 5% of its initial hit points as physical damage once.", type = Bestiary.CharmsTypes.CHARM_OFFENSIVE, points = 600, },
+    [1] = { name = 'Enflame', id = 1, storage = Bestiary.Storage.PLAYER_CHARM_RUNE_BASE + 1, storageMonster = Bestiary.Storage.PLAYER_CHARM_RUNE_MONSTER_BASE + 1,damageType = COMBAT_FIREDAMAGE, message = "You enflame the monster.", description = "Triggers on a creature with a certain chance and deals 5% of its initial hit points as fire damage once.", type = Bestiary.CharmsTypes.CHARM_OFFENSIVE, points = 1000},
+    [2] = { name = 'Poison', id = 2, storage = Bestiary.Storage.PLAYER_CHARM_RUNE_BASE + 2, storageMonster = Bestiary.Storage.PLAYER_CHARM_RUNE_MONSTER_BASE + 2, damageType = COMBAT_EARTHDAMAGE, message = "You poisoned the monster.", description = "Triggers on a creature with a certain chance and deals 5% of its initial hit points as earth damage once.", type = Bestiary.CharmsTypes.CHARM_OFFENSIVE, points = 600},
+    [3] = { name = 'Freeze', id = 3, storage = Bestiary.Storage.PLAYER_CHARM_RUNE_BASE + 3, storageMonster = Bestiary.Storage.PLAYER_CHARM_RUNE_MONSTER_BASE + 3, damageType = COMBAT_ICEDAMAGE, message = "You frozen the monster.", description = "Triggers on a creature with a certain chance and deals 5% of its initial hit points as ice damage once.", type = Bestiary.CharmsTypes.CHARM_OFFENSIVE, points = 800},
+    [4] = { name = 'Zap', id = 4, storage = Bestiary.Storage.PLAYER_CHARM_RUNE_BASE + 4, storageMonster = Bestiary.Storage.PLAYER_CHARM_RUNE_MONSTER_BASE + 4, damageType = COMBAT_ENERGYDAMAGE, message = "You eletrocuted the monster.", description = "Triggers on a creature with a certain chance and deals 5% of its initial hit points as energy damage once.", type = Bestiary.CharmsTypes.CHARM_OFFENSIVE, points = 800},
+    [5] = { name = 'Curse', id = 5, storage = Bestiary.Storage.PLAYER_CHARM_RUNE_BASE + 5, storageMonster = Bestiary.Storage.PLAYER_CHARM_RUNE_MONSTER_BASE + 5, damageType = COMBAT_DEATHDAMAGE, message = "You curse the monster.", description = "Triggers on a creature with a certain chance and deals 5% of its initial hit points as death damage once.", type = Bestiary.CharmsTypes.CHARM_OFFENSIVE, points = 900},
+    [6] = { name = 'Cripple', id = 6, storage = Bestiary.Storage.PLAYER_CHARM_RUNE_BASE + 6, storageMonster = Bestiary.Storage.PLAYER_CHARM_RUNE_MONSTER_BASE + 6, description = "Cripples the creature with a certain chance and paralyses it for 10 seconds.", type = Bestiary.CharmsTypes.CHARM_OFFENSIVE, points = 500},
+    [7] = { name = 'Parry', id = 7, storage = Bestiary.Storage.PLAYER_CHARM_RUNE_BASE + 7, storageMonster = Bestiary.Storage.PLAYER_CHARM_RUNE_MONSTER_BASE + 7, message = "You parry the attack.", description = "Any damage taken is reflected to the aggressor with a certain chance.", type = Bestiary.CharmsTypes.CHARM_DEFENSIVE, points = 1000},
+    [8] = { name = 'Dodge', id = 8, storage = Bestiary.Storage.PLAYER_CHARM_RUNE_BASE + 8, storageMonster = Bestiary.Storage.PLAYER_CHARM_RUNE_MONSTER_BASE + 8, message = "You dodged the attack.", description = "Dodges an attack with a certain chance without taking any damage at all.", type = Bestiary.CharmsTypes.CHARM_DEFENSIVE, points = 600},
+    [9] = { name = 'Adrenaline Burst', id = 9, storage = Bestiary.Storage.PLAYER_CHARM_RUNE_BASE + 9, storageMonster = Bestiary.Storage.PLAYER_CHARM_RUNE_MONSTER_BASE + 9, message = "Your movements where bursted.", description = "Bursts of adrenaline enhance your reflexes with a certain chance after you get hit and let you move faster for 10 seconds.", type = Bestiary.CharmsTypes.CHARM_DEFENSIVE, points = 500},
+    [10] = { name = 'Numb', id = 10, storage = Bestiary.Storage.PLAYER_CHARM_RUNE_BASE + 10, storageMonster = Bestiary.Storage.PLAYER_CHARM_RUNE_MONSTER_BASE + 10, description = "Numbs the creature with a certain chance after its attack and paralyses the creature for 10 seconds.", type = Bestiary.CharmsTypes.CHARM_DEFENSIVE, points = 500},
+    [11] = { name = 'Cleanse', id = 11, storage = Bestiary.Storage.PLAYER_CHARM_RUNE_BASE + 11, storageMonster = Bestiary.Storage.PLAYER_CHARM_RUNE_MONSTER_BASE + 11, description = "Cleanses you from within with a certain chance after you get hit and removes one random active negative status effect and temporarily makes you immune against it.", type = Bestiary.CharmsTypes.CHARM_DEFENSIVE, points = 700},
+    [12] = { name = 'Bless', id = 12, storage = Bestiary.Storage.PLAYER_CHARM_RUNE_BASE + 12, storageMonster = Bestiary.Storage.PLAYER_CHARM_RUNE_MONSTER_BASE + 12, description = "Blesses you and reduces skill and experience loss by 3% when killed by the chosen creature.", type = Bestiary.CharmsTypes.CHARM_PASSIVE, points = 2000},
+    [13] = { name = 'Scavenge', id = 13, storage = Bestiary.Storage.PLAYER_CHARM_RUNE_BASE + 13, storageMonster = Bestiary.Storage.PLAYER_CHARM_RUNE_MONSTER_BASE + 13, description = "Enhances your chances to successfully skin/dust a skinnable/dustable creature.", type = Bestiary.CharmsTypes.CHARM_PASSIVE, points = 1500},
+    [14] = { name = 'Gut', id = 14, storage = Bestiary.Storage.PLAYER_CHARM_RUNE_BASE + 14, storageMonster = Bestiary.Storage.PLAYER_CHARM_RUNE_MONSTER_BASE + 14, description = "Gutting the creature yields 10% more creature products.", type = Bestiary.CharmsTypes.CHARM_PASSIVE, points = 2000},
+    [15] = { name = 'Low Blow', id = 15, storage = Bestiary.Storage.PLAYER_CHARM_RUNE_BASE + 15, storageMonster = Bestiary.Storage.PLAYER_CHARM_RUNE_MONSTER_BASE + 15, description = "Adds 8% critical hit chance to attacks with critical hit weapons.", type = Bestiary.CharmsTypes.CHARM_PASSIVE, points = 2000}
 }
+
+Bestiary.CharmsNames = {
+	["Wound"] = 0,
+	["Enflame"] = 1,
+	["Poison"] = 2,
+	["Freeze"] = 3,
+	["Zap"] = 4,
+	["Curse"] = 5,
+	["Cripple"] = 6,
+	["Parry"] = 7,
+	["Dodge"] = 8,
+	["Adrenaline Burst"] = 9,
+	["Numb"] = 10,
+	["Cleanse"] = 11,
+	["Bless"] = 12,
+	["Scavenge"] = 13,
+	["Gut"] = 14,
+	["Low Blow"] = 15
+}
+
 
 Bestiary.Races = {
     {name = "Amphibic", monsters = {262, 267, 268, 269, 270, 271, 563, 738, 913} },

--- a/data/modules/scripts/bestiary/assets.lua
+++ b/data/modules/scripts/bestiary/assets.lua
@@ -4,7 +4,8 @@ Bestiary.Storage = {
 	PLAYER_CHARM_RUNE_BIT = 61302002,
 	PLAYER_CHARM_RUNE_USED_BIT = 61302003,
 	PLAYER_CHARM_RUNE_BASE = 61303000,
-	PLAYER_CHARM_RUNE_MONSTER_BASE = 61304000
+	PLAYER_CHARM_RUNE_MONSTER_BASE = 61304000,
+	PLAYER_BESTIARY_MONSTER = 61305000
 }
 
 
@@ -1456,6 +1457,6 @@ Bestiary.MonstersName = {
 -- Regex to parse upper table into the lower one:
 --Search: \[(\d{1,4})\].*name = ('|")(.*)('|"), class.*
 --Replace: ["$3"] = $1,
-Bestiary.CreatureEncryptionKeys = {"gnikcuf a si labolG", "!oiarac sion ", "vreSTO", "� !tcejorp emosewa "}
+Bestiary.CreatureEncryptionKeys = {"gnikcuf a si labolG", "!oiarac sion ", "vreSTO", "hE !tcejorp emosewa "}
 Bestiary.CreatureEncryptionOrder = {3,1,4,2}
 

--- a/data/modules/scripts/bestiary/assets.lua
+++ b/data/modules/scripts/bestiary/assets.lua
@@ -1,8 +1,8 @@
 Bestiary.Storage = {
 	PLAYER_CHARM_POINTS = 61301000,
-	PLAYER_CHARM_RUNE_AMOUNT = 61302001,
-	PLAYER_CHARM_SLOT_EXPANSION = 61302002,
-	PLAYER_CHARM_RUNE_BIT = 61302003,
+	PLAYER_CHARM_SLOT_EXPANSION = 61302001,
+	PLAYER_CHARM_RUNE_BIT = 61302002,
+	PLAYER_CHARM_RUNE_USED_BIT = 61302003,
 	PLAYER_CHARM_RUNE_BASE = 61303000,
 	PLAYER_CHARM_RUNE_MONSTER_BASE = 61304000
 }
@@ -179,6 +179,25 @@ Bestiary.CharmsNames = {
 	["Scavenge"] = 13,
 	["Gut"] = 14,
 	["Low Blow"] = 15
+}
+
+Bestiary.CharmsBinaries = {
+	[0] = 1,
+	[1] = 2,
+	[2] = 4,
+	[3] = 8,
+	[4] = 16,
+	[5] = 32,
+	[6] = 64,
+	[7] = 128,
+	[8] = 256,
+	[9] = 512,
+	[10] = 1024,
+	[11] = 2048,
+	[12] = 4096,
+	[13] = 8192,
+	[14] = 16384,
+	[15] = 32768
 }
 
 

--- a/data/modules/scripts/bestiary/bestiary.lua
+++ b/data/modules/scripts/bestiary/bestiary.lua
@@ -1,10 +1,19 @@
-BestiarySystem = {
-    Developer = "gpedro, DudZ",
+Bestiary = {}
+
+Bestiary.Credits = {
+    Developer = "gpedro, DudZ, ticardo, lBaah",
 	Version = "1.0",
 	lastUpdate = "31/03/2020 - 12:00"
 }
 
-Bestiary = {}
+Bestiary.Config = {
+	PremiumRunesAmount = 6,
+	FreeRunesAmount = 3,
+	ResetMonsterPriceModifierXLevel = 100,
+	EnabledRunes = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 },
+	Multiplicator = 0.05,
+	Probability = 0.05
+}
 
 dofile('data/modules/scripts/bestiary/assets.lua')
 
@@ -65,11 +74,11 @@ Bestiary.sendCreatures = function(player, msg)
 	creaturesKilled = player:getBestiaryCountByRace(race)
     for i = 1, #race.monsters do
         msg:addU16(race.monsters[i]) -- monster name
-		local tmpStatus = 1
 		if creaturesKilled[race.monsters[i]] ~= nil then
-			tmpStatus = Bestiary.GetKillStatus(Bestiary.Monsters[race.monsters[i]], creaturesKilled[race.monsters[i]])
+			msg:addU16(Bestiary.GetKillStatus(Bestiary.Monsters[race.monsters[i]], creaturesKilled[race.monsters[i]])) -- monster kill count (starts by 1)
+		else
+			msg:addByte(0) --Blacks out unknown monsters
 		end
-        msg:addU16(tmpStatus) -- monster kill count (starts by 1)
     end
 
     msg:sendToPlayer(player)
@@ -91,27 +100,54 @@ Bestiary.sendRaces = function(player, msg)
     msg:sendToPlayer(player)
 end
 
+
 Bestiary.sendCharms = function(player, msg)
     local playerLocal = Player(player:getId())
     if not playerLocal then
         return true
     end
 
+	local removeRuneCost = Bestiary.getRemoveRuneCost(player)
+
     local msg = NetworkMessage()
     msg:addByte(Bestiary.S_Packets.SendBestiaryCharmsData)
 	msg:addU32(player:getCharmPoints())
-    msg:addByte(#Bestiary.Charms)
-    for k, charm in ipairs(Bestiary.Charms) do -- TODO get better charms bytes
+
+    msg:addByte(#Bestiary.Config.EnabledRunes)
+    for i = 1, #Bestiary.Config.EnabledRunes do
+		local k = Bestiary.Config.EnabledRunes[i]
+		local charm = Bestiary.Charms[k]
 		msg:addByte(k) -- id
         msg:addString(charm.name) --name
         msg:addString(charm.description) --description
-        msg:addByte(0) --unknown (unlocked?) 0 ok | 1-2 n�o faz nada | 3+ n�o testado
+        msg:addByte(0) --TODO unknown (unlocked?) 0 ok | 1-2 não faz nada | 3+ n�o testado
 		msg:addU16(charm.points) --charm points needed charm.points
-        msg:addByte(0) --selecionado o monsto, da pra resetar? 0 : custo em charms | 1 : custo em gp | 2+ n�o testado
-        msg:addByte(0) --unknown (unlocked?) 0 ok | 1 crasha | 2+ n�o testado
+
+		if player:hasCharmRune(charm) then
+			msg:addByte(1) -- Charm liberado = 1 | bloqueado = 0
+			local charmCreature = player:getCharmRuneCreature(charm)
+			if charmCreature > 0 then
+				msg:addByte(1) -- Tem criatura selecionada
+				msg:addU16(charmCreature)
+				msg:addU32(removeRuneCost)
+			else
+				msg:addByte(0)  -- Não Tem criatura selecionada
+			end
+		else
+			msg:addByte(0) -- charm bloqueado
+			msg:addByte(0) -- nenhum monstro selecionado
+		end
     end
-	msg:addByte(16)
-	msg:addU16(0)
+	msg:addByte(4) -- 0x4?? 0x10??
+
+	--Send unlocked and unused monsters 
+
+	local finishedMonsters = player:getBestiaryFinished()
+	msg:addU16(#finishedMonsters)
+	for i = 1, #finishedMonsters do
+		msg:addU16(finishedMonsters[i]) -- monster id que já foram terminados, pra poder selecionar no charm --TODO filtrar monstros que já possuem runas
+	end
+
     msg:sendToPlayer(player)
 end
 
@@ -121,8 +157,58 @@ Bestiary.sendBuyCharmRune = function(player, msg)
         return true
     end
 
+	local playerCharmAmount = player:getCharmPoints()
+
     local runeID = msg:getByte()
-    
+	local action = msg:getByte()
+	local monsterID = msg:getU16()
+    local thisCharm = Bestiary.Charms[runeID]
+	if action == 0 then -- buy charm
+		if playerCharmAmount < thisCharm.points then
+			player:popupFYI("You don't have enough charm points to unlock this rune.")
+			return
+		end
+		player:popupFYI("You sucessfully unlocked \"".. thisCharm.name .."\" for ".. thisCharm.points .." charm points.")
+		player:setCharmPoints(player:getCharmPoints() - thisCharm.points)
+		player:addCharmRune(thisCharm)
+	elseif action == 1 then -- set creature
+		local usedRunes = player:getCharmRuneUsedAmount()
+		local hasExpansion = player:getCharmRuneSlotExpansion()
+		local isPremium = player:isPremium()
+		local limitRunes = 0
+		local message = "Creature has been set!"
+		if isPremium then
+			if hasExpansion then
+				limitRunes = 100
+			else
+				limitRunes = Bestiary.Config.PremiumRunesAmount
+				message = "Creature has been set!\n\nYou are Premium player, so you benefit from up to ".. limitRunes .." runes!\nCharm Expansion allow you to set creatures to all runes at once!"
+			end
+		else
+			limitRunes = Bestiary.Config.FreeRunesAmount
+			message = "Creature has been set!\n\nYou are not a Premium player, so you can only benefit from up to ".. limitRunes .." runes!\nPremium players can hold up to ".. Bestiary.Config.PremiumRunesAmount .." creatures at once.\nCharm Expansion allow you to set creatures to all runes at once!"
+		end
+		print(isPremium)
+		print(hasExpansion)
+		print(usedRunes)
+		print(limitRunes)
+		if limitRunes <= usedRunes then
+			player:popupFYI("You don't have any charm slots available.")
+			return
+		end
+		player:setCharmRuneUsedAmount(usedRunes + 1)
+		player:setCharmRuneCreature(thisCharm, monsterID)
+		player:popupFYI(message)
+		
+	elseif action == 2 then -- reset creature
+		if not player:removeMoneyNpc(Bestiary.getRemoveRuneCost(player)) then
+			player:popupFYI("You don't have enough gold.")
+			return
+		end
+		player:resetCharmRuneCreature(thisCharm)
+		player:popupFYI("You sucessfully removed the creature.")
+	end
+	
     print("> [Bestiary]: Trying to buy rune: "..runeID)
     return true
 end
@@ -138,6 +224,9 @@ Bestiary.GetKillStatus = function(bestiaryMonster, killAmount)
 	return Bestiary.KillStatus.FINISHED
 end
 
+Bestiary.getRemoveRuneCost = function(player)
+	return player:getLevel()*Bestiary.Config.ResetMonsterPriceModifierXLevel
+end
 
 Bestiary.sendMonsterData = function(player, msg)
     local playerLocal = Player(player:getId())
@@ -315,14 +404,19 @@ end
 function onRecvbyte(player, msg, byte)
 	Bestiary.setupDatabase()
     if (byte == Bestiary.C_Packets.RequestBestiaryData) then
+		print("RequestBestiaryData")
         Bestiary.sendRaces(player)
         Bestiary.sendCharms(player)
     elseif (byte == Bestiary.C_Packets.RequestBestiaryOverview) then
+		print("RequestBestiaryOverview")
         Bestiary.sendCreatures(player, msg)
     elseif (byte == Bestiary.C_Packets.RequestBestiaryMonsterData) then
+		print("RequestBestiaryMonsterData")
         Bestiary.sendMonsterData(player, msg)
     elseif (byte == Bestiary.C_Packets.RequestBestiaryCharmUnlock) then
+		print("RequestBestiaryCharmUnlock")
         Bestiary.sendBuyCharmRune(player, msg)
+        Bestiary.sendCharms(player)
 		--TestarBytes(player,msg)
     end
 end
@@ -332,7 +426,7 @@ Bestiary.setupDatabase = function()
 		`player_id` INT NULL,
 		`monster_id` INT UNSIGNED NULL,
 		`count` INT UNSIGNED NULL,
-		`finished` BOOLEAN,
+		`finished` BOOLEAN DEFAULT '0',
 
 		CONSTRAINT `bestiary_killcount_players_fk` FOREIGN KEY (`player_id`) REFERENCES `trindera_global`.`players` (`id`)
 	)]])
@@ -378,6 +472,21 @@ function Player.getBestiaryCountByMonster(self, monsterID) --Returns int with th
 	return count
 end
 
+function Player.getBestiaryFinished(self) --Return table with monster ID of all finished monsters
+	local playerId = self:getGuid()
+	local query = db.storeQuery("SELECT `monster_id` FROM `bestiary_killcount` WHERE `player_id` = " .. playerId.. " AND `finished` = 1")
+	local finishedMonsters = {}
+	
+	if query then
+		repeat
+			local monsterID = result.getNumber(query, "monster_id")
+			table.insert(finishedMonsters, monsterID)
+		until not result.next(query)
+
+		result.free(query)
+	end
+	return finishedMonsters
+end
 
 function Player.getCharmPoints(self)
 	local cp = self:getStorageValue(Bestiary.Storage.PLAYER_CHARM_POINTS)
@@ -394,6 +503,69 @@ end
 
 function Player.setCharmPoints(self, value)
 	self:setStorageValue(Bestiary.Storage.PLAYER_CHARM_POINTS, value)
+end
+
+function Player.addCharmRune(self, charmRuneObj)
+	self:setStorageValue(charmRuneObj.storage, 1)
+end
+
+function Player.getCharmRunesBit(self)
+	local c = math.max(self:getStorageValue(Bestiary.Storage.PLAYER_CHARM_RUNE_BIT), 0)
+	return c
+end
+
+function Player.addCharmRuneBit(self, charmRuneObj) 
+	local c = self:getCharmRunesBit()
+	
+	return c ~= nil and c > 0
+end
+
+function Player.hasCharmRuneBit(self, charmRuneObj) 
+	local c = self:getCharmRunesBit()
+
+	return c ~= nil and c > 0
+end
+
+function Player.hasCharmRune(self, charmRuneObj) -- Can check either via name, ID or object
+	if type(charmRuneObj) == "string" then
+		charmRuneObj = Bestiary.CharmsNames[charmRuneObj]
+		if not charmRuneObj then
+			return false
+		end
+		charmRuneObj = Bestiary.Charms[charmRuneObj]
+	elseif type(charmRuneObj) == "number" then
+		charmRuneObj = Bestiary.Charms[charmRuneObj]
+	end
+	local c = self:getStorageValue(charmRuneObj.storage)
+	return c ~= nil and c > 0
+end
+
+function Player.resetCharmRuneCreature(self, charmRuneObj, creatureID)
+	self:setCharmRuneCreature(charmRuneObj, 0)
+end
+
+function Player.setCharmRuneCreature(self, charmRuneObj, creatureID)
+	self:setStorageValue(charmRuneObj.storageMonster, creatureID)
+end
+
+function Player.getCharmRuneCreature(self, charmRuneObj)
+	return math.max(self:getStorageValue(charmRuneObj.storageMonster), 0)
+end
+
+function Player.getCharmRuneUsedAmount(self)
+	return math.max(self:getStorageValue(Bestiary.Storage.PLAYER_CHARM_RUNE_AMOUNT), 0)
+end
+
+function Player.setCharmRuneUsedAmount(self, amount)
+	self:setStorageValue(Bestiary.Storage.PLAYER_CHARM_RUNE_AMOUNT, amount)
+end
+
+function Player.getCharmRuneSlotExpansion(self)
+	return math.max(self:getStorageValue(Bestiary.Storage.PLAYER_CHARM_SLOT_EXPANSION), 0) == 1
+end
+
+function Player.setCharmRuneSlotExpansion(self, onOff)
+	self:setStorageValue(Bestiary.Storage.PLAYER_CHARM_SLOT_EXPANSION, onOff and 1 or 0)
 end
 
 function Player.addBestiaryKill(self, monsterId) --MonsterID can be Name
@@ -427,4 +599,13 @@ function Player.addBestiaryKill(self, monsterId) --MonsterID can be Name
 end
 
 
-
+function Player.getCharmBonus(self, target)
+	local bestiaryEntry = Bestiary.MonstersName[target:getName()]
+	if not bestiaryEntry then
+		return nil
+	end
+	if self:getCharmRuneUsedAmount() == 0 then
+		return nil
+	end
+	
+end

--- a/data/modules/scripts/bestiary/bestiary.lua
+++ b/data/modules/scripts/bestiary/bestiary.lua
@@ -501,7 +501,7 @@ function Player.hasCharmUnlockedRuneBit(self, charmRuneObj, input)
 	if not input then
 		input = self:getCharmUnlockedRunesBit()
 	end
-	return not (bit.band(input, 2^charmRuneObj.id) == 0)
+	return not (bit.band(input, Bestiary.CharmsBinaries[charmRuneObj.id]) == 0)
 end
 
 function Player.setCharmUnlockedRuneBit(self, value) 
@@ -526,7 +526,7 @@ function Player.hasCharmUsedRuneBit(self, charmRuneObj, input)
 	if not input then
 		input = self:getCharmUsedRunesBit()
 	end
-	return not bit.band(input, 2^charmRuneObj.id) == 0
+	return not bit.band(input, Bestiary.CharmsBinaries[charmRuneObj.id]) == 0
 end
 
 function Player.setCharmUsedRuneBit(self, value) 
@@ -616,9 +616,9 @@ end
 Bestiary.bitToggle = function(input, id, on)  -- to add, we use |, which means OR, which in turns make sue that the final number has the flags which both of the left sided and right sided has
 	print(on)
 	if on then
-		return bit.bor(input, 2^id)
+		return bit.bor(input, Bestiary.CharmsBinaries[id])
 	else
-		local negateFlag = bit.bnot(2^id)
+		local negateFlag = bit.bnot(Bestiary.CharmsBinaries[id])
 		return bit.band(input,negateFlag)
 	end
 end

--- a/data/modules/scripts/bestiary/bestiary.lua
+++ b/data/modules/scripts/bestiary/bestiary.lua
@@ -5,7 +5,8 @@ Bestiary.Credits = {
 	Version = "1.1",
 	lastUpdate = "01/04/2020 - 12:00",
 	todo = {"Add modifiers for the runes implementation",
-			"Add correct monster locations in the bestiary"}
+			"Add correct monster locations in the bestiary",
+			"Fix monster occurency"}
 }
 
 Bestiary.Config = {
@@ -292,10 +293,10 @@ Bestiary.sendMonsterData = function(player, msg)
     msg:addU16(bestiaryMonster.toKill)  -- max kill third phase
 
     msg:addByte(bestiaryMonster.Stars)  -- Difficult
-    msg:addByte(Bestiary.getMonsterOccurrencyByName(bestiaryMonster.name)) -- Occurence
+	local monsterOccurency = Bestiary.getMonsterOccurrencyByName(bestiaryMonster.name)
+	msg:addByte(1) -- TODO Occurency
 	local monsterLoot = monster:getLoot()
     msg:addByte(#monsterLoot)
-
     if #monsterLoot > 0 then
         for i = 1, #monsterLoot do
             local loot = monsterLoot[i]
@@ -303,10 +304,11 @@ Bestiary.sendMonsterData = function(player, msg)
             if item then 
                 local type = 0 -- TODO 0 = normal loot   /  1 = special event loot
                 local difficult = Bestiary.calculateDifficult(loot.chance)
-				msg:addItemId(killCounter > 0 and loot.itemId or 0)
-                msg:addByte(difficult)
-                msg:addByte(type)
-				if killCounter > 0 then
+
+				msg:addItemId(currentLevel > 1 and loot.itemId or 0)
+				msg:addByte(difficult)
+				msg:addByte(type)
+				if currentLevel > 1 then
 					msg:addString(item:getName())
 					msg:addByte(item:isStackable() and 0x1 or 0x0)
 				end
@@ -403,7 +405,7 @@ Bestiary.getMonsterOccurrencyByName = function(monsterName)
 			return i
 		end
 	end
-	return Bestiary.Occurencies.HARMLESS_ORDINARY
+	return Bestiary.Occurrencies.HARMLESS_ORDINARY
 
 end
 
@@ -613,7 +615,6 @@ end
 
 
 Bestiary.bitToggle = function(input, id, on)  -- to add, we use |, which means OR, which in turns make sue that the final number has the flags which both of the left sided and right sided has
-	print(on)
 	if on then
 		return bit.bor(input, Bestiary.CharmsBinaries[id])
 	else

--- a/data/modules/scripts/bestiary/bestiary.lua
+++ b/data/modules/scripts/bestiary/bestiary.lua
@@ -1,9 +1,9 @@
 Bestiary = {}
 
-Bestiary.Credits = {
-    Developer = "gpedro, DudZ, ticardo, lBaah",
-	Version = "1.0",
-	lastUpdate = "31/03/2020 - 12:00"
+BestiarySystem = {
+    Developer = "gpedro, lbaah, Ticardo (Rick), DudZ",
+    Version = "1.0",
+    lastUpdate = "31/03/2020 - 12:00"
 }
 
 Bestiary.Config = {

--- a/data/modules/scripts/bestiary/bestiary.lua
+++ b/data/modules/scripts/bestiary/bestiary.lua
@@ -417,7 +417,7 @@ Bestiary.setupDatabase = function()
 		`count` INT UNSIGNED NULL,
 		`finished` BOOLEAN DEFAULT '0',
 
-		CONSTRAINT `bestiary_killcount_players_fk` FOREIGN KEY (`player_id`) REFERENCES `trindera_global`.`players` (`id`)
+		CONSTRAINT `bestiary_killcount_players_fk` FOREIGN KEY (`player_id`) REFERENCES `otserv`.`players` (`id`)
 	)]])
 end
 

--- a/data/modules/scripts/bestiary/bestiary.lua
+++ b/data/modules/scripts/bestiary/bestiary.lua
@@ -1,9 +1,9 @@
 Bestiary = {}
 
 BestiarySystem = {
-    Developer = "gpedro, lbaah, Ticardo (Rick), DudZ",
-    Version = "1.0",
-    lastUpdate = "31/03/2020 - 12:00"
+	Developer = "gpedro, lbaah, Ticardo (Rick), DudZ",
+	Version = "1.0",
+	lastUpdate = "31/03/2020 - 12:00"
 }
 
 Bestiary.Config = {

--- a/data/modules/scripts/bestiary/bestiary.lua
+++ b/data/modules/scripts/bestiary/bestiary.lua
@@ -1,7 +1,7 @@
 Bestiary = {}
 
 BestiarySystem = {
-	Developer = "gpedro, lbaah, Ticardo (Rick), DudZ",
+	Developer = "fernando mieza (flyckks), gpedro, lbaah, Ticardo (Rick), DudZ",
 	Version = "1.0",
 	lastUpdate = "31/03/2020 - 12:00"
 }

--- a/data/modules/scripts/bestiary/bestiary.lua
+++ b/data/modules/scripts/bestiary/bestiary.lua
@@ -1,9 +1,11 @@
 Bestiary = {}
 
-BestiarySystem = {
+Bestiary.Credits = {
 	Developer = "fernando mieza (flyckks), gpedro, lbaah, Ticardo (Rick), DudZ",
-	Version = "1.0",
-	lastUpdate = "31/03/2020 - 12:00"
+	Version = "1.1",
+	lastUpdate = "01/04/2020 - 12:00",
+	todo = {"Add modifiers for the runes implementation",
+			"Add correct monster locations in the bestiary"}
 }
 
 Bestiary.Config = {
@@ -21,7 +23,9 @@ Bestiary.S_Packets = {
     SendBestiaryData = 0xd5,
     SendBestiaryOverview = 0xd6,
     SendBestiaryMonsterData = 0xd7,
-	SendBestiaryCharmsData = 0xd8
+	SendBestiaryCharmsData = 0xd8,
+	SendBestiaryTracker = 0xd9,
+
 }
 
 Bestiary.C_Packets = {
@@ -57,25 +61,35 @@ Bestiary.sendCreatures = function(player, msg)
     if not playerLocal then
         return true
     end
+	local text = ""
+	local monsterIDs ={}
+    local search = msg:getByte()
+	if search == 1 then
+		local monsterAmount = msg:getU16()
+		for i =1, monsterAmount do
+			table.insert(monsterIDs, msg:getU16())
+		end
+	else
+	
+		local raceName = msg:getString()
 
-    local unknown = msg:getByte()
-    local raceName = msg:getString()
-
-    local race = Bestiary.findRaceByName(raceName)
-    if not race then
-        print("> [Bestiary]: race was not found: "..raceName)
-        return true
-    end
-
+		local race = Bestiary.findRaceByName(raceName)
+		if not race then
+			print("> [Bestiary]: race was not found: "..raceName .." | search " .. search)
+			return true
+		end
+		monsterIDs = race.monsters
+		text = race.name
+	end
     local msg = NetworkMessage()
     msg:addByte(Bestiary.S_Packets.SendBestiaryOverview)
-    msg:addString(race.name) -- race name
-    msg:addU16(#race.monsters) -- monster count
-	creaturesKilled = player:getBestiaryCountByRace(race)
-    for i = 1, #race.monsters do
-        msg:addU16(race.monsters[i]) -- monster name
-		if creaturesKilled[race.monsters[i]] ~= nil then
-			msg:addU16(Bestiary.GetKillStatus(Bestiary.Monsters[race.monsters[i]], creaturesKilled[race.monsters[i]])) -- monster kill count (starts by 1)
+    msg:addString(text) -- race name
+    msg:addU16(#monsterIDs) -- monster count
+	creaturesKilled = player:getBestiaryKillCountByMonsterIDs(monsterIDs)
+    for i = 1, #monsterIDs do
+        msg:addU16(monsterIDs[i]) -- monster name
+		if creaturesKilled[monsterIDs[i]] ~= nil then
+			msg:addU16(Bestiary.GetKillStatus(Bestiary.Monsters[monsterIDs[i]], creaturesKilled[monsterIDs[i]])) -- monster kill count (starts by 1)
 		else
 			msg:addByte(0) --Blacks out unknown monsters
 		end
@@ -185,7 +199,6 @@ Bestiary.sendBuyCharmRune = function(player, msg)
 		local curBit = player:getCharmUnlockedRunesBit()
 		player:setCharmUnlockedRuneBit(Bestiary.bitToggle(curBit, thisCharm.id, true))
 		curBit = player:getCharmUnlockedRunesBit()
-
 	elseif action == 1 then -- set creature
 		local usedRunes = player:getCharmUsedRuneBitAll()
 		local hasExpansion = player:getCharmRuneSlotExpansion()
@@ -262,7 +275,7 @@ Bestiary.sendMonsterData = function(player, msg)
         print("> [Bestiary]: monstertype was not found")
         return true
     end
-    local killCounter = player:getBestiaryCountByMonster(Bestiary.MonstersName[bestiaryMonster.name])
+    local killCounter = player:getBestiaryKillCount(Bestiary.MonstersName[bestiaryMonster.name])
 
 	local currentLevel = Bestiary.GetKillStatus(bestiaryMonster, killCounter)
 
@@ -339,7 +352,7 @@ Bestiary.sendMonsterData = function(player, msg)
 				bestiaryCreatureFinishingKeys = bestiaryCreatureFinishingKeys .. Bestiary.CreatureEncryptionKeys[Bestiary.CreatureEncryptionOrder[b]]:sub(i,i)
 			end
 		end
-        msg:addU16(1) --TODO DESCRIPTION
+        msg:addU16(1) --locations
         msg:addString(bestiaryCreatureFinishingKeys)
     end
 
@@ -395,7 +408,6 @@ Bestiary.getMonsterOccurrencyByName = function(monsterName)
 end
 
 function onRecvbyte(player, msg, byte)
-	Bestiary.setupDatabase()
     if (byte == Bestiary.C_Packets.RequestBestiaryData) then
         Bestiary.sendRaces(player)
         Bestiary.sendCharms(player)
@@ -406,72 +418,49 @@ function onRecvbyte(player, msg, byte)
     elseif (byte == Bestiary.C_Packets.RequestBestiaryCharmUnlock) then
         Bestiary.sendBuyCharmRune(player, msg)
         Bestiary.sendCharms(player)
-		--TestarBytes(player,msg)
     end
 end
 
-Bestiary.setupDatabase = function()
-	db.query([[CREATE TABLE IF NOT EXISTS `bestiary_killcount` (
-		`player_id` INT NULL,
-		`monster_id` INT UNSIGNED NULL,
-		`count` INT UNSIGNED NULL,
-		`finished` BOOLEAN DEFAULT '0',
-
-		CONSTRAINT `bestiary_killcount_players_fk` FOREIGN KEY (`player_id`) REFERENCES `otserv`.`players` (`id`)
-	)]])
+function Player.getBestiaryKillCount(self, monsterID)
+	return math.max(self:getStorageValue(Bestiary.Storage.PLAYER_BESTIARY_MONSTER + monsterID), 0)
 end
 
-function Player.getBestiaryRaceUnlocked(self, raceObject) --Returns int with the unlocked amount
-	local playerId = self:getGuid()
-	local query = db.storeQuery("SELECT COUNT(monster_id) as c FROM `bestiary_killcount` WHERE player_id = " .. playerId .. " AND `monster_id` IN (" .. table.concat(raceObject.monsters, ",") .. ")")
-	local count = result.getNumber(query, "c")
-	result.free(query)
+function Player.addBestiaryKillCount(self, monsterID)
+	self:setStorageValue(Bestiary.Storage.PLAYER_BESTIARY_MONSTER + monsterID, self:getBestiaryKillCount(monsterID) + 1)
+end
+
+function Player.setBestiaryKillCount(self, monsterID, value)
+	self:setStorageValue(Bestiary.Storage.PLAYER_BESTIARY_MONSTER + monsterID, value)
+end
+
+function Player.getBestiaryRaceUnlocked(self, raceObject)
+	local count = 0
+	for i = 1, #raceObject.monsters do
+		if self:getBestiaryKillCount(raceObject.monsters[i]) > 0 then
+			count = count + 1
+		end
+	end
 	return count
 end
 
-function Player.getBestiaryCountByRace(self, raceObject) --Returns table indexed by monsterID and by kill count
-	local playerId = self:getGuid()
-	local query = db.storeQuery("SELECT `monster_id`, `count` FROM `bestiary_killcount` WHERE player_id = " .. playerId .. " AND `monster_id` IN (" .. table.concat(raceObject.monsters, ",") .. ")")
+function Player.getBestiaryKillCountByMonsterIDs(self, monsterTables)
 	local raceMonsters = {}
-	
-	if query then
-		repeat
-			local monsterID = result.getNumber(query, "monster_id")
-			local count = result.getNumber(query, "count")
-
-			raceMonsters[monsterID] = count
-		until not result.next(query)
-
-		result.free(query)
+	for i = 1, #monsterTables do
+		local thisKilled = self:getBestiaryKillCount(monsterTables[i])
+		if thisKilled > 0 then
+			raceMonsters[monsterTables[i]] = thisKilled
+		end
 	end
-
 	return raceMonsters
 end
 
-function Player.getBestiaryCountByMonster(self, monsterID) --Returns int with the kill count
-	local playerId = self:getGuid()
-	local query = db.storeQuery("SELECT `count` FROM `bestiary_killcount` WHERE `player_id` = " .. playerId.. " AND `monster_id` = "..monsterID)
-	local count = 0
-	if query then
-		count = result.getNumber(query, "count")
-		result.free(query)
-	end
-
-	return count
-end
-
-function Player.getBestiaryFinished(self) --Return table with monster ID of all finished monsters
-	local playerId = self:getGuid()
-	local query = db.storeQuery("SELECT `monster_id` FROM `bestiary_killcount` WHERE `player_id` = " .. playerId.. " AND `finished` = 1")
+function Player.getBestiaryFinished(self)
 	local finishedMonsters = {}
-	
-	if query then
-		repeat
-			local monsterID = result.getNumber(query, "monster_id")
-			table.insert(finishedMonsters, monsterID)
-		until not result.next(query)
-
-		result.free(query)
+	for i, monster in pairs(Bestiary.Monsters) do
+		local thisKilled = self:getBestiaryKillCount(i)
+		if thisKilled >= monster.toKill then
+			table.insert(finishedMonsters, i)
+		end
 	end
 	return finishedMonsters
 end
@@ -562,33 +551,35 @@ function Player.setCharmRuneSlotExpansion(self, onOff)
 	self:setStorageValue(Bestiary.Storage.PLAYER_CHARM_SLOT_EXPANSION, onOff and 1 or 0)
 end
 
-function Player.addBestiaryKill(self, monsterId) --MonsterID can be Name
+function Player.addBestiaryKill(self, monsterID) --MonsterID can be Name
 
-	if type(monsterId) == "string" then
-		monsterId = Bestiary.MonstersName[monsterId]
-		if not monsterId then
+	if type(monsterID) == "string" then
+		monsterID = Bestiary.MonstersName[monsterID]
+		if not monsterID then
 			return
 		end
 	end
 	local plId = self:getGuid()
-	local curCount = self:getBestiaryCountByMonster(monsterId)
-	local monster = Bestiary.Monsters[monsterId]
+	local curCount = self:getBestiaryKillCount(monsterID)
+	local monster = Bestiary.Monsters[monsterID]
 	if curCount == 0 then
-		db.query("INSERT INTO `bestiary_killcount` (`player_id`, `monster_id`, `count`) VALUES (" .. plId .. ", " .. monsterId .. ", 1);")
+		self:sendBestiaryEntryChanged(monsterID)
+		self:setBestiaryKillCount(monsterID, 1)
 		self:sendTextMessage(MESSAGE_STATUS_SMALL, 'You unlocked details for creature "'..monster.name..'" ')
 		return
 	end
 
 	curCount = curCount + 1
 	status = Bestiary.GetKillStatus(monster, curCount)
-	db.query('UPDATE `bestiary_killcount` SET `count` = ' .. curCount .. ',`finished` = '.. ((status == Bestiary.KillStatus.FINISHED) and 1 or 0) .. ' WHERE `player_id` = ' .. plId .. " AND `monster_id` = "..monsterId)
-
-
-    if curCount == monster.checkFirst or curCount == monster.checkSecond then
-    	self:sendTextMessage(MESSAGE_STATUS_SMALL, 'You unlocked details for creature "'..target:getName()..'" ')
+	self:setBestiaryKillCount(monsterID, curCount)
+	
+    if curCount == monster.FirstUnlock or curCount == monster.SecondUnlock then
+    	self:sendTextMessage(MESSAGE_STATUS_SMALL, 'You unlocked details for creature "'..monster.name..'".')
+		self:sendBestiaryEntryChanged(monsterID)
     elseif curCount == monster.toKill then
-    	self:sendTextMessage(MESSAGE_STATUS_SMALL, 'You unlocked full details for creature "'..target:getName()..'" ')
+    	self:sendTextMessage(MESSAGE_STATUS_SMALL, 'You unlocked full details for creature "'..monster.name..'"!')
 		self:addCharmPoints(monster.CharmsPoints)
+		self:sendBestiaryEntryChanged(monsterID)
 	end	
 end
 
@@ -610,6 +601,14 @@ function Player.getCharmFromTarget(self, target)
 		end
 	end
 	return nil
+end
+
+
+function Player.sendBestiaryEntryChanged(self, monsterID)
+    local msg = NetworkMessage()
+    msg:addByte(Bestiary.S_Packets.SendBestiaryTracker)
+	msg:addU16(monsterID)
+    msg:sendToPlayer(self)
 end
 
 
@@ -635,4 +634,3 @@ Bestiary.bitSet = function(input)
 	until input == 0
     return rtn;
 end
-

--- a/data/scripts/talkactions/god/charms.lua
+++ b/data/scripts/talkactions/god/charms.lua
@@ -51,9 +51,11 @@ function talk.onSay(player, words, param)
 	target:setCharmPoints(0)
 	target:setCharmRuneUsedAmount(0)
 	target:setCharmRuneSlotExpansion(false)
+	
 	for i, charm in pairs(Bestiary.Charms) do
 		target:resetCharmRuneCreature(charm)
 	end
+	target:setCharmUnlockedRuneBit(0)
     target:getPosition():sendMagicEffect(CONST_ME_HOLYAREA)
 
 end
@@ -109,9 +111,13 @@ function talk.onSay(player, words, param)
 
 	player:sendCancelMessage("Added all charm runes to '" .. target:getName() .. "'.")	
 	target:sendCancelMessage("Received all charm runes!")
+	playerCurBit = target:getCharmRunesBit()
+
 	for i, charm in pairs(Bestiary.Charms) do
 		target:addCharmRune(charm)
+		playerCurBit = target:calculateCharmRuneBit(charm, true, playerCurBit)
 	end
+	target:setCharmRuneBit(playerCurBit)
     target:getPosition():sendMagicEffect(CONST_ME_HOLYAREA)
 
 end
@@ -119,3 +125,4 @@ end
 
 talk:separator(" ")
 talk:register()
+

--- a/data/scripts/talkactions/god/charms.lua
+++ b/data/scripts/talkactions/god/charms.lua
@@ -22,15 +22,14 @@ function talk.onSay(player, words, param)
 	--trim left
 	split[2] = split[2]:gsub("^%s*(.-)$", "%1")
 	
-	player:sendCancelMessage("Adicionado " .. split[2] .. " charm points para o personagem '" .. target:getName() .. "'.")
-	target:sendCancelMessage("Recebido " .. split[2] .. " charm points!")
+	player:sendCancelMessage("Added " .. split[2] .. " charm points to character '" .. target:getName() .. "'.")
+	target:sendCancelMessage("Received " .. split[2] .. " charm points!")
 	target:addCharmPoints(tonumber(split[2]))
     target:getPosition():sendMagicEffect(CONST_ME_HOLYAREA)
 
 end
 talk:separator(" ")
 talk:register()
-
 local talk = TalkAction("/resetcharms")
 
 function talk.onSay(player, words, param)
@@ -47,10 +46,76 @@ function talk.onSay(player, words, param)
 		return false
 	end
 
-	player:sendCancelMessage("Resetado as charms do personagem '" .. target:getName() .. "'.")	
-	player:sendCancelMessage("Adicionado " .. split[2] .. " charm points para o personagem '" .. target:getName() .. "'.")
-	target:sendCancelMessage("Resetado as suas charms points!")
+	player:sendCancelMessage("Reseted charm points from character '" .. target:getName() .. "'.")	
+	target:sendCancelMessage("Reseted your charm points!")
 	target:setCharmPoints(0)
+	target:setCharmRuneUsedAmount(0)
+	target:setCharmRuneSlotExpansion(false)
+	for i, charm in pairs(Bestiary.Charms) do
+		target:resetCharmRuneCreature(charm)
+	end
     target:getPosition():sendMagicEffect(CONST_ME_HOLYAREA)
 
 end
+
+
+talk:separator(" ")
+talk:register()
+
+
+local talk = TalkAction("/charmexpansion")
+
+function talk.onSay(player, words, param)
+	if not player:getGroup():getAccess() or player:getAccountType() < ACCOUNT_TYPE_GOD then
+		return true
+	end
+
+	if param == "" then
+		param = player:getName()
+	end
+	local target = Player(param)
+	if not target then
+		player:sendCancelMessage("A player with that name is not online.")
+		return false
+	end
+
+	player:sendCancelMessage("Added charm expansion for player '" .. target:getName() .. "'.")	
+	target:sendCancelMessage("Received charm expansion!")
+	target:setCharmRuneSlotExpansion(true)
+    target:getPosition():sendMagicEffect(CONST_ME_HOLYAREA)
+
+end
+
+
+talk:separator(" ")
+talk:register()
+
+
+local talk = TalkAction("/charmrunes")
+
+function talk.onSay(player, words, param)
+	if not player:getGroup():getAccess() or player:getAccountType() < ACCOUNT_TYPE_GOD then
+		return true
+	end
+
+	if param == "" then
+		param = player:getName()
+	end
+	local target = Player(param)
+	if not target then
+		player:sendCancelMessage("A player with that name is not online.")
+		return false
+	end
+
+	player:sendCancelMessage("Added all charm runes to '" .. target:getName() .. "'.")	
+	target:sendCancelMessage("Received all charm runes!")
+	for i, charm in pairs(Bestiary.Charms) do
+		target:addCharmRune(charm)
+	end
+    target:getPosition():sendMagicEffect(CONST_ME_HOLYAREA)
+
+end
+
+
+talk:separator(" ")
+talk:register()


### PR DESCRIPTION
Now it blacks out the monster when you dont have it unlocked yet. Charms can be unlocked. There is a charm expansion method aswell, which someone should link to the gamestore (player:setCharmRuneSlotExpansion(true/false)). There is also a method that you can use to get the active charm for the monster(if any): player:getCharmFromTarget(target)

TODO add the methods to trigger the charm runes
TODO add information related to monster locations in bestiary
TODO add information of loot form special event (this should be fixed in creature loots and then parsed to the bestiary)

Special thanks to Rick and lBaah :)