### PR TITLE
House AccessList: drop support for regular expressions (TFS)

### DIFF
--- a/src/house.cpp
+++ b/src/house.cpp
@@ -492,6 +492,8 @@ void AccessList::parseList(const std::string& listToParse)
 			} else {
 				addGuildRank(line.substr(0, at_pos - 1), line.substr(at_pos + 1));
 			}
+		} else if (line == "*") {
+			allowEveryone = true;
 		} else if (line.find("!") != std::string::npos || line.find("*") != std::string::npos || line.find("?") != std::string::npos) {
 			continue; // regexp no longer supported
 		} else {
@@ -555,6 +557,10 @@ void AccessList::addGuildRank(const std::string& name, const std::string& guildN
 
 bool AccessList::isInList(const Player* player)
 {
+	if (allowEveryone) {
+		return true;
+	}
+
 	std::string name = asLowerCaseString(player->getName());
 	std::cmatch what;
 

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -561,9 +561,6 @@ bool AccessList::isInList(const Player* player)
 		return true;
 	}
 
-	std::string name = asLowerCaseString(player->getName());
-	std::cmatch what;
-
 	auto playerIt = playerList.find(player->getGUID());
 	if (playerIt != playerList.end()) {
 		return true;

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -460,6 +460,7 @@ void AccessList::parseList(const std::string& listToParse)
 {
 	playerList.clear();
 	guildRankList.clear();
+	allowEveryone = false;
 	this->list = list;
 	if (list.empty()) {
 		return;

--- a/src/house.h
+++ b/src/house.h
@@ -48,6 +48,7 @@ class AccessList
 		std::string list;
 		std::unordered_set<uint32_t> playerList;
 		std::unordered_set<uint32_t> guildRankList;
+		bool allowEveryone = false;
 };
 
 class Door final : public Item

--- a/src/house.h
+++ b/src/house.h
@@ -20,7 +20,6 @@
 #ifndef FS_HOUSE_H_EB9732E7771A438F9CD0EFA8CB4C58C4
 #define FS_HOUSE_H_EB9732E7771A438F9CD0EFA8CB4C58C4
 
-#include <regex>
 #include <set>
 #include <unordered_set>
 

--- a/src/house.h
+++ b/src/house.h
@@ -38,8 +38,7 @@ class AccessList
 		void parseList(const std::string& list);
 		void addPlayer(const std::string& name);
 		void addGuild(const std::string& name);
-		void addGuildRank(const std::string& name, const std::string& guildName);
-		void addExpression(const std::string& expression);
+		void addGuildRank(const std::string& name, const std::string& rankName);
 
 		bool isInList(const Player* player);
 
@@ -49,8 +48,6 @@ class AccessList
 		std::string list;
 		std::unordered_set<uint32_t> playerList;
 		std::unordered_set<uint32_t> guildRankList;
-		std::list<std::string> expressionList;
-		std::list<std::pair<std::regex, bool>> regExList;
 };
 
 class Door final : public Item


### PR DESCRIPTION
This change removes support for house access list lines using:

regular expressions (? for single character, * for many characters)
exclusions (lines starting with !)
Guild name and guild rank is still supported.
Access list is limited to 100 entries and each entry can be max 100 characters long


@DSpeichert 
cherry-picked from otland/forgottenserver#2965