### PR TITLE
Fix memory leak, fix build on Ubuntu 20.04 and Debian 10 and update GHA checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,6 +17,11 @@ indent_size = 4
 indent_style = space
 indent_size = 2
 
+#cmake
+[CMakeLists.txt]
+indent_style = space
+indent_size = 2
+
 # Google Style
 [*.{cpp,hpp,h}]
 indent_style = space

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Get file changes
       id: get_file_changes
-      uses: trilom/file-changes-action@v1.2.3
+      uses: trilom/file-changes-action@master
       with:
         githubToken: ${{ secrets.GITHUB_TOKEN }}
         output: ' '

--- a/.github/workflows/lua-linter.yml
+++ b/.github/workflows/lua-linter.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Get file changes
       id: get_file_changes
-      uses: trilom/file-changes-action@v1.2.3
+      uses: trilom/file-changes-action@master
       with:
         githubToken: ${{ secrets.GITHUB_TOKEN }}
         output: ' '

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,14 +159,22 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   set(CMAKE_CXX_FLAGS_DEBUG     " /Wall")
 endif()
 
+# *****************************************************************************
+# Add Source Directory
+# *****************************************************************************
+add_subdirectory(src)
+
+
+# *****************************************************************************
+# Library
+# *****************************************************************************
+add_library(otbr_lib ${otbr_SRC})
+
 
 # *****************************************************************************
 # Executable
 # *****************************************************************************
-
-add_subdirectory(src)
-add_executable(otbr ${otbr_SRC})
-# set_target_properties(otbr PROPERTIES LINK_FLAGS "-std=c++11 -lstdc++ -lpthread -ldl")
+add_executable(otbr ${CMAKE_CURRENT_SOURCE_DIR}/src/otserv.cpp)
 
 
 # *****************************************************************************
@@ -246,6 +254,7 @@ option(PACKAGE_TESTS "Build the tests" OFF)
 if(PACKAGE_TESTS)
     enable_testing()
     add_subdirectory(tests)
+    target_compile_definitions(otbr_lib PRIVATE UNIT_TESTING=1)
 endif()
 
 # *****************************************************************************
@@ -255,7 +264,7 @@ include_directories(SYSTEM ${MYSQL_INCLUDE_DIR} ${LUA_INCLUDE_DIR}
                     ${Boost_INCLUDE_DIRS} ${PUGIXML_INCLUDE_DIR}
                     ${CRYPTOPP_INCLUDE_DIR})
 
