### PR TITLE
Fix player depots memory leak

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -65,6 +65,12 @@ Player::~Player()
 			item->decrementReferenceCounter();
 		}
 	}
+  
+  for (const auto& it : depotChests) {
+		if (!it.second->getRealParent()) {
+			it.second->decrementReferenceCounter();
+		}
+	}
 
 	for (const auto& it : depotLockerMap) {
 		it.second->removeInbox(inbox);
@@ -858,6 +864,7 @@ DepotLocker* Player::getDepotLocker(uint32_t depotId)
 	}
 
 	DepotLocker* depotLocker = new DepotLocker(ITEM_LOCKER1);
+  depotLocker->incrementReferenceCounter();
 	depotLocker->setDepotId(depotId);
 	depotLocker->internalAddThing(Item::CreateItem(ITEM_MARKET));
 	depotLocker->internalAddThing(inbox);


### PR DESCRIPTION
Fix critical memory leak - player depots aren't destroyed at all 

Author: @SaiyansKing