### PR TITLE
Support for countMin in loot

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -967,6 +967,7 @@ void LuaScriptInterface::pushLoot(lua_State* L, const std::vector<LootBlock>& lo
 		setField(L, "chance", lootBlock.chance);
 		setField(L, "subType", lootBlock.subType);
 		setField(L, "maxCount", lootBlock.countmax);
+		setField(L, "minCount", lootBlock.countmin);
 		setField(L, "actionId", lootBlock.actionId);
 		setField(L, "text", lootBlock.text);
 		pushBoolean(L, lootBlock.unique);
@@ -14387,6 +14388,7 @@ void LuaScriptInterface::parseLoot(lua_State* L, const std::vector<LootBlock>& l
 		setField(L, "chance", lootBlock.chance);
 		setField(L, "subType", lootBlock.subType);
 		setField(L, "maxCount", lootBlock.countmax);
+		setField(L, "minCount", lootBlock.countmin);
 		setField(L, "actionId", lootBlock.actionId);
 		setField(L, "text", lootBlock.text);
 		pushBoolean(L, lootBlock.unique);
@@ -14854,6 +14856,19 @@ int LuaScriptInterface::luaLootSetMaxCount(lua_State* L)
 	Loot* loot = getUserdata<Loot>(L, 1);
 	if (loot) {
 		loot->lootBlock.countmax = getNumber<uint32_t>(L, 2);
+		pushBoolean(L, true);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaLootSetMinCount(lua_State* L)
+{
+	// loot:setMinCount(min)
+	Loot* loot = getUserdata<Loot>(L, 1);
+	if (loot) {
+		loot->lootBlock.countmin = getNumber<uint32_t>(L, 2);
 		pushBoolean(L, true);
 	} else {
 		lua_pushnil(L);

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1387,6 +1387,7 @@ class LuaScriptInterface
 		static int luaDeleteLoot(lua_State* L);
 		static int luaLootSetId(lua_State* L);
 		static int luaLootSetMaxCount(lua_State* L);
+		static int luaLootSetMinCount(lua_State* L);
 		static int luaLootSetSubType(lua_State* L);
 		static int luaLootSetChance(lua_State* L);
 		static int luaLootSetActionId(lua_State* L);

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -1319,6 +1319,12 @@ bool Monsters::loadLootItem(const pugi::xml_node& node, LootBlock& lootBlock)
 	} else {
 		lootBlock.countmax = 1;
 	}
+	
+	if ((attr = node.attribute("countmin"))) {
+		lootBlock.countmin = std::max<int32_t>(1, pugi::cast<int32_t>(attr.value()));
+	} else {
+		lootBlock.countmin = 1;
+	}
 
 	if ((attr = node.attribute("chance")) || (attr = node.attribute("chance1"))) {
 		lootBlock.chance = std::min<int32_t>(MAX_LOOTCHANCE, pugi::cast<int32_t>(attr.value()));

--- a/src/monsters.h
+++ b/src/monsters.h
@@ -29,6 +29,7 @@ const uint32_t MAX_STATICWALK = 100;
 struct LootBlock {
 	uint16_t id;
 	uint32_t countmax;
+	uint32_t countmin;
 	uint32_t chance;
 
 	//optional
@@ -49,6 +50,7 @@ struct LootBlock {
 	LootBlock() {
 		id = 0;
 		countmax = 1;
+		countmin = 1;
 		chance = 0;
 
 		subType = -1;


### PR DESCRIPTION
This PR allows you to use countMin in the definition of a loot.

Now you can have countmin, countmax, both or neither.

After doing this commit please do also #1217 so you have countMin considered in the dropLoot function.