### PR TITLE
fixing race condition in outfit

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3899,11 +3899,11 @@ void Game::internalCreatureChangeOutfit(Creature* creature, const Outfit_t& outf
 		return;
 	}
 
-	creature->setCurrentOutfit(outfit);
-
 	if (creature->isInvisible()) {
 		return;
 	}
+	
+	creature->setCurrentOutfit(outfit);
 
 	//send to clients
 	SpectatorHashSet spectators;


### PR DESCRIPTION
condition invisible trigger a change in outfit (sparkles). They are linked in a way that you're not supposed to be invisible without the outfit. This PR is to guarantee you won't have any outfit change if you're invisible.