### PR TITLE
Feat: fix bug on experienceGain and wrong display exp percent from client 12

### DIFF
--- a/data/creaturescripts/scripts/others/login.lua
+++ b/data/creaturescripts/scripts/others/login.lua
@@ -150,6 +150,7 @@ function onLogin(player)
 		player:setBaseXpGain(displayRate*0.5*100) -- ALL players low stamina
 		player:setStaminaXpBoost(50)
 	end
+	player:setBaseXpGain(100)
 
 	if player:getClient().version > 1110 then
 		local worldTime = getWorldTime()

--- a/data/creaturescripts/scripts/others/login.lua
+++ b/data/creaturescripts/scripts/others/login.lua
@@ -121,36 +121,23 @@ function onLogin(player)
         player:setStorageValue(Storage.combatProtectionStorage, 1)
         onMovementRemoveProtection(playerId, player:getPosition(), 10)
 	end
-
 	-- Set Client XP Gain Rate
+	local baseExp = 100
 	if Game.getStorageValue(GlobalStorage.XpDisplayMode) > 0 then
-		displayRate = getRateFromTable(experienceStages, self:getLevel(), configManager.getNumber(configKeys.RATE_EXP))
-		else
-		displayRate = 1
+		baseExp = getRateFromTable(experienceStages, player:getLevel(), configManager.getNumber(configKeys.RATE_EXP))
 	end
+
 	local staminaMinutes = player:getStamina()
-	local storeBoost = player:getExpBoostStamina()
-	player:setStoreXpBoost(storeBoost > 0 and 50 or 0)
-	if staminaMinutes > 2400 and player:isPremium() and storeBoost > 0 then
-		player:setBaseXpGain(displayRate*2*100) -- Premium + Stamina boost + Store boost
-		player:setStaminaXpBoost(150)
-	elseif staminaMinutes > 2400 and player:isPremium() and storeBoost <= 0 then
-		player:setBaseXpGain(displayRate*1.5*100) -- Premium + Stamina boost
-		player:setStaminaXpBoost(150)
-	elseif staminaMinutes <= 2400 and staminaMinutes > 840 and player:isPremium() and storeBoost > 0 then
-		player:setBaseXpGain(displayRate*1.5*100) -- Premium + Store boost
-		player:setStaminaXpBoost(100)
-	elseif staminaMinutes > 840 and storeBoost > 0 then
-		player:setBaseXpGain(displayRate*1.5*100) -- FACC + Store boost
-		player:setStaminaXpBoost(100)
-	elseif staminaMinutes <= 840 and storeBoost > 0 then
-		player:setBaseXpGain(displayRate*1*100) -- ALL players low stamina + Store boost
-		player:setStaminaXpBoost(50)
-	elseif staminaMinutes <= 840 then
-		player:setBaseXpGain(displayRate*0.5*100) -- ALL players low stamina
-		player:setStaminaXpBoost(50)
+	local doubleExp = false -- pode mudar pra true se tiver double no server
+	local staminaBonus = (staminaMinutes > 2400) and 150 or ((staminaMinutes < 840) and 50 or 100)
+
+	if doubleExp then
+		baseExp = baseExp * 2
 	end
-	player:setBaseXpGain(100)
+
+	player:setStaminaXpBoost(staminaBonus)
+	player:setBaseXpGain(baseExp)
+	--player:setStoreXpBoost(storeXpBoost) NÃO DEVE SER DEFINIDA AQUI PORQUE DEPENDE DA STORE/DO USUARIO QUANDO COMPROU
 
 	if player:getClient().version > 1110 then
 		local worldTime = getWorldTime()

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -733,11 +733,12 @@ function Player:onGainExperience(source, exp, rawExp)
 	end
 
 	-- Experience Stage Multiplier
-	exp = exp * getRateFromTable(experienceStages, self:getLevel(), configManager.getNumber(configKeys.RATE_EXP))
-	baseExp = rawExp * exp
+	local getExperienceStage = getRateFromTable(experienceStages, self:getLevel(), configManager.getNumber(configKeys.RATE_EXP))
+	exp = exp * getExperienceStage
+	baseExp = rawExp * getExperienceStage
 	if Game.getStorageValue(GlobalStorage.XpDisplayMode) > 0 then
 		displayRate = exp
-		else
+	else
 		displayRate = 1
 	end
 
@@ -785,7 +786,7 @@ function Player:onGainExperience(source, exp, rawExp)
 		end
 	end
 
