### PR TITLE
Fixes in dawnport and action creation at server startup

### DIFF
--- a/data/scripts/actions/dawnport/vocation_door.lua
+++ b/data/scripts/actions/dawnport/vocation_door.lua
@@ -1,3 +1,30 @@
+local UniqueTable = {
+	-- Vocation doors
+	[22001] = {
+		vocation = VOCATION.ID.SORCERER,
+		storage = Storage.Dawnport.DoorVocation,
+		destination = {x = 32054, y = 31883, z = 6}
+	},
+	-- Druid
+	[22002] = {
+		vocation = VOCATION.ID.DRUID,
+		storage = Storage.Dawnport.DoorVocation,
+		destination = {x = 32073, y = 31883, z = 6}
+	},
+	-- Paladin
+	[22003] = {
+		vocation = VOCATION.ID.PALADIN,
+		storage = Storage.Dawnport.DoorVocation,
+		destination = {x = 32059, y = 31884, z = 6}
+	},
+	-- Knight
+	[22004] = {
+		vocation = VOCATION.ID.KNIGHT,
+		storage = Storage.Dawnport.DoorVocation,
+		destination = {x = 32068, y = 31883, z = 6}
+	},
+}
+
 local slots = {
 	1, 2, 4, 5, 6, 7, 8, 9, 10
 }
@@ -56,8 +83,8 @@ function vocationDoor.onUse(player, item, target, position, fromPosition)
 	return true
 end
 
-for uniqueRange = 22001, 22004 do
-	vocationDoor:uid(uniqueRange)
+for index, value in pairs(UniqueTable) do
+	vocationDoor:uid(index)
 end
 
 vocationDoor:register()

--- a/data/scripts/actions/quests/dawnport/vocation_reward.lua
+++ b/data/scripts/actions/quests/dawnport/vocation_reward.lua
@@ -1,3 +1,39 @@
+local UniqueTable = {
+	-- Dawnport vocation rewards
+	-- Sorcerer
+	[14025] = {
+		itemBag = 1988,
+		itemReward = {{2643, 1}, {2175, 1}, {2190, 1}, {8819, 1}, {8820, 1}, {2649, 1}},
+		itemRewardContainer = {{7620, 5}, {18559, 1}},
+		storage = Storage.Quest.Dawnport.VocationReward,
+		value = 1
+	},
+	-- Druid
+	[14026] = {
+		itemBag = 1988,
+		itemReward = {{2643, 1}, {2175, 1}, {2182, 1}, {8819, 1}, {8820, 1}, {2649, 1}},
+		itemRewardContainer = {{7620, 5}, {18559, 1}},
+		storage = Storage.Quest.Dawnport.VocationReward,
+		value = 2
+	},
+	-- Paladin
+	[14027] = {
+		itemBag = 1988,
+		itemReward = {{2643, 1}, {2389, 1}, {2660, 1}, {8923, 1}, {2461, 1}},
+		itemRewardContainer = {{2544, 100}, {18559, 1}},
+		storage = Storage.Quest.Dawnport.VocationReward,
+		value = 3
+	},
+	-- Knight
+	[14028] = {
+		itemBag = 1988,
+		itemReward = {{2643, 1}, {2509, 1}, {8602, 1}, {2465, 1}, {2460, 1}, {2478, 1}},
+		itemRewardContainer = {{7618, 5}, {18559, 1}},
+		storage = Storage.Quest.Dawnport.VocationReward,
+		value = 4
+	}
+}
+
 local vocationReward = Action()
 
 function vocationReward.onUse(player, item, fromPosition, itemEx, toPosition)
@@ -35,8 +71,8 @@ function vocationReward.onUse(player, item, fromPosition, itemEx, toPosition)
 	return true
 end
 
-for key = 25022,25025 do
-	vocationReward:uid(key)
+for index, value in pairs(UniqueTable) do
+	vocationReward:uid(index)
 end
 
 vocationReward:register()

--- a/data/scripts/actions/system/quest_reward_container.lua
+++ b/data/scripts/actions/system/quest_reward_container.lua
@@ -2,7 +2,7 @@
 -- You just need to add a new table in the data/startup/tables/chest.lua file and this script will pull everything from there.
 local containerReward = Action()
 function containerReward.onUse(player, item, fromPosition, itemEx, toPosition)
