### PR TITLE
Blocking corpses to be deleted upon push

### DIFF
--- a/src/item.h
+++ b/src/item.h
@@ -943,6 +943,9 @@ class Item : virtual public Thing
 		bool isMoveable() const {
 			return items[id].moveable;
 		}
+		bool isCorpse() const {
+			return items[id].corpseType != RACE_NONE;
+		}
 		bool isPickupable() const {
 			return items[id].pickupable;
 		}

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1071,7 +1071,7 @@ void Monster::pushItems(Tile* tile)
 					|| item->hasProperty(CONST_PROP_BLOCKSOLID))) {
 				if (moveCount < 20 && Monster::pushItem(item)) {
 					++moveCount;
-				} else if (g_game.internalRemoveItem(item) == RETURNVALUE_NOERROR) {
+				} else if (!item->isCorpse() && g_game.internalRemoveItem(item) == RETURNVALUE_NOERROR) {
 					++removeCount;
 				}
 			}
@@ -1121,7 +1121,7 @@ void Monster::pushCreatures(Tile* tile)
 				}
 
 				monster->changeHealth(-monster->getHealth());
-				monster->setDropLoot(false);
+				monster->setDropLoot(true);
 				removeCount++;
 			}
 


### PR DESCRIPTION
If a monster that can pushes tries to push a monster that can't push to a tile where there is no room, it deletes the monster completely.

With this change he will kill the creature and it will drop loot normally.
Fixes [#1918](https://github.com/otland/forgottenserver/issues/1918) from forgottenserver