-target_link_libraries(otbr ${MYSQL_CLIENT_LIBS} ${LUA_LIBRARIES}
+target_link_libraries(otbr otbr_lib ${MYSQL_CLIENT_LIBS} ${LUA_LIBRARIES}
                       ${Boost_LIBRARIES} ${Boost_FILESYSTEM_LIBRARY}
                       ${PUGIXML_LIBRARIES} ${CRYPTOPP_LIBRARIES}
                       ${CMAKE_THREAD_LIBS_INIT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ set(CMAKE_CXX_FLAGS     "${CMAKE_CXX_FLAGS} -std=c++11 -lstdc++ -lpthread -ldl")
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   # using Clang
   # cmake -DCMAKE_BUILD_TYPE=Release ..
-  set(CMAKE_CXX_FLAGS_RELEASE   "-pipe -fvisibility=hidden -march=native -O2 -Wno-everything")
+  set(CMAKE_CXX_FLAGS_RELEASE   "-pipe -fvisibility=hidden -march=native -O3 -Wno-everything")
 
   # cmake -DCMAKE_BUILD_TYPE=Debug ..
   set(CMAKE_CXX_FLAGS_DEBUG     "-pipe -O0 -g -Wno-everything")
@@ -139,15 +139,15 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   # https://kristerw.blogspot.com/2017/09/useful-gcc-warning-options-not-enabled.html
 
   # cmake -DCMAKE_BUILD_TYPE=Release ..
-  set(CMAKE_CXX_FLAGS_RELEASE   "-Wall -Werror -pipe -fvisibility=hidden -march=native -O2")
+  set(CMAKE_CXX_FLAGS_RELEASE   " -pipe -fvisibility=hidden -march=native -O3")
 
   # cmake -DCMAKE_BUILD_TYPE=Debug ..
   # Ubuntu 16.04
   if(CMAKE_CXX_COMPILER_VERSION STREQUAL "5.4.0")
-    set(CMAKE_CXX_FLAGS_DEBUG   "-Wall -Werror -pipe -O0 -g -Wextra -Wconversion -Wlogical-op -Wold-style-cast -Wuseless-cast -Wdouble-promotion -Wshadow -Wformat=2 -Wno-error")
+    set(CMAKE_CXX_FLAGS_DEBUG   "-Wall -Wextra -Werror -pipe -O0 -g -Wconversion -Wlogical-op -Wold-style-cast -Wuseless-cast -Wdouble-promotion -Wshadow -Wformat=2 -Wno-error")
   else()
     # Ubuntu 18.04
-    set(CMAKE_CXX_FLAGS_DEBUG   "-Wall -Werror -pipe -O0 -g -Wextra -Wconversion -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wrestrict -Wnull-dereference -Wold-style-cast -Wuseless-cast -Wdouble-promotion -Wshadow -Wformat=2 -Wno-error")
+    set(CMAKE_CXX_FLAGS_DEBUG   "-Wall -Wextra -Werror -pipe -O0 -g -Wconversion -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wrestrict -Wnull-dereference -Wold-style-cast -Wuseless-cast -Wdouble-promotion -Wshadow -Wformat=2 -Wno-error")
   endif()
 
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   # https://kristerw.blogspot.com/2017/09/useful-gcc-warning-options-not-enabled.html
 
   # cmake -DCMAKE_BUILD_TYPE=Release ..
-  set(CMAKE_CXX_FLAGS_RELEASE   " -pipe -fvisibility=hidden -march=native -O3")
+  set(CMAKE_CXX_FLAGS_RELEASE   " -Wno-format -pipe -fvisibility=hidden -march=native -O3")
 
   # cmake -DCMAKE_BUILD_TYPE=Debug ..
   # Ubuntu 16.04

--- a/src/account.cpp
+++ b/src/account.cpp
@@ -409,7 +409,7 @@ error_t Account::GetPremiumLastDay(time_t *last_day) {
 
 error_t Account::SetAccountType(AccountType account_type) {
   if (account_type < 0 || account_type > 5) {
-    LOG_F(ERROR, "Invalid Account Type!", static_cast<int>(account_type));
+    LOG_F(ERROR, "Invalid Account Type[%d]!", static_cast<int>(account_type));
     return ERROR_INVALID_ACC_TYPE;
   }
   account_type_ = account_type;

--- a/src/iologindata.cpp
+++ b/src/iologindata.cpp
@@ -32,15 +32,13 @@ extern Game g_game;
 
 bool IOLoginData::LoginServerAuthentication(const std::string& name,
                                             const std::string& password) {
-  int result = 0;
-  account::Account *account = new account::Account();
-  result = account->LoadAccountDB(name);
-  if (result) {
+  account::Account account;
+  if (account::ERROR_NO != account.LoadAccountDB(name)) {
     return false;
   }
 
   std::string acc_password;
-  account->GetPassword(&acc_password);
+  account.GetPassword(&acc_password);
   if (transformToSHA1(password) != acc_password) {
     return false;
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,13 +9,12 @@ project(otbr_unittest)
 set(CMAKE_CXX_FLAGS     "-pipe -O0 -g -Wno-everything -std=c++11 -lstdc++ -lpthread -ldl")
 
 add_executable(otbr_unittest
-							${otbr_SRC}
 							main.cpp
 							account_test.cpp)
 
 target_compile_definitions(otbr_unittest PUBLIC -DUNIT_TESTING -DDEBUG_LOG)
 
-target_link_libraries(otbr_unittest Catch2::Catch2 ${MYSQL_CLIENT_LIBS} ${LUA_LIBRARIES}
+target_link_libraries(otbr_unittest Catch2::Catch2 otbr_lib ${MYSQL_CLIENT_LIBS} ${LUA_LIBRARIES}
 						${Boost_LIBRARIES} ${Boost_FILESYSTEM_LIBRARY}
 						${PUGIXML_LIBRARIES} ${CRYPTOPP_LIBRARIES}
 						${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
- Fix build on Ubuntu 20.04 and Debian 10
- Fix memory leak
- Change GHA file-changes-action to use master