### PR TITLE
Allow attack feature from config.lua

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -68,7 +68,8 @@ houseRentPeriod = "never"
 -- Do not touch here
 -- Avoid use of WIPE program to crash the distro
 timeBetweenActions = 500
-timeBetweenExActions = 700
+timeBetweenExActions = 1000
+actionTimerInterruptAttack = true -- should actions interval interrupt attack?
 
 -- Push Delay
 pushDelay = 1000

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -185,6 +185,7 @@ bool ConfigManager::load()
 	integer[HOUSE_PRICE] = getGlobalNumber(L, "housePriceEachSQM", 1000);
 	integer[ACTIONS_DELAY_INTERVAL] = getGlobalNumber(L, "timeBetweenActions", 200);
 	integer[EX_ACTIONS_DELAY_INTERVAL] = getGlobalNumber(L, "timeBetweenExActions", 1000);
+	boolean[ACTION_DELAY_INTERRUPT_ATTACK] = getGlobalBoolean(L, "actionTimerInterruptAttack", true);
 	integer[MAX_MESSAGEBUFFER] = getGlobalNumber(L, "maxMessageBuffer", 4);
 	integer[KICK_AFTER_MINUTES] = getGlobalNumber(L, "kickIdlePlayerAfterMinutes", 15);
 	integer[PROTECTION_LEVEL] = getGlobalNumber(L, "protectionLevel", 1);

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -52,6 +52,7 @@ class ConfigManager
 			FORCE_MONSTERTYPE_LOAD,
 			STOREMODULES,
 			ALLOW_BLOCK_SPAWN,
+			ACTION_DELAY_INTERRUPT_ATTACK,
 
 			LAST_BOOLEAN_CONFIG /* this must be the last one */
 		};

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3349,10 +3349,12 @@ void Player::doAttacking(uint32_t)
 		bool classicSpeed = g_config.getBoolean(ConfigManager::CLASSIC_ATTACK_SPEED);
 
 		if (weapon) {
-			if (!weapon->interruptSwing()) {
-				result = weapon->useWeapon(this, tool, attackedCreature);
-			} else if (!classicSpeed && !canDoAction()) {
-				delay = getNextActionTime();
+			if (g_config.getBoolean(ConfigManager::ACTION_DELAY_INTERRUPT_ATTACK)){
+				if (!weapon->interruptSwing()) {
+					result = weapon->useWeapon(this, tool, attackedCreature);
+				} else if (!classicSpeed && !canDoAction()) {
+					delay = getNextActionTime();
+				}
 			} else {
 				result = weapon->useWeapon(this, tool, attackedCreature);
 			}


### PR DESCRIPTION
This will allow everyone who wants to allow/disallow the attack delay swing through the config.lua without removing any feature.
This is an alternative to https://github.com/opentibiabr/otservbr-global/pull/1175