### PR TITLE
Show clientId in look

### DIFF
--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -179,6 +179,12 @@ function Player:onLook(thing, position, distance)
 			if decayId ~= -1 then
 				description = string.format("%s\nDecays to: %d", description, decayId)
 			end
+			
+			local clientId = itemType:getClientId()
+			if clientId then
+				description = string.format("%s\nClient ID: %d", description, clientId)
+			end
+			
 		elseif thing:isCreature() then
 			local str = "%s\nHealth: %d / %d"
 			if thing:isPlayer() and thing:getMaxMana() > 0 then


### PR DESCRIPTION
This PR will enable clientId for items in look if you are in a group with access.