### PR TITLE
Allow regeneration on PZ through config

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -19,6 +19,7 @@ monthKillsToRedSkull = 10
 redSkullDuration = 30
 blackSkullDuration = 45
 orangeSkullDuration = 7
+allowProtectionZoneRegeneration = false -- enable/disable food regeneration in protection zone
 
 -- Connection Config
 -- NOTE: maxPlayers set to 0 means no limit

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -732,7 +732,7 @@ bool ConditionRegeneration::executeCondition(Creature* creature, int32_t interva
 	internalHealthTicks += interval;
 	internalManaTicks += interval;
 
-	if (creature->getZone() != ZONE_PROTECTION) {
+	if ((creature->getZone() != ZONE_PROTECTION) || g_config.getBoolean(ConfigManager::ALLOW_PROTECTION_ZONE_REGENERATION)) {
 		if (internalHealthTicks >= healthTicks) {
 			internalHealthTicks = 0;
 

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -20,6 +20,7 @@
 #include "otpch.h"
 
 #include "condition.h"
+#include "configmanager.h"
 #include "game.h"
 
 extern Game g_game;

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -23,6 +23,7 @@
 #include "game.h"
 
 extern Game g_game;
+extern ConfigManager g_config;
 
 bool Condition::setParam(ConditionParam_t param, int32_t value)
 {

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -30,6 +30,7 @@
 #endif
 
 extern Game g_game;
+extern ConfigManager g_config;
 
 namespace {
 

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -30,7 +30,7 @@
 #endif
 
 extern Game g_game;
-extern ConfigManager g_config;
+
 
 namespace {
 

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -162,6 +162,7 @@ bool ConfigManager::load()
 	boolean[FORCE_MONSTERTYPE_LOAD] = getGlobalBoolean(L, "forceMonsterTypesOnLoad", true);
 	boolean[SERVER_SAVE_SHUTDOWN] = getGlobalBoolean(L, "serverSaveShutdown", true);
 	boolean[STOREMODULES] = getGlobalBoolean(L, "gamestoreByModules", true);
+	boolean[ALLOW_PROTECTION_ZONE_REGENERATION] = getGlobalBoolean(L, "allowProtectionZoneRegeneration", false);
 
 	string[DEFAULT_PRIORITY] = getGlobalString(L, "defaultPriority", "high");
 	string[SERVER_NAME] = getGlobalString(L, "serverName", "");

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -30,7 +30,7 @@
 #endif
 
 extern Game g_game;
-
+extern ConfigManager g_config;
 
 namespace {
 

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -52,6 +52,7 @@ class ConfigManager
 			FORCE_MONSTERTYPE_LOAD,
 			STOREMODULES,
 			ALLOW_BLOCK_SPAWN,
+			ALLOW_PROTECTION_ZONE_REGENERATION,
 
 			LAST_BOOLEAN_CONFIG /* this must be the last one */
 		};


### PR DESCRIPTION
This will allow food and item regeneration through config.lua.

true = enable
false = disable