### PR TITLE
Fix getMinMaxValues attackSkill with distance weapons

### DIFF
--- a/data/spells/scripts/attack/ethereal spear.lua
+++ b/data/spells/scripts/attack/ethereal spear.lua
@@ -4,10 +4,9 @@ combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HITAREA)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ETHEREALSPEAR)
 combat:setParameter(COMBAT_PARAM_BLOCKARMOR, 1)
 
-function onGetFormulaValues(player, attack, factor)
-	local skillTotal = 2 * player:getEffectiveSkillLevel(SKILL_DISTANCE)
+function onGetFormulaValues(player, skill, attack, factor)
 	local levelTotal = player:getLevel() / 5
-	return -(((skillTotal + attack / 3500) * 0.35) + (levelTotal) + 0), -(((skillTotal + attack / 3125) * 0.5) + (levelTotal) + 5)
+	return -(((2 * skill + attack / 3500) * 0.35) + (levelTotal) + 0), -(((2 * skill + attack / 3125) * 0.5) + (levelTotal) + 5)
 end
 
 combat:setCallback(CALLBACK_PARAM_SKILLVALUE, "onGetFormulaValues")

--- a/data/spells/scripts/attack/strong ethereal spear.lua
+++ b/data/spells/scripts/attack/strong ethereal spear.lua
@@ -4,10 +4,9 @@ combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_HITAREA)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_ETHEREALSPEAR)
 combat:setParameter(COMBAT_PARAM_BLOCKARMOR, 1)
 
-function onGetFormulaValues(player, attack, factor)
-	local skillTotal = 2 * player:getEffectiveSkillLevel(SKILL_DISTANCE)
+function onGetFormulaValues(player, skill, attack, factor)
 	local levelTotal = player:getLevel() / 5
-	return -(((skillTotal + attack / 2500) * 2.30) + (levelTotal) + 7), -(((skillTotal + attack / 1875) * 3.30) + (levelTotal) + 13)
+	return -(((2 * skill + attack / 2500) * 2.30) + (levelTotal) + 7), -(((2 * skill + attack / 1875) * 3.30) + (levelTotal) + 13)
 end
 
 combat:setCallback(CALLBACK_PARAM_SKILLVALUE, "onGetFormulaValues")

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1012,11 +1012,12 @@ void ValueCallback::getMinMaxValues(Player* player, CombatDamage& damage, bool u
 			//onGetPlayerMinMaxValues(player, attackSkill, attackValue, attackFactor)
 			Item* tool = player->getWeapon();
 			const Weapon* weapon = g_weapons->getWeapon(tool);
+			Item* item = nullptr;
 
 			if (weapon) {
 				attackValue = tool->getAttack();
 				if (tool->getWeaponType() == WEAPON_AMMO) {
-					Item* item = player->getWeapon(true);
+					item = player->getWeapon(true);
 					if (item) {
 						attackValue += item->getAttack();
 					}
@@ -1044,7 +1045,7 @@ void ValueCallback::getMinMaxValues(Player* player, CombatDamage& damage, bool u
 				}
 			}
 
-			lua_pushnumber(L, player->getWeaponSkill(tool));
+			lua_pushnumber(L, player->getWeaponSkill(item ? item : tool));
 			lua_pushnumber(L, attackValue);
 			lua_pushnumber(L, player->getAttackFactor());
 			parameters += 3;


### PR DESCRIPTION
When player is using distance weapon that needs ammunition and have ammo item in ammunition slot, attackSkill value is 0, this is because ammunition item is checked first and these items don't have any skill types.