### PR TITLE
Fix Quest Reward (Mintwallin Cyclops and Mad Mage Room)

### DIFF
--- a/data/actions/scripts/system/quest_system2.lua
+++ b/data/actions/scripts/system/quest_system2.lua
@@ -363,6 +363,18 @@ local config = {
 		},
 		storage = 857448
 	},
+	[65211] = {
+		items = {
+			{itemId = 2145, count = 1}
+		},
+		storage = 857449
+	},
+	[65212] = {
+		items = {
+			{itemId = 2088, actionId = 3667}
+		},
+		storage = 857450
+	},
 	-- 65203 reservado
 }
 


### PR DESCRIPTION
Fix Mintwallin Cyclops Quest Reward (new it's possible to get small diamond and daily respawn itens)
Fix Mad Mage Room Quest Reward (now it's possible to get  Key 3667)