### PR TITLE
Fixing Sub type problems

### DIFF
--- a/data/lib/core/container.lua
+++ b/data/lib/core/container.lua
@@ -9,20 +9,26 @@ function Container.createLootItem(self, item)
 
 	local itemCount = 0
 	local randvalue = getLootRandom()
+	local lootBlockType = ItemType(item.itemId)
+	
 	if randvalue < item.chance then
-		if ItemType(item.itemId):isStackable() then
-			itemCount = randvalue % item.maxCount + 1
+		if lootBlockType:isStackable() then
+			local maxc, minc = item.maxCount or 1, item.minCount or 1
+			itemCount = math.max(0, randvalue % (maxc - minc + 1)) + minc			
 		else
 			itemCount = 1
 		end
 	end
-
-	if itemCount > 0 then
-		local tmpItem = self:addItem(item.itemId, math.min(itemCount, 100))
+	
+	while (itemCount > 0) do
+		local n = math.min(itemCount, 100)
+		itemCount = itemCount - n
+		
+		local tmpItem = self:addItem(item.itemId, n)
 		if not tmpItem then
 			return false
 		end
-
+	
 		if tmpItem:isContainer() then
 			for i = 1, #item.childLoot do
 				if not tmpItem:createLootItem(item.childLoot[i]) then
@@ -33,7 +39,9 @@ function Container.createLootItem(self, item)
 		end
 
 		if item.subType ~= -1 then
-			tmpItem:setAttribute(ITEM_ATTRIBUTE_CHARGES, item.subType)
+			tmpItem:transform(item.itemId, item.subType)
+		elseif lootBlockType:isFluidContainer() then
+			tmpItem:transform(item.itemId, 0)
 		end
 
 		if item.actionId ~= -1 then

--- a/data/lib/core/container.lua
+++ b/data/lib/core/container.lua
@@ -28,7 +28,7 @@ function Container.createLootItem(self, item)
 		if not tmpItem then
 			return false
 		end
-	
+
 		if tmpItem:isContainer() then
 			for i = 1, #item.childLoot do
 				if not tmpItem:createLootItem(item.childLoot[i]) then

--- a/data/npc/lib/npcsystem/modules.lua
+++ b/data/npc/lib/npcsystem/modules.lua
@@ -1117,6 +1117,8 @@ if Modules == nil then
 
 		if not isItemFluidContainer(itemid) then
 			subType = -1
+		elseif subType == 0 then 
+			subType = -1
 		end
 
 		if player:removeItem(itemid, amount, subType, ignoreEquipped) then


### PR DESCRIPTION
Before this PR:
- No support for item.minCount
- Any item that has more than 100 of count will be restricted for 100.
- Fluid container will always drop with water.
- Npcs won't buy any items with subtypes different from the specified. If none is specified it will only buy 'empty' and if you're trying to sell a golden mug with water it won't appear in the sell list.

After this PR:
- If you edit source and insert item.minCount the method will handle it. Check #1218 for how to implement it.
- Items don't need to be duplicated inside monsters.xml as now you can specify values bigger than 100
- Fluids container (such as golden mug of Dragon Lord) will always drop 'empty'
- Npcs that do not have specific subtypes to buy will buy ANY subtype