### PR TITLE
Monster strategies

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1284,7 +1284,7 @@ bool Monster::getDanceStep(const Position& creaturePos, Direction& moveDirection
 	uint32_t centerToDist = std::max<uint32_t>(distance_x, distance_y);
 	
 	//monsters not at targetDistance shouldn't dancestep
-	if (centerToDist < mType->info.targetDistance) {
+	if (centerToDist < (uint32_t) mType->info.targetDistance) {
 		return false;
 	}
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -488,20 +488,46 @@ void Monster::onCreatureLeave(Creature* creature)
 
 bool Monster::searchTarget(TargetSearchType_t searchType /*= TARGETSEARCH_DEFAULT*/)
 {
+	if (searchType == TARGETSEARCH_DEFAULT) {
+		int32_t rnd = uniform_random(1, 100);
+		
+		searchType = TARGETSEARCH_NEAREST;
+		
+		int32_t sum = this->mType->info.targetStrategiesNearestPercent;
+		if (rnd > sum) {
+			searchType = TARGETSEARCH_HP;
+			sum += this->mType->info.targetStrategiesLowerHPPercent;
+
+			if (rnd > sum) {
+				searchType = TARGETSEARCH_DAMAGE;
+				sum += this->mType->info.targetStrategiesMostDamagePercent;
+				if (rnd > sum) {
+					searchType = TARGETSEARCH_RANDOM;
+				}
+			}
+		}
+	}
+	
 	std::list<Creature*> resultList;
 	const Position& myPos = getPosition();
 
 	for (Creature* creature : targetList) {
-		if (followCreature != creature && isTarget(creature)) {
-			if (searchType == TARGETSEARCH_RANDOM || canUseAttack(myPos, creature)) {
+		if (isTarget(creature)) {
+			if ((this->mType->info.targetDistance == 1) || canUseAttack(myPos, creature)) {
 				resultList.push_back(creature);
 			}
 		}
 	}
-
+	
+	if (resultList.empty()) {
+		return false;
+	}
+	
+	Creature* target = nullptr;
+	
 	switch (searchType) {
 		case TARGETSEARCH_NEAREST: {
-			Creature* target = nullptr;
+			target = nullptr;
 			if (!resultList.empty()) {
 				auto it = resultList.begin();
 				target = *it;
@@ -539,10 +565,51 @@ bool Monster::searchTarget(TargetSearchType_t searchType /*= TARGETSEARCH_DEFAUL
 				return true;
 			}
 			break;
-		}
+		}		
+		case TARGETSEARCH_HP: {
+			target = nullptr;
+			if (!resultList.empty()) {
+				auto it = resultList.begin();
+				target = *it;
+				if (++it != resultList.end()) {
+					int32_t minHp = target->getHealth();
+					do {
+						if ((*it)->getHealth() < minHp) {
+							target = *it;
 
-		case TARGETSEARCH_DEFAULT:
-		case TARGETSEARCH_ATTACKRANGE:
+							minHp = target->getHealth();
+						}
+					} while (++it != resultList.end());
+				}
+			}
+			if (target && selectTarget(target)) {
+				return true;
+			}
+			break;
+		}
+		case TARGETSEARCH_DAMAGE: {
+			target = nullptr;
+			if (!resultList.empty()) {
+				auto it = resultList.begin();
+				target = *it;
+				if (++it != resultList.end()) {
+					int32_t mostDamage = 0;
+					do {
+						const auto& dmg = damageMap.find((*it)->getID());
+						if (dmg != damageMap.end()) {
+							if (dmg->second.total > mostDamage) {
+								mostDamage = dmg->second.total;
+								target = *it;
+							}
+						}
+					} while (++it != resultList.end());
+				}
+			}
+			if (target && selectTarget(target)) {
+				return true;
+			}
+			break;
+		}
 		case TARGETSEARCH_RANDOM:
 		default: {
 			if (!resultList.empty()) {
@@ -550,18 +617,13 @@ bool Monster::searchTarget(TargetSearchType_t searchType /*= TARGETSEARCH_DEFAUL
 				std::advance(it, uniform_random(0, resultList.size() - 1));
 				return selectTarget(*it);
 			}
-
-			if (searchType == TARGETSEARCH_ATTACKRANGE) {
-				return false;
-			}
-
 			break;
 		}
 	}
 
 	//lets just pick the first target in the list
 	for (Creature* target : targetList) {
-		if (followCreature != target && selectTarget(target)) {
+		if (selectTarget(target)) {
 			return true;
 		}
 	}
@@ -757,10 +819,10 @@ void Monster::onThink(uint32_t interval)
 				}
 			} else if (!targetList.empty()) {
 				if (!followCreature || !hasFollowPath) {
-					searchTarget();
+					searchTarget(TARGETSEARCH_NEAREST);
 				} else if (isFleeing()) {
 					if (attackedCreature && !canUseAttack(getPosition(), attackedCreature)) {
-						searchTarget(TARGETSEARCH_ATTACKRANGE);
+						searchTarget(TARGETSEARCH_DEFAULT);
 					}
 				}
 			}
@@ -790,6 +852,10 @@ void Monster::doAttacking(uint32_t interval)
 
 		if (attackedCreature == nullptr) {
 			break;
+		}
+		
+		if(it->isMelee && isFleeing()){
+			continue;
 		}
 
 		if (canUseSpell(myPos, targetPos, spellBlock, interval, inRange, resetTicks)) {
@@ -917,11 +983,7 @@ void Monster::onThinkTarget(uint32_t interval)
 					}
 
 					if (mType->info.changeTargetChance >= uniform_random(1, 100)) {
-						if (mType->info.targetDistance <= 1) {
-							searchTarget(TARGETSEARCH_RANDOM);
-						} else {
-							searchTarget(TARGETSEARCH_NEAREST);
-						}
+						searchTarget(TARGETSEARCH_DEFAULT);
 					}
 				}
 			}
@@ -1220,6 +1282,11 @@ bool Monster::getDanceStep(const Position& creaturePos, Direction& moveDirection
 	int_fast32_t distance_y = std::abs(offset_y);
 
 	uint32_t centerToDist = std::max<uint32_t>(distance_x, distance_y);
+	
+	//monsters not at targetDistance shouldn't dancestep
+	if (centerToDist < mType->info.targetDistance) {
+		return false;
+	}
 
 	std::vector<Direction> dirList;
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -854,7 +854,7 @@ void Monster::doAttacking(uint32_t interval)
 			break;
 		}
 		
-		if(it->isMelee && isFleeing()){
+		if(spellBlock.isMelee && isFleeing()){
 			continue;
 		}
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -32,9 +32,10 @@ using CreatureList = std::list<Creature*>;
 
 enum TargetSearchType_t {
 	TARGETSEARCH_DEFAULT,
-	TARGETSEARCH_RANDOM,
-	TARGETSEARCH_ATTACKRANGE,
 	TARGETSEARCH_NEAREST,
+	TARGETSEARCH_HP,
+	TARGETSEARCH_DAMAGE,
+	TARGETSEARCH_RANDOM
 };
 
 class Monster final : public Creature

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -943,6 +943,32 @@ MonsterType* Monsters::loadMonster(const std::string& file, const std::string& m
 			std::cout << "[Warning - Monsters::loadMonster] Missing targetchange chance. " << file << std::endl;
 		}
 	}
+	
+	if ((node = monsterNode.child("targetstrategies"))) {
+		if ((attr = node.attribute("nearest"))) {
+			mType->info.targetStrategiesNearestPercent = pugi::cast<int32_t>(attr.value());
+		} else {
+			std::cout << "[Warning - Monsters::loadMonster] Missing targetStrategiesNearestPercent. " << file << std::endl;
+		}
+
+		if ((attr = node.attribute("health"))) {
+			mType->info.targetStrategiesLowerHPPercent = pugi::cast<int32_t>(attr.value());
+		} else {
+			std::cout << "[Warning - Monsters::loadMonster] Missing targetStrategiesLowerHPPercent. " << file << std::endl;
+		}
+
+		if ((attr = node.attribute("damage"))) {
+			mType->info.targetStrategiesMostDamagePercent = pugi::cast<int32_t>(attr.value());
+		} else {
+			std::cout << "[Warning - Monsters::loadMonster] Missing targetStrategiesMostDamagePercent. " << file << std::endl;
+		}
+
+		if ((attr = node.attribute("random"))) {
+			mType->info.targetStrategiesRandom = pugi::cast<int32_t>(attr.value());
+		} else {
+			std::cout << "[Warning - Monsters::loadMonster] Missing targetStrategiesRandom. " << file << std::endl;
+		}
+	}
 
 	if ((node = monsterNode.child("look"))) {
 		if ((attr = node.attribute("type"))) {

--- a/src/monsters.h
+++ b/src/monsters.h
@@ -162,6 +162,10 @@ class MonsterType
 		int32_t changeTargetChance = 0;
 		int32_t defense = 0;
 		int32_t armor = 0;
+		int32_t targetStrategiesNearestPercent = 0;
+		int32_t targetStrategiesLowerHPPercent = 0;
+		int32_t targetStrategiesMostDamagePercent = 0;
+		int32_t targetStrategiesRandom = 0;
 
 		bool canPushItems = false;
 		bool canPushCreatures = false;


### PR DESCRIPTION
This PR includes all the commits below from OTHire but translated to TFS/OTX format:
- https://github.com/TwistedScorpio/OTHire/commit/8e567570eec5a2d4570a376bb7431ee280d36513
- https://github.com/TwistedScorpio/OTHire/commit/6a0528647d15ad883720015f9d22648150316e00
- https://github.com/TwistedScorpio/OTHire/commit/f8b96488a40f3f51c994f5f654a06b1fe4ad3998
- https://github.com/TwistedScorpio/OTHire/commit/7ebb966c60eaf09b97329886bdd98d16efd13ec1

Has a strong dependency on #1213 and small dependency on #1198

Improvements:
- With this ranged monsters will only dancestep when they reach ideal distance (usually 4).
- ranged monsters will change target correctly now (NEEDS #1198)  (always picking the
closest one), also all monsters have correct chance to change target and
strategies as they work in real tibia, they can pick the nearest target,
the one with the lowest % health, the one that did the most damage and
also a random one.
- Fleeing monsters don't melee attack
- With this ranged monsters will only dancestep when they reach ideal distance (usually 4).