### PR TITLE
Small fixes on the datapack

### DIFF
--- a/data/actions/scripts/farmine/oberon_lever.lua
+++ b/data/actions/scripts/farmine/oberon_lever.lua
@@ -1,97 +1,60 @@
-local config = {
-	bossName = "Grand Master Oberon",
-	lockStorage = 5000105, -- globalstorage
-	bossPos = Position(33364, 31317, 9),
-	centerRoom = Position(33364, 31318, 9), -- Center Room
-	exitPosition = Position(33366, 31342, 9), -- Exit Position
-	newPos = Position(33364, 31321, 9),
+local setting = {
+	timeToFightAgain = 20,
+	clearRoomTime = 60, -- In hour
+	centerRoom = {x = 33364, y = 31318, z = 9},
 	range = 10,
-	time = 10, -- time in minutes to remove the player
+	storage = Storage.TheSecretLibrary.TheOrderOfTheFalcon.OberonTimer,
+	clearRoomStorage = GlobalStorage.OberonEventTime,
+	bossName = "grand master oberon",
+	bossPosition = {x = 33364, y = 31317, z = 9}
 }
 
---[[local monsters = {
-	{pillar = "oberons ire", pos = Position(33367, 31320, 9)},
-	{pillar = "oberons spite", pos = Position(33361, 31320, 9)},
-	{pillar = "oberons hate", pos = Position( 33367, 31316, 9)},
-	{pillar = "oberons bile", pos = Position(33361, 31316, 9)}
-}]]
+local playerPositions = {
+	{fromPos = {x = 33364, y = 31344, z = 9}, toPos = {x = 33364, y = 31321, z = 9}},
+	{fromPos = {x = 33363, y = 31344, z = 9}, toPos = {x = 33363, y = 31321, z = 9}},
+	{fromPos = {x = 33365, y = 31344, z = 9}, toPos = {x = 33365, y = 31321, z = 9}},
+	{fromPos = {x = 33362, y = 31344, z = 9}, toPos = {x = 33362, y = 31321, z = 9}},
+	{fromPos = {x = 33366, y = 31344, z = 9}, toPos = {x = 33366, y = 31321, z = 9}}
+}
 
-local function clearOberonRoom()
-	if Game.getStorageValue(config.lockStorage) == 1 then
-		local spectators = Game.getSpectators(config.bossPos, false, false, 10, 10, 10, 10)
-		for i = 1, #spectators do
-			local spectator = spectators[i]
-			if spectator:isPlayer() then
-				spectator:teleportTo(config.exitPosition)
-				spectator:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
-				spectator:say('Time out! You were teleported out by strange forces.', TALKTYPE_MONSTER_SAY)
-			elseif spectator:isMonster() then
-				spectator:remove()
-			end
-		end
-		Game.setStorageValue(config.lockStorage, 0)
-	end
-end
 -- Start Script
 function onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	if item.itemid == 1945 and item.actionid == 57605 then
-		if player:getPosition() ~= Position(33364, 31344, 9) then
-			return true
-		end
-
-	for x = 33362, 33366 do
-	local playerTile = Tile(Position(x, 31344, 9)):getTopCreature()
-		if playerTile and playerTile:isPlayer() then
-			if playerTile:getStorageValue(Storage.TheSecretLibrary.TheOrderOfTheFalcon.OberonTimer) > os.time() then
-				playerTile:sendTextMessage(MESSAGE_STATUS_SMALL, "You or a member in your team have to wait 20 hours to challange Grand Master Oberon again!")
-				item:transform(1946)
+		for i = 1, #playerPositions do
+			local creature = Tile(playerPositions[i].fromPos):getTopCreature()
+			if not creature then
+				player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You need 5 players to fight with this boss.")
 				return true
 			end
 		end
-	end
 
-	local specs, spec = Game.getSpectators(config.centerRoom, false, false, 15, 15, 15, 15)
-	for i = 1, #specs do
-		spec = specs[i]
-		if spec:isPlayer() then
-			player:sendTextMessage(MESSAGE_STATUS_SMALL, "There's someone fighting with Grand Master Oberon.")
-			item:transform(1946)
+		if roomIsOccupied(setting.centerRoom, setting.range, setting.range)
+					or Game.getStorageValue(setting.clearRoomStorage) == 1 then
+			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Someone is fighting against the boss! You need wait awhile.")
 			return true
 		end
-	end
 
-	if Game.getStorageValue(config.lockStorage) == 1 then
-		player:sendTextMessage(MESSAGE_STATUS_SMALL, "You need wait 10 minutes to room cleaner!")
-		return true
-	end
-
-	local spectators = Game.getSpectators(config.bossPos, false, false, 15, 15, 15, 15)
-	for i = 1, #spectators do
-		local spectator = spectators[i]
-		if spectator:isMonster() then
-			spectator:remove()
+		for i = 1, #playerPositions do
+			local creature = Tile(playerPositions[i].fromPos):getTopCreature()
+			if creature and creature:isPlayer() then
+				if not creature:getStorageValue(setting.storage) >= os.time() then
+					creature:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have faced this boss in the last " .. setting.timeToFightAgain .. " hours.")
+					return true
+				end
+				if creature:getStorageValue(setting.storage) < os.time() then
+					creature:setStorageValue(setting.storage, os.time() + setting.timeToFightAgain * 60 * 60)
+					creature:teleportTo(playerPositions[i].toPos)
+					creature:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+				end
+			else
+				return false
+			end
 		end
+		-- One hour for clean the room and other time goto again
+		addEvent(clearRoom, setting.clearRoomTime * 60 * 1000, setting.centerRoom,
+					setting.range, setting.range, setting.clearRoomStorage)
+		Game.createMonster(setting.bossName, setting.bossPosition)
+		Game.setStorageValue(setting.clearRoomStorage, 1)
 	end
-		--[[for n = 1, #monsters do
-			Game.createMonster(monsters[n].pillar, monsters[n].pos, true, true)
-		end]]
-	Game.createMonster(config.bossName, config.bossPos, true, true)
-	Game.setStorageValue(config.lockStorage, 1)
-	for x = 33362, 33366 do
-		local playerTile = Tile(Position(x, 31344, 9)):getTopCreature()
-		if playerTile and playerTile:isPlayer() then
-			playerTile:getPosition():sendMagicEffect(CONST_ME_POFF)
-			playerTile:teleportTo(config.newPos)
-			playerTile:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
-			playerTile:setStorageValue(Storage.TheSecretLibrary.TheOrderOfTheFalcon.OberonTimer, os.time() + 20 * 60 * 60)
-			addEvent(clearOberonRoom, 60 * config.time * 1000, playerTile:getId(), config.centerRoom, config.range, config.range, config.exitPosition)
-			playerTile:sendTextMessage(MESSAGE_STATUS_SMALL, "You have 10 minutes to kill and loot this boss. Otherwise you will lose that chance and will be kicked out.")
-			item:transform(1946)
-		end
-	end
-
-elseif item.itemid == 1946 then
-		item:transform(1945)
-	end
-		return true
+	return true
 end

--- a/data/actions/scripts/roshamuul/prison/golden.lua
+++ b/data/actions/scripts/roshamuul/prison/golden.lua
@@ -29,7 +29,7 @@ function onUse(player, item, fromPosition, target, toPosition, monster, isHotkey
 	end
 
 	if toPosition == Position(33606, 32362, 11) then
-		if roomIsOccupied(setting.centerRoom, setting.range, setting.range) then
+		if roomIsOccupied(setting.centerRoom, setting.range, setting.range)
 					or Game.getStorageValue(setting.clearRoomStorage) == 1 then
 			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Someone is fighting against the boss! You need wait awhile.")
 			return true

--- a/data/actions/scripts/roshamuul/prison/golden.lua
+++ b/data/actions/scripts/roshamuul/prison/golden.lua
@@ -3,8 +3,8 @@ local setting = {
 	clearRoomTime = 60, -- In hour
 	centerRoom = {x = 33528, y = 32334, z = 12},
 	range = 10,
-	exitPosition = {x = 33609, y = 32365, z = 11},
 	storage = Storage.PrinceDrazzakTime,
+	clearRoomStorage = GlobalStorage.PrinceDrazzakEventTime,
 	bossName = "prince drazzak",
 	bossPosition = {x = 33528, y = 32333, z = 12}
 }
@@ -30,28 +30,33 @@ function onUse(player, item, fromPosition, target, toPosition, monster, isHotkey
 
 	if toPosition == Position(33606, 32362, 11) then
 		if roomIsOccupied(setting.centerRoom, setting.range, setting.range) then
+					or Game.getStorageValue(setting.clearRoomStorage) == 1 then
 			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Someone is fighting against the boss! You need wait awhile.")
 			return true
 		end
 
 		for i = 1, #playerPositions do
 			local creature = Tile(playerPositions[i].fromPos):getTopCreature()
-			if creature then
+			if creature and creature:isPlayer() then
 				if creature:getStorageValue(setting.storage) >= os.time() then
 					creature:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have faced this boss in the last " .. setting.timeToFightAgain .. " hours.")
 					return true
 				end
 				if creature:getStorageValue(setting.storage) < os.time() then
-					item:remove()
 					creature:setStorageValue(setting.storage, os.time() + setting.timeToFightAgain * 60 * 60)
 					creature:teleportTo(playerPositions[i].toPos)
 					creature:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 				end
+			else
+				return false
 			end
 		end
-		-- One hour for clean the room
-		addEvent(clearRoom, setting.clearRoomTime * 60 * 1000, setting.centerRoom, setting.range, setting.range, setting.exitPosition)
+		item:remove()
+		-- One hour for clean the room and other time goto again
+		addEvent(clearRoom, setting.clearRoomTime * 60 * 1000, setting.centerRoom,
+					setting.range, setting.range, setting.clearRoomStorage)
 		Game.createMonster(setting.bossName, setting.bossPosition)
+		Game.setStorageValue(setting.clearRoomStorage, 1)
 	end
 	return true
 end

--- a/data/lib/core/functions.lua
+++ b/data/lib/core/functions.lua
@@ -196,7 +196,7 @@ function clearBossRoom(playerId, bossId, centerPosition, rangeX, rangeY, exitPos
 	end
 end
 
-function clearRoom(centerPosition, rangeX, rangeY, exitPosition)
+function clearRoom(centerPosition, rangeX, rangeY, resetGlobalStorage)
 	local spectators,
 	spectator = Game.getSpectators(centerPosition, false, false, rangeX, rangeX, rangeY, rangeY)
 	for i = 1, #spectators do
@@ -204,6 +204,9 @@ function clearRoom(centerPosition, rangeX, rangeY, exitPosition)
 		if spectator:isMonster() then
 			spectator:remove()
 		end
+	end
+	if Game.getStorageValue(resetGlobalStorage) == 1 then
+		Game.setStorageValue(resetGlobalStorage, -1)
 	end
 end
 

--- a/data/lib/core/storages.lua
+++ b/data/lib/core/storages.lua
@@ -2159,7 +2159,10 @@ GlobalStorage = {
 	SwordOfFury = 65005,
 	XpDisplayMode = 65006,
 	LionsRockFields = 65007,
-	TheMummysCurse = 65007
+	TheMummysCurse = 65008,
+	OberonEventTime = 65009,
+	PrinceDrazzakEventTime = 65010,
+	ScarlettEtzelEventTime = 65011
 }
 
 

--- a/data/scripts/actions/other/teleport_item.lua
+++ b/data/scripts/actions/other/teleport_item.lua
@@ -6,7 +6,8 @@ local teleportItem = Action()
 function teleportItem.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	-- Scarlett Etzel teleport item
 	if item.uid == 15003 then
-		if roomIsOccupied({x = 33396, y = 32648, z = 6}, 11, 11) then
+		if roomIsOccupied({x = 33396, y = 32648, z = 6}, 11, 11)
+					or Game.getStorageValue(setting.clearRoomStorage) == 1 then
 			player:say("Someone is fighting against the boss! You need wait awhile.", TALKTYPE_MONSTER_SAY)
 			return true
 		end
@@ -20,7 +21,9 @@ function teleportItem.onUse(player, item, fromPosition, target, toPosition, isHo
 		player:teleportTo({x = 33395, y = 32657, z = 6})
 		player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 		player:setStorageValue(Storage.GraveDanger.ScarlettEtzel, os.time() + 20 * 60 * 60)
-		addEvent(clearRoom, 60 * 60 * 1000, {x = 33396, y = 32648, z = 6}, 11, 11, {x = 33395, y = 32662, z = 6})
+		-- addEvent = One hour for clean the room and other time goto again
+		addEvent(clearRoom, 60 * 60 * 1000, {x = 33396, y = 32648, z = 6}, 11, 11, GlobalStorage.ScarlettEtzelEventTime)
+		Game.setStorageValue(GlobalStorage.ScarlettEtzelEventTime, 1)
 		return true
 	end
 

--- a/data/scripts/actions/quests/dark_trails/corpse.lua
+++ b/data/scripts/actions/quests/dark_trails/corpse.lua
@@ -10,5 +10,5 @@ function corpse.onUse(player)
 	return true
 end
 
-corpse:uid(20000)
+corpse:uid(20001)
 corpse:register()

--- a/data/scripts/actions/quests/lions_rock/lions_rock.lua
+++ b/data/scripts/actions/quests/lions_rock/lions_rock.lua
@@ -79,7 +79,7 @@ function lionsRockSkeleton.onUse(player, item, fromPosition, target, toPosition,
 	return true
 end
 
-lionsRockSkeleton:uid(20001)
+lionsRockSkeleton:uid(20002)
 lionsRockSkeleton:register()
 
 -- Lions rock sacrifices

--- a/data/scripts/custom/monster_training_machine.lua
+++ b/data/scripts/custom/monster_training_machine.lua
@@ -56,7 +56,8 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 1,
-	armor = 1
+	armor = 1,
+	{name = "combat", type = COMBAT_HEALING, chance = 15, interval = 2*1000, minDamage = 10000, maxDamage = 50000, effect = CONST_ME_MAGIC_BLUE}
 }
 
 monster.elements = {

--- a/data/startup/tables/corpse.lua
+++ b/data/startup/tables/corpse.lua
@@ -4,7 +4,7 @@ Look README.md for look the reserved action/unique
 
 ]]
 CorpseAction = {
-	[20000] = {
+	[20001] = {
 		itemId = false,
 		itemPos = {{x = xxxxx, y = xxxxx, z = xx}}
 	}
@@ -13,13 +13,13 @@ CorpseAction = {
 CorpseUnique = {
 	-- Dark trails (Quandon corpse)
 	-- Path: data\scripts\actions\quests\dark_trails\corpse.lua
-	[20000] = {
+	[20001] = {
 		itemId = false,
 		itemPos = {x = 33574, y = 31952, z = 6}
 	},
 	-- Lions rock corpse
 	-- Path: data\scripts\actions\quests\lions_rock\lions_rock.lua
-	[20001] = {
+	[20002] = {
 		itemId = false,
 		itemPos = {x = 33146, y = 32341, z = 8}
 	}


### PR DESCRIPTION
Oberon lever correction (refactored)
Correction in the boss levers system, added GlobalStorage to check if the room cleaning event has already been executed or not, thus preventing the boss from cleaning before the scheduled time, while a team is inside

Also fixed a bug that allows players to enter monsters / summons instead of other players, now only players will enter the boss rooms

Added heal magic on trainers

Added a Game.setGlobalStorage in the clearRoom function

Fixed bug in the corpses' unique range (from the startup folder)