### PR TITLE
Fix stacking creatures in a tile

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -618,7 +618,7 @@ bool Game::removeCreature(Creature* creature, bool isLogout/* = true*/)
 	map.getSpectators(spectators, tile->getPosition(), true);
 	for (Creature* spectator : spectators) {
 		if (Player* player = spectator->getPlayer()) {
-			oldStackPosVector.push_back(player->canSeeCreature(creature) ? tile->getStackposOfCreature(player, creature) : -1);
+			oldStackPosVector.push_back(player->canSeeCreature(creature) ? tile->getClientIndexOfCreature(player, creature) : -1);
 		}
 	}
 
@@ -630,7 +630,7 @@ bool Game::removeCreature(Creature* creature, bool isLogout/* = true*/)
 	size_t i = 0;
 	for (Creature* spectator : spectators) {
 		if (Player* player = spectator->getPlayer()) {
-			player->sendRemoveTileThing(tilePosition, oldStackPosVector[i++]);
+			player->sendRemoveTileCreature(creature, tilePosition, oldStackPosVector[i++]);
 		}
 	}
 

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -11138,7 +11138,7 @@ int LuaScriptInterface::luaPlayerSetGhostMode(lua_State* L)
 		Player* tmpPlayer = spectator->getPlayer();
 		if (tmpPlayer != player && !tmpPlayer->isAccessPlayer()) {
 			if (enabled) {
-				tmpPlayer->sendRemoveTileThing(position, tile->getStackposOfCreature(tmpPlayer, player));
+				tmpPlayer->sendRemoveTileCreature(player, position, tile->getClientIndexOfCreature(tmpPlayer, player));
 			} else {
 				tmpPlayer->sendCreatureAppear(player, position, true);
 			}

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -286,7 +286,7 @@ void Map::moveCreature(Creature& creature, Tile& newTile, bool forceTeleport/* =
 			//Use the correct stackpos
 			int32_t stackpos = oldStackPosVector[i++];
 			if (stackpos != -1) {
-				tmpPlayer->sendCreatureMove(&creature, newPos, newTile.getStackposOfCreature(tmpPlayer, &creature), oldPos, stackpos, teleport);
+				tmpPlayer->sendCreatureMove(&creature, newPos, newTile.getClientIndexOfCreature(tmpPlayer, &creature), oldPos, stackpos, teleport);
 			}
 		}
 	}

--- a/src/player.h
+++ b/src/player.h
@@ -902,7 +902,7 @@ class Player final : public Creature, public Cylinder
 				if (visible) {
 					client->sendAddCreature(creature, creature->getPosition(), stackpos, false);
 				} else {
-					client->sendRemoveTileThing(creature->getPosition(), stackpos);
+					client->sendRemoveTileCreature(creature, creature->getPosition(), stackpos);
 				}
 			}
 		}

--- a/src/player.h
+++ b/src/player.h
@@ -820,6 +820,11 @@ class Player final : public Creature, public Cylinder
 				client->sendRemoveTileThing(pos, stackpos);
 			}
 		}
+		void sendRemoveTileCreature(const Creature* creature, const Position& pos, int32_t stackpos) {
+			if (client) {
+				client->sendRemoveTileCreature(creature, pos, stackpos);
+			}
+		}
 		void sendUpdateTile(const Tile* updateTile, const Position& pos) {
 			if (client) {
 				client->sendUpdateTile(updateTile, pos);
@@ -838,7 +843,7 @@ class Player final : public Creature, public Cylinder
 		}
 		void sendCreatureAppear(const Creature* creature, const Position& pos, bool isLogin) {
 			if (client) {
-				client->sendAddCreature(creature, pos, creature->getTile()->getStackposOfCreature(this, creature), isLogin);
+				client->sendAddCreature(creature, pos, creature->getTile()->getClientIndexOfCreature(this, creature), isLogin);
 			}
 		}
 		void sendCreatureMove(const Creature* creature, const Position& newPos, int32_t newStackPos, const Position& oldPos, int32_t oldStackPos, bool teleport) {
@@ -848,7 +853,7 @@ class Player final : public Creature, public Cylinder
 		}
 		void sendCreatureTurn(const Creature* creature) {
 			if (client && canSeeCreature(creature)) {
-				int32_t stackpos = creature->getTile()->getStackposOfCreature(this, creature);
+				int32_t stackpos = creature->getTile()->getClientIndexOfCreature(this, creature);
 				if (stackpos != -1) {
 					client->sendCreatureTurn(creature, stackpos);
 				}
@@ -889,7 +894,7 @@ class Player final : public Creature, public Cylinder
 			} else if (canSeeInvisibility()) {
 				client->sendCreatureOutfit(creature, creature->getCurrentOutfit());
 			} else {
-				int32_t stackpos = creature->getTile()->getStackposOfCreature(this, creature);
+				int32_t stackpos = creature->getTile()->getClientIndexOfCreature(this, creature);
 				if (stackpos == -1) {
 					return;
 				}

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -2729,7 +2729,6 @@ void ProtocolGame::sendAddCreature(const Creature* creature, const Position& pos
 			if (const Tile* tile = creature->getTile()) {
 				sendUpdateTile(tile, pos);
 			}
-			return;
 		} else {
 			// if stackpos is -1, the client will automatically detect it
 			NetworkMessage msg;

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -2730,19 +2730,19 @@ void ProtocolGame::sendAddCreature(const Creature* creature, const Position& pos
 				sendUpdateTile(tile, pos);
 			}
 			return;
+		} else {
+			// if stackpos is -1, the client will automatically detect it
+			NetworkMessage msg;
+			msg.addByte(0x6A);
+			msg.addPosition(pos);
+			msg.addByte(stackpos);
+
+			bool known;
+			uint32_t removedKnown;
+			checkCreatureAsKnown(creature->getID(), known, removedKnown);
+			AddCreature(msg, creature, known, removedKnown);
+			writeToOutputBuffer(msg);
 		}
-
-		// if stackpos is -1, the client will automatically detect it
-		NetworkMessage msg;
-		msg.addByte(0x6A);
-		msg.addPosition(pos);
-		msg.addByte(stackpos);
-
-		bool known;
-		uint32_t removedKnown;
-		checkCreatureAsKnown(creature->getID(), known, removedKnown);
-		AddCreature(msg, creature, known, removedKnown);
-		writeToOutputBuffer(msg);
 
 		if (isLogin) {
 			if (const Player* creaturePlayer = creature->getPlayer()) {

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3779,7 +3779,7 @@ void ProtocolGame::RemoveTileCreature(NetworkMessage& msg, const Creature* creat
 
 	msg.addByte(0x6C);
 	msg.add<uint16_t>(0xFFFF);
-	msg.addByte(creature->getID());
+	msg.add<uint32_t>(creature->getID());
 }
 
 void ProtocolGame::MoveUpCreature(NetworkMessage& msg, const Creature* creature, const Position& newPos, const Position& oldPos)

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -2420,8 +2420,14 @@ void ProtocolGame::sendCreatureTurn(const Creature* creature, uint32_t stackPos)
 
 	NetworkMessage msg;
 	msg.addByte(0x6B);
-	msg.addPosition(creature->getPosition());
-	msg.addByte(stackPos);
+	if (stackPos >= 10) {
+		msg.add<uint16_t>(0xFFFF);
+		msg.add<uint32_t>(creature->getID());
+	} else {
+		msg.addPosition(creature->getPosition());
+		msg.addByte(stackPos);
+	}
+
 	msg.add<uint16_t>(0x63);
 	msg.add<uint32_t>(creature->getID());
 	msg.addByte(creature->getDirection());
@@ -2712,9 +2718,21 @@ void ProtocolGame::sendAddCreature(const Creature* creature, const Position& pos
 	}
 
 	if (creature != player) {
+		// stack pos is always real index now, so it can exceed the limit
+		// if stack pos exceeds the limit, we need to refresh the tile instead
+		// 1. this is a rare case, and is only triggered by forcing summon in a position
+		// 2. since no stackpos will be send to the client about that creature, removing
+		//    it must be done with its id if its stackpos remains >= 10. this is done to
+		//    add creatures to battle list instead of rendering on screen
+		if (stackpos >= 10) {
+			// @todo: should we avoid this check?
+			if (const Tile* tile = creature->getTile()) {
+				sendUpdateTile(tile, pos);
+			}
+			return;
+		}
+
 		// if stackpos is -1, the client will automatically detect it
-		// if the amount of creatures exceeds the limit of the tile (10)
-		// it will just add it to battle-list without rendering it to the map
 		NetworkMessage msg;
 		msg.addByte(0x6A);
 		msg.addPosition(pos);

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -290,6 +290,7 @@ class ProtocolGame final : public Protocol
 		void sendAddTileItem(const Position& pos, uint32_t stackpos, const Item* item);
 		void sendUpdateTileItem(const Position& pos, uint32_t stackpos, const Item* item);
 		void sendRemoveTileThing(const Position& pos, uint32_t stackpos);
+		void sendRemoveTileCreature(const Creature* creature, const Position& pos, uint32_t stackpos);
 		void sendUpdateTile(const Tile* tile, const Position& pos);
 
 		void sendAddCreature(const Creature* creature, const Position& pos, int32_t stackpos, bool isLogin);
@@ -341,6 +342,7 @@ class ProtocolGame final : public Protocol
 
 		//tiles
 		static void RemoveTileThing(NetworkMessage& msg, const Position& pos, uint32_t stackpos);
+		static void RemoveTileCreature(NetworkMessage& msg, const Creature* creature, const Position& pos, uint32_t stackpos);
 
 		void MoveUpCreature(NetworkMessage& msg, const Creature* creature, const Position& newPos, const Position& oldPos);
 		void MoveDownCreature(NetworkMessage& msg, const Creature* creature, const Position& newPos, const Position& oldPos);

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -1129,8 +1129,6 @@ void Tile::removeCreature(Creature* creature)
 	removeThing(creature, 0);
 }
 
-// @todo: verify that using items on stack-invisible creatures triggers no visual effect
-// ref: Game::playerUseWithCreature
 int32_t Tile::getThingIndex(const Thing* thing) const
 {
 	int32_t n = -1;
@@ -1203,38 +1201,6 @@ int32_t Tile::getClientIndexOfCreature(const Player* player, const Creature* cre
 				return n;
 			} else if (player->canSeeCreature(c)) {
 				++n;
-			}
-		}
-	}
-	return -1;
-}
-
-// @todo: deprecated and no longer referenced, use getClientIndexOfCreature
-int32_t Tile::getStackposOfCreature(const Player* player, const Creature* creature) const
-{
-	int32_t n;
-	if (ground) {
-		n = 1;
-	} else {
-		n = 0;
-	}
-
-	const TileItemVector* items = getItemList();
-	if (items) {
-		n += items->getTopItemCount();
-		if (n >= 10) {
-			return -1;
-		}
-	}
-
-	if (const CreatureVector* creatures = getCreatures()) {
-		for (const Creature* c : boost::adaptors::reverse(*creatures)) {
-			if (c == creature) {
-				return n;
-			} else if (player->canSeeCreature(c)) {
-				if (++n >= 10) {
-					return -1;
-				}
 			}
 		}
 	}

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -1129,6 +1129,8 @@ void Tile::removeCreature(Creature* creature)
 	removeThing(creature, 0);
 }
 
+// @todo: verify that using items on stack-invisible creatures triggers no visual effect
+// ref: Game::playerUseWithCreature
 int32_t Tile::getThingIndex(const Thing* thing) const
 {
 	int32_t n = -1;
@@ -1207,6 +1209,7 @@ int32_t Tile::getClientIndexOfCreature(const Player* player, const Creature* cre
 	return -1;
 }
 
+// @todo: deprecated and no longer referenced, use getClientIndexOfCreature
 int32_t Tile::getStackposOfCreature(const Player* player, const Creature* creature) const
 {
 	int32_t n;

--- a/src/tile.h
+++ b/src/tile.h
@@ -237,7 +237,6 @@ class Tile : public Cylinder
 		std::string getDescription(int32_t lookDistance) const override final;
 
 		int32_t getClientIndexOfCreature(const Player* player, const Creature* creature) const;
-		int32_t getStackposOfCreature(const Player* player, const Creature* creature) const;
 		int32_t getStackposOfItem(const Player* player, const Item* item) const;
 
 		//cylinder implementations


### PR DESCRIPTION
> TFS limits creatures to 10 in a tile, so the creatures wouldn't appear in battle-list. While this wouldn't affect you at all, it can affect worlds where expert pvp is introduced or even in depots.

In order to properly test creature stacking in a tile using client 12, I applied the patch to the OtservBR repository. 
https://github.com/otland/forgottenserver/pull/2673#pullrequestreview-430243400

More information available here:
https://github.com/otland/forgottenserver/pull/2673