### PR TITLE
Print duplicate storages

### DIFF
--- a/data/lib/core/storages.lua
+++ b/data/lib/core/storages.lua
@@ -2187,7 +2187,7 @@ GlobalStorage = {
 
 }
 
--- Função de extração de values
+-- Values extraction function
 local function extractValues(tab)
   local ret = {}
   for _, v in pairs(tab) do
@@ -2204,16 +2204,16 @@ local function extractValues(tab)
 end
 
 local benchmark = os.clock()
-local extraction = extractValues(Storage) -- Chama a função
-table.sort(extraction) -- Ordena a tabela
--- A escolha da ordenação se deve ao fato de que ordenação é bem barato O(log2(n)) e aí podemos simplesmente comparar um a um os elementos achando duplicatas em O(n)
+local extraction = extractValues(Storage) -- Call function
+table.sort(extraction) -- Sort the table
+-- The choice of sorting is due to the fact that sorting is very cheap O (log2 (n)) and then we can simply compare one by one the elements finding duplicates in O(n)
 
--- Percorre a tabela extraída verificando se há duplicatas
+-- Scroll through the extracted table for duplicates
 if #extraction > 1 then
   for i = 1, #extraction - 1 do
     if extraction[i] == extraction[i+1] then
       print("Duplicate storage value found: ".. extraction[i])
     end 
   end
-  print(string.format("Processado em %.4f(s)", os.clock() - benchmark))
+  print(string.format("Processed in %.4f(s)", os.clock() - benchmark))
 end

--- a/data/lib/core/storages.lua
+++ b/data/lib/core/storages.lua
@@ -2186,3 +2186,34 @@ GlobalStorage = {
 	XpDisplayMode = 5634
 
 }
+
+-- Função de extração de values
+local function extractValues(tab)
+  local ret = {}
+  for _, v in pairs(tab) do
+    if type(v) == "number" then
+      table.insert(ret, v)
+    else
+      local extraction = extractValues(v)
+      for _, k in pairs(extraction) do
+        table.insert(ret, k)
+      end
+    end
+  end
+  return ret
+end
+
+local benchmark = os.clock()
+local extraction = extractValues(Storage) -- Chama a função
+table.sort(extraction) -- Ordena a tabela
+-- A escolha da ordenação se deve ao fato de que ordenação é bem barato O(log2(n)) e aí podemos simplesmente comparar um a um os elementos achando duplicatas em O(n)
+
+-- Percorre a tabela extraída verificando se há duplicatas
+if #extraction > 1 then
+  for i = 1, #extraction - 1 do
+    if extraction[i] == extraction[i+1] then
+      print("Duplicate storage value found: ".. extraction[i])
+    end 
+  end
+  print(string.format("Processado em %.4f(s)", os.clock() - benchmark))
+end

--- a/data/lib/core/storages.lua
+++ b/data/lib/core/storages.lua
@@ -2187,6 +2187,7 @@ GlobalStorage = {
 
 }
 
+
 -- Values extraction function
 local function extractValues(tab, ret)
 	if type(tab) == "number" then
@@ -2200,16 +2201,16 @@ end
 
 local benchmark = os.clock()
 local extraction = {}
-extractValues(Storage, extraction)  -- Call function
+extractValues(Storage, extraction) -- Call function
 table.sort(extraction) -- Sort the table
 -- The choice of sorting is due to the fact that sorting is very cheap O (n log2 (n)) and then we can simply compare one by one the elements finding duplicates in O(n)
 
 -- Scroll through the extracted table for duplicates
 if #extraction > 1 then
-  for i = 1, #extraction - 1 do
-    if extraction[i] == extraction[i+1] then
-      print("Duplicate storage value found: ".. extraction[i])
-    end 
-  end
-  print(string.format("Processed in %.4f(s)", os.clock() - benchmark))
+	for i = 1, #extraction - 1 do
+		if extraction[i] == extraction[i+1] then
+			print("Duplicate storage value found: ".. extraction[i])
+		end
+	end
+	print(string.format("Processed in %.4f(s)", os.clock() - benchmark))
 end

--- a/data/lib/core/storages.lua
+++ b/data/lib/core/storages.lua
@@ -2206,7 +2206,7 @@ end
 local benchmark = os.clock()
 local extraction = extractValues(Storage) -- Call function
 table.sort(extraction) -- Sort the table
--- The choice of sorting is due to the fact that sorting is very cheap O (log2 (n)) and then we can simply compare one by one the elements finding duplicates in O(n)
+-- The choice of sorting is due to the fact that sorting is very cheap O (n log2 (n)) and then we can simply compare one by one the elements finding duplicates in O(n)
 
 -- Scroll through the extracted table for duplicates
 if #extraction > 1 then

--- a/data/lib/core/storages.lua
+++ b/data/lib/core/storages.lua
@@ -2188,23 +2188,19 @@ GlobalStorage = {
 }
 
 -- Values extraction function
-local function extractValues(tab)
-  local ret = {}
-  for _, v in pairs(tab) do
-    if type(v) == "number" then
-      table.insert(ret, v)
-    else
-      local extraction = extractValues(v)
-      for _, k in pairs(extraction) do
-        table.insert(ret, k)
-      end
-    end
-  end
-  return ret
+local function extractValues(tab, ret)
+	if type(tab) == "number" then
+		table.insert(ret, tab)
+	else
+		for _, v in pairs(tab) do
+			extractValues(v, ret)
+		end
+	end
 end
 
 local benchmark = os.clock()
-local extraction = extractValues(Storage) -- Call function
+local extraction = {}
+extractValues(Storage, extraction)  -- Call function
 table.sort(extraction) -- Sort the table
 -- The choice of sorting is due to the fact that sorting is very cheap O (n log2 (n)) and then we can simply compare one by one the elements finding duplicates in O(n)
 


### PR DESCRIPTION
This change has very low impact on startup and allow people to identify duplicate storages as long as all storages used in the game are inside this table.