### PR TITLE
Change of Npc Hugo dialogue

### DIFF
--- a/data/npc/scripts/hugo.lua
+++ b/data/npc/scripts/hugo.lua
@@ -16,7 +16,7 @@ function onThink()
 end
 
 local config = {
-	['brown piece of cloth'] = {
+	['20 brown pieces of cloth'] = {
 		itemId = 5913,
 		count = 20,
 		value = 1,
@@ -27,7 +27,7 @@ local config = {
 			success = 'Yes, yes, that\'s it! Very well, now I need 50 pieces of minotaur leather to continue.'
 		}
 	},
-	['minotaur leather'] = {
+	['50 minotaur leathers'] = {
 		itemId = 5878,
 		count = 50,
 		value = 2,
@@ -38,7 +38,7 @@ local config = {
 			success = 'Great! This leather will suffice. Now, please, the 10 bat wings.'
 		}
 	},
-	['bat wings'] = {
+	['10 bat wings'] = {
 		itemId = 5894,
 		count = 10,
 		value = 3,
@@ -49,7 +49,7 @@ local config = {
 			success = 'Hooray! These bat wings are ugly enough. Now the last thing: Please bring me 30 heaven blossoms to neutralise the ghoulish stench.'
 		}
 	},
-	['heaven blossom'] = {
+	['30 heaven blossoms'] = {
 		itemId = 5921,
 		count = 30,
 		value = 4,


### PR DESCRIPTION
Bem, o dialogo anterior não seguia o apresentado na tibiawiki e isso prejudicava de certa forma os jogadores do servidor a concluir a missão, uma vez que a maioria deles utilizam a tibiawiki como spoiler de quest.

as mudanças foram testadas em jogo e não apresentaram nenhum tipo de problema.