### PR TITLE
Monster Improvement - Distance Target Choice

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -508,7 +508,7 @@ bool Monster::searchTarget(TargetSearchType_t searchType /*= TARGETSEARCH_DEFAUL
 
 				if (++it != resultList.end()) {
 					const Position& targetPosition = target->getPosition();
-					int32_t minRange = std::max<int32_t>(Position::getDistanceX(myPos, pos), Position::getDistanceY(myPos, pos));
+					int32_t minRange = std::max<int32_t>(Position::getDistanceX(myPos, targetPosition), Position::getDistanceY(myPos, targetPosition));
 					do {
 						const Position& pos = (*it)->getPosition();
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -508,11 +508,11 @@ bool Monster::searchTarget(TargetSearchType_t searchType /*= TARGETSEARCH_DEFAUL
 
 				if (++it != resultList.end()) {
 					const Position& targetPosition = target->getPosition();
-					int32_t minRange = Position::getDistanceX(myPos, targetPosition) + Position::getDistanceY(myPos, targetPosition);
+					int32_t minRange = std::max<int32_t>(Position::getDistanceX(myPos, pos), Position::getDistanceY(myPos, pos));
 					do {
 						const Position& pos = (*it)->getPosition();
 
-						int32_t distance = Position::getDistanceX(myPos, pos) + Position::getDistanceY(myPos, pos);
+						int32_t distance = std::max<int32_t>(Position::getDistanceX(myPos, pos), Position::getDistanceY(myPos, pos));
 						if (distance < minRange) {
 							target = *it;
 							minRange = distance;
@@ -527,7 +527,7 @@ bool Monster::searchTarget(TargetSearchType_t searchType /*= TARGETSEARCH_DEFAUL
 					}
 
 					const Position& pos = creature->getPosition();
-					int32_t distance = Position::getDistanceX(myPos, pos) + Position::getDistanceY(myPos, pos);
+					int32_t distance = std::max<int32_t>(Position::getDistanceX(myPos, pos), Position::getDistanceY(myPos, pos));
 					if (distance < minRange) {
 						target = creature;
 						minRange = distance;


### PR DESCRIPTION
This PR will improve the search of targets by monsters. Distance in 2d should be the [Chebyshev Distance](https://en.wikipedia.org/wiki/Chebyshev_distance) defined by dist(x1, y1, x2, y2) = max(dist(x1,x2), dist(y1,y2)) distance and not manhattan/taxicab one.

it is in fact just a PR to make the formula look as it was [before this commit from 2015](https://github.com/otland/forgottenserver/commit/bc83c4e5bed96eaeb027b9d2aca75403733a74e2)


Consequences: All monsters that attack from distance will be way more realistic as TARGET_NEAREST will choose who's really the closest target. For monsters that walk to target, since diagonal is just a sugarcoat for 2 walking movements (horizontal and vertical), in some specific situations they may prefer to walk 1 additional sqm to another target if they are in the same distance.

Previous function (the amount of coins shows the output of function accordingly to the distance)
by the image below you can notice a monster in my diagonal have way less chance to be prioritized even if it's closer than one in straight line.
![image](https://user-images.githubusercontent.com/8560144/81491868-7297e500-9269-11ea-85dc-5b8254b07eaa.png)
