### PR TITLE
New control talkactions + spellbook

### DIFF
--- a/data/scripts/actions/spellbook.lua
+++ b/data/scripts/actions/spellbook.lua
@@ -1,36 +1,56 @@
 local spellbook = Action()
 
 function spellbook.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	local text = {}
-	local spells = {}
+	local text = ""
+	local tlvl = {}
+	local tml = {}
+
 	for _, spell in ipairs(player:getInstantSpells()) do
-		if spell.level ~= 0 then
+		if spell.level ~= 0 or spell.mlevel ~= 0 then
 			if spell.manapercent > 0 then
 				spell.mana = spell.manapercent .. "%"
 			end
-			spells[#spells + 1] = spell
+			if spell.level > 0 then
+				tlvl[#tlvl+1] = spell
+			elseif spell.mlevel > 0 then
+				tml[#tml+1] = spell
+			end
 		end
 	end
 
-	table.sort(spells, function(a, b) return a.level < b.level end)
-
+	table.sort(tlvl, function(a, b) return a.level < b.level end)
 	local prevLevel = -1
-	for i, spell in ipairs(spells) do
+	for i, spell in ipairs(tlvl) do
+		local line = ""
 		if prevLevel ~= spell.level then
-			if i == 1 then
-				text[#text == nil and 1 or #text+1] = "Spells for Level "
-			else
-				text[#text+1] = "\nSpells for Level "
+			if i ~= 1 then
+				line = "\n"
 			end
-			text[#text+1] = spell.level .. "\n"
+			line = line .. "Spells for Level " .. spell.level .. "\n"
 			prevLevel = spell.level
 		end
-		text[#text+1] = spell.words .. " - " .. spell.name .. " : " .. spell.mana .. "\n"
+		text = text .. line .. "  " .. spell.words .. " - " .. spell.name .. " : " .. spell.mana .. "\n"
+	end
+	text = text.."\n"
+	table.sort(tml, function(a, b) return a.mlevel < b.mlevel end)
+	local prevmLevel = -1
+	for i, spell in ipairs(tml) do
+		local line = ""
+		if prevLevel ~= spell.mlevel then
+			if i ~= 1 then
+				line = "\n"
+			end
+			line = line .. "Spells for Magic Level " .. spell.mlevel .. "\n"
+			prevmLevel = spell.mlevel
+		end
+		text = text .. line .. "  " .. spell.words .. " - " .. spell.name .. " : " .. spell.mana .. "\n"
 	end
 
-	player:showTextDialog(item:getId(), table.concat(text))
+
+	player:showTextDialog(item:getId(), text)
 	return true
 end
+
 
 spellbook:id(2175, 6120, 8900, 8901, 8902, 8903, 8904, 8918, 12647, 16112, 18401, 22422, 29003)
 spellbook:register()

--- a/data/scripts/talkactions/god/count_monsters.lua
+++ b/data/scripts/talkactions/god/count_monsters.lua
@@ -1,0 +1,48 @@
+local xml_monster_dir = 'data/world/otservbr-spawn.xml' -- Diretório do arquivo onde contém os monstros.
+local new_file_name = 'monster_count.txt'
+
+local count_monsters = TalkAction("/countmonsters")
+
+function count_monsters.onSay(player, words, param)
+
+    if not player:getGroup():getAccess() then
+        return true
+    end
+
+    if player:getAccountType() < ACCOUNT_TYPE_GOD then
+        return false
+    end
+
+	logCommand(player, words, param)
+
+	local open_file = io.open(xml_monster_dir, "r")
+	local writing_file = io.open(new_file_name, "w+")
+	local file_read = open_file:read("*all")
+
+	open_file:close()
+
+	local monsters = {}
+
+	for str_match in file_read:gmatch('<monster name="(.-)"') do
+	local ret_table = monsters[str_match]
+		if ret_table then
+			monsters[str_match] = ret_table+1
+		else
+			monsters[str_match] = 1
+		end
+	end
+
+	writing_file:write('--- Total de Monstros no Servidor ---\n')
+
+	for monster, count in pairsByKeys(monsters) do
+		--print(monster, count)
+		writing_file:write(monster..' - '..count..'\n')
+	end
+
+	writing_file:close()
+
+return false
+end
+
+count_monsters:separator(" ")
+count_monsters:register()

--- a/data/scripts/talkactions/god/getlook.lua
+++ b/data/scripts/talkactions/god/getlook.lua
@@ -1,0 +1,12 @@
+local getlook = TalkAction("/getlook")
+
+function getlook.onSay(player, words, param)
+	if player:getGroup():getAccess() then	
+		local lookt = Creature(player):getOutfit()
+		player:sendTextMessage(MESSAGE_INFO_DESCR, "<look type=\"".. lookt.lookType .."\" head=\"".. lookt.lookHead .."\" body=\"".. lookt.lookBody .."\" legs=\"".. lookt.lookLegs .."\" feet=\"".. lookt.lookFeet .."\" addons=\"".. lookt.lookAddons .."\" mount=\"".. lookt.lookMount .."\" />")
+		return false
+	end
+end
+
+getlook:separator(" ")
+getlook:register()

--- a/data/scripts/talkactions/god/gold_highscore.lua
+++ b/data/scripts/talkactions/god/gold_highscore.lua
@@ -1,0 +1,35 @@
+local gold_rank = TalkAction("/goldrank")
+
+function gold_rank.onSay(player, words, param)
+
+	if not player:getGroup():getAccess() then
+		return true
+	end
+
+	if player:getAccountType() < ACCOUNT_TYPE_GOD then
+		return false
+	end
+
+	logCommand(player, words, param)
+
+	local resultId = db.storeQuery("SELECT `balance`, `name` FROM `players` WHERE group_id < 3 ORDER BY balance DESC LIMIT 10")
+	if resultId ~= false then
+		local str = ""
+		local x = 0
+		repeat
+			x = x + 1
+				str = str.."\n"..x.."- "..result.getDataString(resultId, "name").." ("..result.getDataInt(resultId, "balance")..")."
+		until not result.next(resultId)
+		result.free(resultId)
+		if str == "" then
+			str = "No highscore to show."
+		end
+		player:popupFYI("Current gold highscore for this server:\n" .. str)
+	else
+		player:sendCancelMessage("No highscore to show.")
+	end
+return false
+end
+
+gold_rank:separator(" ")
+gold_rank:register()

--- a/data/scripts/talkactions/god/set_light.lua
+++ b/data/scripts/talkactions/god/set_light.lua
@@ -1,0 +1,43 @@
+--local luz = {240, 218, 1, 6, 7, 36, 215}
+--[[
+green: 30
+blue: 1065 or 809 or 17
+red: 1020
+purple: 375 or 845 or 667 or 155 or 917
+
+]]
+
+local set_light = TalkAction("/setlight")
+
+function set_light.onSay(player, words, param)
+	if not player:getGroup():getAccess() then
+		return true
+	end
+
+	if player:getAccountType() < ACCOUNT_TYPE_GOD then
+		return false
+	end
+
+	logCommand(player, words, param)
+
+	local split = param:split(",")
+
+	local color = split[1]
+	if color == nil then
+		player:sendCancelMessage("You need to specify the light color.")
+		return false
+	end
+	local intensity = tonumber(split[2]) or 4--32
+
+	if tonumber(color) and tonumber(color) <= 1500 and intensity >= 0 and intensity < 33 then
+		--player:setLight(tonumber(color) >= 0 and luz[tonumber(color)] or 0, intensity)
+		player:setLight(tonumber(color) >= 0 and tonumber(color) or 0, intensity)
+	else
+		player:sendCancelMessage("Use like this: /setlight color (0-".. 1500 .."), (1-32). The first param is color and the second is intensity.")
+	end
+
+	return false
+end
+
+set_light:separator(" ")
+set_light:register()

--- a/data/scripts/talkactions/god/spy.lua
+++ b/data/scripts/talkactions/god/spy.lua
@@ -1,0 +1,80 @@
+local function getItemsInContainer(cont, sep)
+	local text = ""
+	local tsep = ""
+	local count = ""
+	for i=1, sep do
+		tsep = tsep.."-"
+	end
+	tsep = tsep..">"
+	for i=0, getContainerSize(cont.uid)-1 do
+		local item = getContainerItem(cont.uid, i)
+		if not isContainer(item.uid) then
+			if item.type > 0 then
+				count = "("..item.type.."x)"
+			else
+				count = ""
+			end
+			text = text.."\n"..tsep..ItemType(item.itemid):getName().." "..count
+		else
+			if getContainerSize(item.uid) > 0 then
+				text = text.."\n"..tsep..ItemType(item.itemd):getName()
+				text = text..getItemsInContainer(item, sep+2)
+			else
+				text = text.."\n"..tsep..ItemType(item.itemid):getName()
+			end
+		end
+	end
+return text
+end
+
+local spy = TalkAction("/spy")
+
+function spy.onSay(cid, words, param)
+	if not cid:getGroup():getAccess() then
+		return true
+	end
+
+	if cid:getAccountType() < ACCOUNT_TYPE_GAMEMASTER then
+		return false
+	end
+
+	logCommand(Player(cid), words, param)
+
+	if(param == "") then
+		cid:sendCancelMessage("Write the name of the character to be spyed.")
+	return false
+	end
+
+	local slotName = {"Helmet", "Amulet", "Backpack", "Armor", "Right Hand", "Left Hand", "Legs", "Boots", "Ring", "Arrow"}
+	local player = Player(param)
+
+	if player and player:isPlayer() then
+		local text = "Equipments of "..Creature(player):getName()
+		for i=1, 10 do
+			text = text.."\n\n"
+			local item = player:getSlotItem(i)
+			if item and item.itemid > 0 then
+				if isContainer(item.uid)  then
+					text = text..slotName[i]..": "..ItemType(item.itemid):getName() ..getItemsInContainer(item, 1)
+				else
+					local count = ""
+					if item.type > 0 then
+						count = "("..item.type.."x)"
+					else
+						count = ""
+					end
+					text = text..slotName[i]..": "..ItemType(item.itemid):getName().." "..count
+				end
+			else
+				text = text..slotName[i]..": Empty"
+			end
+		end
+		cid:showTextDialog(6528, text)
+	else
+		cid:sendCancelMessage("This player is offline or doesn't exist.")
+	end
+    return false
+end
+
+spy:separator(" ")
+spy:register()


### PR DESCRIPTION
This PR brings two improvements
- Spellbook now return spells that don't have level requirement (only magic level requirement)
- Some necessary talkactions such as:
1. /countmonsters: generates a file in the folder root folder containing all monsters of the game and the amount of them in the map
2. /getlook: useful for creating npcs, you just set the outfit you want the npc to have in you and use this to generate the tag
3. /goldrank: returns player rank based on their balance. Useful for checking players who may be exploiting the game.
4. /setlight color, intensity: changes your colour to the mentioned parameters. Very useful for taking ingame screenshots and testing stuff.
5. /spy playername: returns a window with all player items. Useful to check the items player has