### PR TITLE
Golden prision key script fix and Prince Drazzak loot table small fix.

### DIFF
--- a/data/actions/scripts/roshamuul/prison/golden.lua
+++ b/data/actions/scripts/roshamuul/prison/golden.lua
@@ -42,6 +42,7 @@ function onUse(player, item, fromPosition, target, toPosition, monster, isHotkey
 					return true
 				end
 				if creature:getStorageValue(setting.storage) < os.time() then
+					item:remove()
 					creature:setStorageValue(setting.storage, os.time() + setting.timeToFightAgain * 60 * 60)
 					creature:teleportTo(playerPositions[i].toPos)
 					creature:getPosition():sendMagicEffect(CONST_ME_TELEPORT)

--- a/data/monster/bosses/prince_drazzak.xml
+++ b/data/monster/bosses/prince_drazzak.xml
@@ -60,8 +60,9 @@
 		<voice sentence="They used you fools to escape and they left ME behind!!??" />
 	</voices>
 	<loot>
-		<item id="22396" countmax="5" chance="100000" /><!-- cluster of solace -->
-		<item id="22598" countmax="3" chance="1000" /><!-- unrealized dream -->
+		<item id="22397" chance="100000" /><!-- Dream Matter -->
+		<item id="22396" countmax="2" chance="100000" /><!-- cluster of solace -->		
+		<item id="22598" countmax="3" chance="93750" /><!-- Unrealized Dream -->
 		<item id="6500" countmax="2" chance="100000" /><!-- demonic essence -->
 		<item id="5954" chance="50000" /><!-- demon horn -->
 		<item id="2152" countmax="50" chance="100000" /><!-- platinum coin -->


### PR DESCRIPTION
The golden key should be removed from the player when used and Prince Drazzak should always drop a dream matter and has a 93.75 chance to drop a maximum of 3 unrealized dreams.