### PR TITLE
Fixing decay issues (infinite duration)

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4781,7 +4781,7 @@ void Game::checkDecay()
 	auto it = decayItems[bucket].begin(), end = decayItems[bucket].end();
 	while (it != end) {
 		Item* item = *it;
-		if (!item->canDecay()) {
+		if (!item->canDecay() || item->getDecaying() == DECAYING_FALSE) {
 			item->setDecaying(DECAYING_FALSE);
 			ReleaseItem(item);
 			it = decayItems[bucket].erase(it);

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -644,6 +644,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 				DepotChest* depotChest = player->getDepotChest(pid, true);
 				if (depotChest) {
 					depotChest->internalAddThing(item);
+					item->startDecaying();
 				}
 			} else {
 				ItemMap::const_iterator it2 = itemMap.find(pid);
@@ -654,6 +655,7 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 				Container* container = it2->second.first->getContainer();
 				if (container) {
 					container->internalAddThing(item);
+					item->startDecaying();
 				}
 			}
 		}
@@ -696,6 +698,12 @@ bool IOLoginData::loadPlayer(Player* player, DBResult_ptr result)
 			}
 
 			ItemMap::const_iterator it2 = itemMap.find(pid);
+			
+			for (const auto& it : player->depotLockerMap) {
+				it.second->setParent(VirtualCylinder::virtualCylinder);
+				it.second->startDecaying();
+			}
+			
 			if (it2 == itemMap.end()) {
 				continue;
 			}


### PR DESCRIPTION
Before this PR you may find two issues:
Issue 1:  setting decay state to false doesn't work. Check issue [#2182](https://github.com/otland/forgottenserver/issues/2182) from tfs

Issue 2: items with decay (like magic light wand) put into depot can be turn into infinite.
All you need to do is turn it on, put it inside depot and relog. When you enter again and pick the item the decay will be frozen.