-	self:setBaseXpGain(displayRate * 100)
+	self:setBaseXpGain(100)
 	return exp
 end
 

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -479,7 +479,7 @@ function Player:onMoveItem(item, count, fromPosition, toPosition, fromCylinder, 
 
 		if moveItem then
 			local parent = item:getParent()
-			if parent:isContainer() and parent:getSize() == parent:getCapacity() then
+			if parent:getSize() == parent:getCapacity() then
 				self:sendTextMessage(MESSAGE_STATUS_SMALL, Game.getReturnMessage(RETURNVALUE_CONTAINERNOTENOUGHROOM))
 				return false
 			else
@@ -733,11 +733,11 @@ function Player:onGainExperience(source, exp, rawExp)
 	end
 
 	-- Experience Stage Multiplier
-	local getExperienceStage = getRateFromTable(experienceStages, self:getLevel(), configManager.getNumber(configKeys.RATE_EXP))
-	exp = exp * getExperienceStage
-	baseExp = rawExp * getExperienceStage
+	local expStage = getRateFromTable(experienceStages, self:getLevel(), configManager.getNumber(configKeys.RATE_EXP))
+	exp = exp * expStage
+	baseExp = rawExp * expStage
 	if Game.getStorageValue(GlobalStorage.XpDisplayMode) > 0 then
-		displayRate = exp
+		displayRate = expStage
 	else
 		displayRate = 1
 	end
@@ -746,47 +746,42 @@ function Player:onGainExperience(source, exp, rawExp)
 	for slot = CONST_PREY_SLOT_FIRST, CONST_PREY_SLOT_THIRD do
 		if (self:getPreyCurrentMonster(slot) == source:getName() and self:getPreyBonusType(slot) == CONST_BONUS_XP_BONUS) then
 			exp = exp + math.floor(exp * (self:getPreyBonusValue(slot) / 100))
-			preyTimeLeft(self, slot) -- slot consumption
 			break
+		end
+		if (self:getPreyTimeLeft(slot) / 60) > 0 then
+			preyTimeLeft(self, slot) -- slot consumption, outside of the mosnter check
 		end
 	end
 
 	-- Store Bonus
-	local Boost = self:getExpBoostStamina()
 	useStaminaXp(self) -- Use store boost stamina
-	self:setStoreXpBoost(Boost > 0 and 50 or 0)
-	if (self:getExpBoostStamina() <= 0 and self:getStoreXpBoost() > 0) then
-		self:setStoreXpBoost(0) -- Reset Store boost to 0 if boost stamina has ran out
-	end
-	if (self:getStoreXpBoost() > 0) then
-		exp = exp + (baseExp * (self:getStoreXpBoost()/100)) -- Exp Boost
-		displayRate = displayRate * ((self:getStoreXpBoost()+100)/100)
+	
+	local Boost = self:getExpBoostStamina()
+	local stillHasBoost = Boost > 0
+	local storeXpBoostAmount = stillHasBoost and self:getStoreXpBoost() or 0
+
+	self:setStoreXpBoost(storeXpBoostAmount) 
+
+	if (storeXpBoostAmount > 0) then
+		exp = exp + (baseExp * (storeXpBoostAmount/100)) -- Exp Boost
 	end
 
-	-- Stamina modifier
+	-- Stamina Bonus
 	if configManager.getBoolean(configKeys.STAMINA_SYSTEM) then
 		useStamina(self)
-
 		local staminaMinutes = self:getStamina()
 		if staminaMinutes > 2400 and self:isPremium() then
-			exp = exp + baseExp * 0.5
-			displayRate = displayRate + exp * 0.5
+			exp = exp * 1.5
 			self:setStaminaXpBoost(150)
 		elseif staminaMinutes <= 840 then
-			exp = exp * 0.5
+			exp = exp * 0.5 --TODO destroy loot of people with 840- stamina
 			self:setStaminaXpBoost(50)
-			displayRate = displayRate * 0.5
 		else
 			self:setStaminaXpBoost(100)
 		end
-		for slot = CONST_PREY_SLOT_FIRST, CONST_PREY_SLOT_THIRD do
-			if self:getPreyState(slot) == 2 then
-			 preyTimeLeft(self, slot) -- slot consumption
-			end
-		end
 	end
-
-	self:setBaseXpGain(100)
+	
+	self:setBaseXpGain(displayRate * 100)
 	return exp
 end
 


### PR DESCRIPTION
Fix:
* Error in the calculation of bonuses (baseExp + store + stamina), which together were giving the wrong exp.
* Tibia 12 percent display error
* Error in gaining experience of pr # 958, the multiplication calculation was wrong

Thanks and credits to:
@dudztroyer 