### PR TITLE
[WIP] Improvement - Creature Reload

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2391,6 +2391,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Creature", "remove", LuaScriptInterface::luaCreatureRemove);
 	registerMethod("Creature", "teleportTo", LuaScriptInterface::luaCreatureTeleportTo);
 	registerMethod("Creature", "say", LuaScriptInterface::luaCreatureSay);
+	registerMethod("Creature", "reload", LuaScriptInterface::luaCreatureReload);
 
 	registerMethod("Creature", "getDamageMap", LuaScriptInterface::luaCreatureGetDamageMap);
 
@@ -8212,6 +8213,28 @@ int LuaScriptInterface::luaCreatureTeleportTo(lua_State* L)
 		}
 	}
 	pushBoolean(L, true);
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureReload(lua_State* L)
+{
+	// creature:reload()
+	Creature* creature = getUserdata<Creature>(L, 1);
+	if (!creature) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	const Position& position = creature->getPosition();
+	SpectatorHashSet spectators;
+	g_game.map.getSpectators(spectators, position, false, true); // 3 parameter is multifloor, check if there's need.
+	for (Creature* spectator : spectators) {
+		Player* tmpPlayer = spectator->getPlayer();
+		if (tmpPlayer) {
+			tmpPlayer->reloadCreature(creature, "");
+		}
+	}
+
 	return 1;
 }
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -825,6 +825,7 @@ class LuaScriptInterface
 		static int luaCreatureRemove(lua_State* L);
 		static int luaCreatureTeleportTo(lua_State* L);
 		static int luaCreatureSay(lua_State* L);
+		static int luaCreatureReload(lua_State* L);
 
 		static int luaCreatureGetDamageMap(lua_State* L);
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -77,6 +77,13 @@ class Monster final : public Creature
 		std::string getDescription(int32_t) const override {
 			return strDescription + '.';
 		}
+		
+		const std::string getNewName() const {
+			return newName;
+		}
+		void setNewName(std::string new_name) {
+			newName = new_name;
+		}
 
 		CreatureType_t getType() const override {
 			return CREATURETYPE_MONSTER;
@@ -205,7 +212,8 @@ class Monster final : public Creature
 
 		MonsterType* mType;
 		Spawn* spawn = nullptr;
-
+		
+		std::string newName = "";
 		int64_t lastMeleeAttack = 0;
 
 		uint32_t attackTicks = 0;

--- a/src/player.h
+++ b/src/player.h
@@ -1272,6 +1272,12 @@ class Player final : public Creature, public Cylinder
 				client->sendOpenStore(serviceType);
 			}
 		}
+		
+		void reloadCreature(const Creature* creature, std::string name) {
+			if (client) {
+				client->reloadCreature(creature, name);
+			}
+		}
 
 		void receivePing() {
 			lastPong = OTSYS_TIME();

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3407,7 +3407,7 @@ void ProtocolGame::sendModalWindow(const ModalWindow& modalWindow)
 }
 
 ////////////// Add common messages
-void ProtocolGame::AddCreature(NetworkMessage& msg, const Creature* creature, bool known, uint32_t remove)
+void ProtocolGame::AddCreature(NetworkMessage& msg, const Creature* creature, bool known, uint32_t remove, std::string newName/* = ""*/)
 {
 	CreatureType_t creatureType = creature->getType();
 	const Player* otherPlayer = creature->getPlayer();

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -289,7 +289,7 @@ class ProtocolGame final : public Protocol
 		void sendRemoveTileThing(const Position& pos, uint32_t stackpos);
 		void sendUpdateTile(const Tile* tile, const Position& pos);
 
-		void sendAddCreature(const Creature* creature, const Position& pos, int32_t stackpos, bool isLogin);
+		void sendAddCreature(const Creature* creature, const Position& pos, int32_t stackpos, bool isLogin, std::string newName = "");
 		void sendMoveCreature(const Creature* creature, const Position& newPos, int32_t newStackPos,
 							  const Position& oldPos, int32_t oldStackPos, bool teleport);
 
@@ -327,7 +327,7 @@ class ProtocolGame final : public Protocol
 		void GetMapDescription(int32_t x, int32_t y, int32_t z,
 		                       int32_t width, int32_t height, NetworkMessage& msg);
 
-		void AddCreature(NetworkMessage& msg, const Creature* creature, bool known, uint32_t remove);
+		void AddCreature(NetworkMessage& msg, const Creature* creature, bool known, uint32_t remove, std::string newName = "");
 		void AddPlayerStats(NetworkMessage& msg);
 		void AddOutfit(NetworkMessage& msg, const Outfit_t& outfit);
 		void AddPlayerSkills(NetworkMessage& msg);
@@ -347,6 +347,9 @@ class ProtocolGame final : public Protocol
 
 		//otclient
 		void parseExtendedOpcode(NetworkMessage& msg);
+		
+		//custom
+		void reloadCreature(const Creature* creature, const std::string newName);
 
 		friend class Player;
 


### PR DESCRIPTION
This PR will allow to you quickly reload creatures to all players that is inside the spectator list. Useful to avoid having to create creatures far away for updating their hp, flags, emblems, skull, etc.

Conflicts with #1252 