-	local setting = UniqueTable[item.uid]
+	local setting = ChestUnique[item.uid]
 	if player:getStorageValue(setting.storage) < 0 then
 		local backpack = player:getSlotItem(CONST_SLOT_BACKPACK)
 		if backpack and backpack:getEmptySlots(true) > 1 then

--- a/data/startup/others/functions.lua
+++ b/data/startup/others/functions.lua
@@ -16,7 +16,7 @@ function loadLuaMapAction(tablename)
 					item = tile:getItemById(value.itemId)
 				end
 				-- If he found the item, add the action id.
-				if item and value.actionId then
+				if item then
 					item:setAttribute(ITEM_ATTRIBUTE_ACTIONID, index)
 				end
 				if value.itemId == false and tile:getTopDownItem() then

--- a/data/startup/tables/chest.lua
+++ b/data/startup/tables/chest.lua
@@ -114,54 +114,9 @@ ChestUnique = {
 	-- Reward inside of container, there is also the option to put a key inside
 	-- If the table has a variable for key, (keyItem and keyAction) then it is inside the bag
 	-- Path: data\scripts\actions\system\quest_reward_container.lua
-	-- Dawnport vocation rewards
-	-- Sorcerer
 	[10001] = {
-		-- For use of the map
-		itemId = 1740,
-		itemPos = {x = 32054, y = 31882, z = 6},
-		-- For use of the script
-		itemBag = 1988,
-		itemReward = {{2643, 1}, {2175, 1}, {2190, 1}, {8819, 1}, {8820, 1}, {2649, 1}},
-		itemRewardContainer = {{7620, 5}, {18559, 1}},
-		storage = Storage.Quest.Dawnport.VocationReward,
-		value = 1
-	},
-	-- Druid
-	[10002] = {
-		-- For use of the map
-		itemId = 1740,
-		itemPos = {x = 32073, y = 31882, z = 6},
-		-- For use of the script
-		itemBag = 1988,
-		itemReward = {{2643, 1}, {2175, 1}, {2182, 1}, {8819, 1}, {8820, 1}, {2649, 1}},
-		itemRewardContainer = {{7620, 5}, {18559, 1}},
-		storage = Storage.Quest.Dawnport.VocationReward,
-		value = 2
-	},
-	-- Paladin
-	[10003] = {
-		-- For use of the map
-		itemId = 1740,
-		itemPos = {x = 32059, y = 31882, z = 6},
-		-- For use of the script
-		itemBag = 1988,
-		itemReward = {{2643, 1}, {2389, 1}, {2660, 1}, {8923, 1}, {2461, 1}},
-		itemRewardContainer = {{2544, 100}, {18559, 1}},
-		storage = Storage.Quest.Dawnport.VocationReward,
-		value = 3
-	},
-	-- Knight
-	[10004] = {
-		-- For use of the map
-		itemId = 1740,
-		itemPos = {x = 32068, y = 31882, z = 6},
-		-- For use of the script
-		itemBag = 1988,
-		itemReward = {{2643, 1}, {2509, 1}, {8602, 1}, {2465, 1}, {2460, 1}, {2478, 1}},
-		itemRewardContainer = {{7618, 5}, {18559, 1}},
-		storage = Storage.Quest.Dawnport.VocationReward,
-		value = 4
+		itemId = false,
+		itemPos = {x = xxxxx, y = yyyyy, z = z}
 	},
 
 	-- Reward of others scrips files (varied rewards)
@@ -264,5 +219,26 @@ ChestUnique = {
 	[14024] = {
 		itemId = 5677,
 		itemPos = {x = 31938, y = 32837, z = 7}
+	},
+	-- Dawnport vocation rewards
+	-- Sorcerer
+	[14025] = {
+		itemId = 1740,
+		itemPos = {x = 32054, y = 31882, z = 6}
+	},
+	-- Druid
+	[14026] = {
+		itemId = 1740,
+		itemPos = {x = 32073, y = 31882, z = 6}
+	},
+	-- Paladin
+	[14027] = {
+		itemId = 1740,
+		itemPos = {x = 32059, y = 31882, z = 6}
+	},
+	-- Knight
+	[14028] = {
+		itemId = 1740,
+		itemPos = {x = 32068, y = 31882, z = 6}
 	}
 }

--- a/data/startup/tables/chest.lua
+++ b/data/startup/tables/chest.lua
@@ -11,7 +11,11 @@
 	Reward with container
 	Varied rewards
 
-	The first three are automatic scripts, where it is only necessary to duplicate the table and configure the unique (or action)/itemId/itemPos/itemReward and etc and it will work, and the varied reward is for use by other scripts.
+	The first three are automatic scripts, where it is only necessary to duplicate the table and configure the unique (or action)/itemId/itemPos/itemReward and etc and it will work, and the varied reward is for use by other scripts
+
+	Note:
+	The "for use of the map" variables are only used to create the action or unique on the map during startup
+	The "for use of the script" variables are used by the scripts, to allow a single script to manage all rewards of the same type
 ]]
 
 ChestAction = {
@@ -115,8 +119,37 @@ ChestUnique = {
 	-- If the table has a variable for key, (keyItem and keyAction) then it is inside the bag
 	-- Path: data\scripts\actions\system\quest_reward_container.lua
 	[10001] = {
+		-- For use of the map
 		itemId = false,
-		itemPos = {x = xxxxx, y = yyyyy, z = z}
+		itemPos = {x = xxxxx, y = yyyyy, z = z},
+		-- For use of the script
+		itemBag = containerId,
+		itemReward = {
+			{itemId, itemCount},
+			{itemId, itemCount},
+			{itemId, itemCount},
+			{itemId, itemCount}
+		},
+		weight = WeightContainerNumber,
+		storage = StorageKeyVariable
+	},
+	-- Example of chest having key reward
+	[10002] = {
+		-- For use of the map
+		itemId = false,
+		itemPos = {x = xxxxx, y = yyyyy, z = z},
+		-- For use of the script
+		itemBag = containerId,
+		itemReward = {
+			{itemId, itemCount},
+			{itemId, itemCount},
+			{itemId, itemCount},
+			{itemId, itemCount}
+		},
+		weight = WeightContainerNumber,
+		keyItem = keyId,
+		keyAction = keyActionNumber,
+		storage = StorageKeyVariable
 	},
 
 	-- Reward of others scrips files (varied rewards)

--- a/data/startup/tables/door_quest.lua
+++ b/data/startup/tables/door_quest.lua
@@ -631,42 +631,22 @@ QuestDoorUnique = {
 	-- Vocation doors
 	-- Sorcerer
 	[22001] = {
-		-- For use of the map
 		itemId = 12195,
-		itemPos = {x = 32055, y = 31885, z = 6},
-		-- For use of the script
-		vocation = VOCATION.ID.SORCERER,
-		storage = Storage.Dawnport.DoorVocation,
-		destination = {x = 32054, y = 31883, z = 6}
+		itemPos = {x = 32055, y = 31885, z = 6}
 	},
 	-- Druid
 	[22002] = {
-		-- For use of the map
 		itemId = 7040,
-		itemPos = {x = 32073, y = 31885, z = 6},
-		-- For use of the script
-		vocation = VOCATION.ID.DRUID,
-		storage = Storage.Dawnport.DoorVocation,
-		destination = {x = 32073, y = 31883, z = 6}
+		itemPos = {x = 32073, y = 31885, z = 6}
 	},
 	-- Paladin
 	[22003] = {
-		-- For use of the map
 		itemId = 6898,
-		itemPos = {x = 32059, y = 31885, z = 6},
-		-- For use of the script
-		vocation = VOCATION.ID.PALADIN,
-		storage = Storage.Dawnport.DoorVocation,
-		destination = {x = 32059, y = 31884, z = 6}
+		itemPos = {x = 32059, y = 31885, z = 6}
 	},
 	-- Knight
 	[22004] = {
-		-- For use of the map
 		itemId = 9279,
-		itemPos = {x = 32069, y = 31885, z = 6},
-		-- For use of the script
-		vocation = VOCATION.ID.KNIGHT,
-		storage = Storage.Dawnport.DoorVocation,
-		destination = {x = 32068, y = 31883, z = 6}
-	},
+		itemPos = {x = 32069, y = 31885, z = 6}
+	}
 }


### PR DESCRIPTION
Corrections in dawnport variables and a small correction in the startup's functions.lua, which prevented it from creating action in game on the server startup.

This errors is created after the commit: https://github.com/opentibiabr/otservbr-global/commit/dbbf14c5be1eda173a80837f2a5aaa7577c3db65 from pr #1325 