### PR TITLE
fix: creature update walk

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -587,6 +587,7 @@ void Creature::onCreatureMove(Creature* creature, const Tile* newTile, const Pos
 	if (creature == followCreature || (creature == this && followCreature)) {
 		if (hasFollowPath) {
 			isUpdatingPath = true;
+			g_dispatcher.addTask(createTask(std::bind(&Game::updateCreatureWalk, &g_game, getID())));
 		}
 
 		if (newPos.z != oldPos.z || !canSee(followCreature->getPosition())) {


### PR DESCRIPTION
this change makes onCreatureMove run the task to update follow path on every creature movement

https://imgur.com/a/kP3LQEV

note: probably will increase the CPU usage
credits to @marksamman [(reference)](https://otland.net/threads/weird-monster-behaviour-in-tfs-1-1.228021/post-2200365)
