### PR TITLE
Fix build on GNU/Linux Ubuntu 16.04 with GCC 5.4.0 and ccache enabled. Closes #1115

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,11 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   # https://kristerw.blogspot.com/2017/09/useful-gcc-warning-options-not-enabled.html
 
   # cmake -DCMAKE_BUILD_TYPE=Release ..
-  set(CMAKE_CXX_FLAGS_RELEASE   "-Wall -Werror -pipe -fvisibility=hidden -march=native -O2")
+  set(CMAKE_CXX_FLAGS_RELEASE  "-Wall -Werror -pipe -fvisibility=hidden -O2")
+
+  if (NOT CCACHE_PROGRAM)
+    set(CMAKE_CXX_FLAGS_RELEASE  "${CMAKE_CXX_FLAGS_RELEASE} -march=native")
+  endif()
 
   # cmake -DCMAKE_BUILD_TYPE=Debug ..
   # Ubuntu 16.04


### PR DESCRIPTION
Something was causing the -march to be incorrect, causing inclusion of files from different platforms such as IA32.