### PR TITLE
Resolves #1253: add lastday to the account table when purchasing premium in store

### DIFF
--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -1087,7 +1087,7 @@ function GameStore.processAllBlessingsPurchase(player)
 end
 
 function GameStore.processPremiumPurchase(player, offerId)
-	db.query(string.format("UPDATE `accounts` SET `lastday` = ".. os.time() .." WHERE `id` = " .. player:getAccountId()))
+	db.query("UPDATE `accounts` SET `lastday` = ".. os.time() .." WHERE `id` = " .. player:getAccountId())
 	player:addPremiumDays(offerId-3000)
 
 	-- Update Prey Data

--- a/data/modules/scripts/gamestore/init.lua
+++ b/data/modules/scripts/gamestore/init.lua
@@ -1087,6 +1087,7 @@ function GameStore.processAllBlessingsPurchase(player)
 end
 
 function GameStore.processPremiumPurchase(player, offerId)
+	db.query(string.format("UPDATE `accounts` SET `lastday` = ".. os.time() .." WHERE `id` = " .. player:getAccountId()))
 	player:addPremiumDays(offerId-3000)
 
 	-- Update Prey Data


### PR DESCRIPTION
Fixed the lastday update in the accounts table after buying a premium in the store.

![image](https://user-images.githubusercontent.com/8551443/83492033-0fc0f480-a489-11ea-9b9f-25fc813d5870.png)
![image](https://user-images.githubusercontent.com/8551443/83492106-28c9a580-a489-11ea-8875-34434f57445b.png)

Thanks @Heitortadeu for the report and tips on how to fix
