### PR TITLE
fix inq teleport

### DIFF
--- a/data/movements/scripts/quests/inquisition/entrance.lua
+++ b/data/movements/scripts/quests/inquisition/entrance.lua
@@ -23,18 +23,16 @@ function onStepIn(creature, item, position, fromPosition)
 		return true
 	end
 
-	if not hasTouchedOneThrone(player) or player:getLevel() < 100 or player:getStorageValue(Storage.TheInquisition.Questline) < 20 then
-	if player:getLevel() < 100 then
-		player:teleportTo(fromPosition)
-		position:sendMagicEffect(CONST_ME_TELEPORT)
-		fromPosition:sendMagicEffect(CONST_ME_TELEPORT)
+	if hasTouchedOneThrone(player) and player:getLevel() >= 100 and player:getStorageValue(Storage.TheInquisition.Questline) >= 20 then
+		local destination = Position(33168, 31683, 15)
+			player:teleportTo(destination)
+			position:sendMagicEffect(CONST_ME_TELEPORT)
+			destination:sendMagicEffect(CONST_ME_TELEPORT)
 		return true
-	end
-
-	local destination = Position(33168, 31683, 15)
-	player:teleportTo(destination)
-	position:sendMagicEffect(CONST_ME_TELEPORT)
-	destination:sendMagicEffect(CONST_ME_TELEPORT)
-	return true
+	else
+			player:teleportTo(fromPosition)
+			position:sendMagicEffect(CONST_ME_TELEPORT)
+			fromPosition:sendMagicEffect(CONST_ME_TELEPORT)
+		return true
 	end
 end

--- a/data/movements/scripts/quests/inquisition/entrance.lua
+++ b/data/movements/scripts/quests/inquisition/entrance.lua
@@ -25,14 +25,15 @@ function onStepIn(creature, item, position, fromPosition)
 
 	if hasTouchedOneThrone(player) and player:getLevel() >= 100 and player:getStorageValue(Storage.TheInquisition.Questline) >= 20 then
 		local destination = Position(33168, 31683, 15)
-			player:teleportTo(destination)
-			position:sendMagicEffect(CONST_ME_TELEPORT)
-			destination:sendMagicEffect(CONST_ME_TELEPORT)
-		return true
-	else
-			player:teleportTo(fromPosition)
-			position:sendMagicEffect(CONST_ME_TELEPORT)
-			fromPosition:sendMagicEffect(CONST_ME_TELEPORT)
+		player:teleportTo(destination)
+		position:sendMagicEffect(CONST_ME_TELEPORT)
+		destination:sendMagicEffect(CONST_ME_TELEPORT)
 		return true
 	end
+
+	player:teleportTo(fromPosition)
+	position:sendMagicEffect(CONST_ME_TELEPORT)
+	fromPosition:sendMagicEffect(CONST_ME_TELEPORT)
+	return true
+
 end


### PR DESCRIPTION
Rewrote to check for quest, level req., and has touched throne of poi. Before this if you touched poi throne you wouldn't be able to enter inq. teleport.