### PR TITLE
Possible fix for the bug in the imbuement (#1281)

### DIFF
--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -506,6 +506,7 @@ function Player:onMoveItem(item, count, fromPosition, toPosition, fromCylinder, 
 		return false
 	end
 
+	self:closeImbuementWindow()
 	return true
 end
 

--- a/data/scripts/lib/defaults_move_event.lua
+++ b/data/scripts/lib/defaults_move_event.lua
@@ -17,6 +17,7 @@ function defaultRemoveItem(moveitem, tileitem, pos)
 end
 
 function defaultEquip(player, item, slot, isCheck)
+    self:closeImbuementWindow()
 	return true
 end
 


### PR DESCRIPTION
It needs to be tested, but the logic applies. If you move an item with the imbuement window open, it will be closed 

As it is already here (for do not crashes on the trade): https://github.com/opentibiabr/otservbr-global/blob/3fdc41f2e24ae3b0fa8505bff078aba0d7b87332/data/events/scripts/player.lua#L614
