### PR TITLE
Fixing login/logout effects for gamemasters

### DIFF
--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -2744,8 +2744,8 @@ void ProtocolGame::sendAddCreature(const Creature* creature, const Position& pos
 		uint32_t removedKnown;
 		checkCreatureAsKnown(creature->getID(), known, removedKnown);
 		AddCreature(msg, creature, known, removedKnown);
-		writeToOutputBuffer(msg);		
-		
+		writeToOutputBuffer(msg);
+
 		if (isLogin) {
 			if (const Player* creaturePlayer = creature->getPlayer()) {
 				if (!creaturePlayer->isAccessPlayer() || !creaturePlayer->getAccountType() >= ACCOUNT_TYPE_NORMAL)

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -238,7 +238,7 @@ void ProtocolGame::logout(bool displayEffect, bool forced)
 			}
 		}
 
-		if (displayEffect && player->getHealth() > 0) {
+		if (displayEffect && player->getHealth() > 0 && !player->isInGhostMode()) {
 			g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
 		}
 	}
@@ -2744,10 +2744,15 @@ void ProtocolGame::sendAddCreature(const Creature* creature, const Position& pos
 		uint32_t removedKnown;
 		checkCreatureAsKnown(creature->getID(), known, removedKnown);
 		AddCreature(msg, creature, known, removedKnown);
-		writeToOutputBuffer(msg);
-
+		writeToOutputBuffer(msg);		
+		
 		if (isLogin) {
-			sendMagicEffect(pos, CONST_ME_TELEPORT);
+			if (const Player* creaturePlayer = creature->getPlayer()) {
+				if (!creaturePlayer->isAccessPlayer() || !creaturePlayer->getAccountType() >= ACCOUNT_TYPE_NORMAL)
+					sendMagicEffect(pos, CONST_ME_TELEPORT);
+			} else {
+				sendMagicEffect(pos, CONST_ME_TELEPORT);
+			}
 		}
 
 		return;


### PR DESCRIPTION
Before this PR:
- If you logout in ghost mode everyone sees the poff effect.
- If you login in ghost mode everyone sees the teleport effect.

After this PR:
- If you logout in ghost mode you don't send poff effect
- If you have access or is from an account with access you don't send teleport effect at all (even outside ghost mode*)

*I needed to do it like this because when you are executing 'sendAddCreature' the isInGhostMode() always return false for some reason.

Fix #1091