### PR TITLE
Heart of Destruction Creaturescripts review

### DIFF
--- a/data/creaturescripts/scripts/quests/heart_of_destruction/aftershock_transform.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/aftershock_transform.lua
@@ -1,5 +1,5 @@
 function onThink(creature)
-	if not creature:isMonster() then
+	if not creature or not creature:isMonster() then
 		return false
 	end
 

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/aftershock_transform.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/aftershock_transform.lua
@@ -1,5 +1,5 @@
 function onThink(creature)
-	if not creature:isCreature() then
+	if not creature:isMonster() then
 		return false
 	end
 

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/aftershock_transform.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/aftershock_transform.lua
@@ -7,7 +7,6 @@ function onThink(creature)
 	if realityQuakeStage == 0 then
 		if hp <= 80 and aftershockStage == 0 then
 			aftershockHealth = creature:getHealth()
-			local from = creature:getId()
 			creature:remove()
 			local monster = Game.createMonster("foreshock", {x = 32208, y = 31248, z = 14}, false, true)
 			monster:addHealth(-monster:getHealth() + foreshockHealth, false)
@@ -18,7 +17,6 @@ function onThink(creature)
 			aftershockStage = 1
 		elseif hp <= 60 and aftershockStage == 1 then
 			aftershockHealth = creature:getHealth()
-			local from = creature:getId()
 			creature:remove()
 			local monster = Game.createMonster("foreshock", {x = 32208, y = 31248, z = 14}, false, true)
 			monster:addHealth(-monster:getHealth() + foreshockHealth, false)
@@ -40,7 +38,6 @@ function onThink(creature)
 			aftershockStage = 3
 		elseif hp <= 25 and aftershockStage == 3 then
 			aftershockHealth = creature:getHealth()
-			local from = creature:getId()
 			creature:remove()
 			local monster = Game.createMonster("foreshock", {x = 32208, y = 31248, z = 14}, false, true)
 			monster:addHealth(-monster:getHealth() + foreshockHealth, false)
@@ -51,7 +48,6 @@ function onThink(creature)
 			aftershockStage = 4
 		elseif hp <= 10 and aftershockStage == 4 then
 			aftershockHealth = creature:getHealth()
-			local from = creature:getId()
 			creature:remove()
 			local monster = Game.createMonster("aftershock", {x = 32208, y = 31248, z = 14}, false, true)
 			monster:addHealth(-monster:getHealth() + aftershockHealth, false)

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/anomaly_transform.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/anomaly_transform.lua
@@ -1,5 +1,5 @@
 function onThink(creature)
-	if not creature:isMonster() then
+	if not creature or not creature:isMonster() then
 		return false
 	end
 

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/anomaly_transform.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/anomaly_transform.lua
@@ -1,5 +1,5 @@
 function onThink(creature)
-	if not creature:isCreature() then
+	if not creature:isMonster() then
 		return false
 	end
 

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/anomaly_transform.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/anomaly_transform.lua
@@ -4,14 +4,13 @@ function onThink(creature)
 	end
 
 	local hp = (creature:getHealth() / creature:getMaxHealth()) * 100
-	local from = creature:getId()
 	if hp <= 75 and Game.getStorageValue(14322) == 0 then
 		creature:remove()
 		Game.createMonster("spark of destruction", {x = 32267, y = 31253, z = 14}, false, true)
 		Game.createMonster("spark of destruction", {x = 32274, y = 31255, z = 14}, false, true)
 		Game.createMonster("spark of destruction", {x = 32274, y = 31249, z = 14}, false, true)
 		Game.createMonster("spark of destruction", {x = 32267, y = 31249, z = 14}, false, true)
-		local monster = Game.createMonster("charged anomaly", {x = 32271, y = 31249, z = 14}, false, true)
+		Game.createMonster("charged anomaly", {x = 32271, y = 31249, z = 14}, false, true)
 		Game.setStorageValue(14322, 1)
 	elseif hp <= 50 and Game.getStorageValue(14322) == 1 then
 		creature:remove()
@@ -19,7 +18,7 @@ function onThink(creature)
 		Game.createMonster("spark of destruction", {x = 32274, y = 31255, z = 14}, false, true)
 		Game.createMonster("spark of destruction", {x = 32274, y = 31249, z = 14}, false, true)
 		Game.createMonster("spark of destruction", {x = 32267, y = 31249, z = 14}, false, true)
-		local monster = Game.createMonster("charged anomaly", {x = 32271, y = 31249, z = 14}, false, true)
+		Game.createMonster("charged anomaly", {x = 32271, y = 31249, z = 14}, false, true)
 		Game.setStorageValue(14322, 2)
 	elseif hp <= 25 and Game.getStorageValue(14322) == 2 then
 		creature:remove()
@@ -27,7 +26,7 @@ function onThink(creature)
 		Game.createMonster("spark of destruction", {x = 32274, y = 31255, z = 14}, false, true)
 		Game.createMonster("spark of destruction", {x = 32274, y = 31249, z = 14}, false, true)
 		Game.createMonster("spark of destruction", {x = 32267, y = 31249, z = 14}, false, true)
-		local monster = Game.createMonster("charged anomaly", {x = 32271, y = 31249, z = 14}, false, true)
+		Game.createMonster("charged anomaly", {x = 32271, y = 31249, z = 14}, false, true)
 		Game.setStorageValue(14322, 3)
 	elseif hp <= 5 and Game.getStorageValue(14322) == 3 then
 		creature:remove()
@@ -35,7 +34,7 @@ function onThink(creature)
 		Game.createMonster("spark of destruction", {x = 32274, y = 31255, z = 14}, false, true)
 		Game.createMonster("spark of destruction", {x = 32274, y = 31249, z = 14}, false, true)
 		Game.createMonster("spark of destruction", {x = 32267, y = 31249, z = 14}, false, true)
-		local monster = Game.createMonster("charged anomaly", {x = 32271, y = 31249, z = 14}, false, true)
+		Game.createMonster("charged anomaly", {x = 32271, y = 31249, z = 14}, false, true)
 		Game.setStorageValue(14322, 4)
 	end
 	return true

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/charging_out_death.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/charging_out_death.lua
@@ -1,6 +1,5 @@
 function onDeath(creature)
 	if chargingOutKilled == false then
-		local from = creature:getId()
 		local monster = Game.createMonster("outburst", {x = 32234, y = 31285, z = 14}, false, true)
 		monster:addHealth(-monster:getHealth() + outburstHealth, false)
 	end

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/crackler_transform.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/crackler_transform.lua
@@ -1,5 +1,5 @@
 function onThink(creature)
-	if not creature:isMonster() then
+	if not creature or not creature:isMonster() then
 		return true
 	end
 

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/crackler_transform.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/crackler_transform.lua
@@ -5,8 +5,8 @@ function onThink(creature)
 
 	if cracklerTransform == true then
 		local monster = Game.createMonster("depolarized crackler", creature:getPosition(), false, true)
-		creature:remove()
 		monster:addHealth(-monster:getHealth() + creature:getHealth(), false)
+		creature:remove()
 	end
 
 	return true

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/depolarized_transform.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/depolarized_transform.lua
@@ -1,5 +1,5 @@
 function onThink(creature)
-	if not creature:isMonster() then
+	if not creature or not creature:isMonster() then
 		return false
 	end
 

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/depolarized_transform.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/depolarized_transform.lua
@@ -1,5 +1,5 @@
 function onThink(creature)
-	if not creature:isCreature() then
+	if not creature:isMonster() then
 		return false
 	end
 

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/depolarized_transform.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/depolarized_transform.lua
@@ -4,9 +4,9 @@ function onThink(creature)
 	end
 
 	if cracklerTransform == false then
-		creature:remove()
 		local monster = Game.createMonster("Crackler", creature:getPosition(), false, true)
 		monster:addHealth(-monster:getHealth() + creature:getHealth(), false)
+		creature:remove()
 	end
 	return true
 end

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/eradicator_transform.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/eradicator_transform.lua
@@ -1,5 +1,5 @@
 function onThink(creature)
-	if not creature:isMonster() then
+	if not creature or not creature:isMonster() then
 		return false
 	end
 

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/eradicator_transform.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/eradicator_transform.lua
@@ -7,7 +7,6 @@ function onThink(creature)
 		if eradicatorWeak == 0 then
 			local pos = creature:getPosition()
 			local health = creature:getHealth()
-			local from = creature:getId()
 			creature:remove()
 
 			local monster = Game.createMonster("eradicator2", pos, false, true)
@@ -22,7 +21,6 @@ function onThink(creature)
 		elseif eradicatorWeak == 1 then
 			local pos = creature:getPosition()
 			local health = creature:getHealth()
-			local from = creature:getId()
 
 			creature:remove()
 

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/eradicator_transform.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/eradicator_transform.lua
@@ -1,5 +1,5 @@
 function onThink(creature)
-	if not creature:isCreature() then
+	if not creature:isMonster() then
 		return false
 	end
 

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/foreshock_transform.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/foreshock_transform.lua
@@ -1,5 +1,5 @@
 function onThink(creature)
-	if not creature:isMonster() then
+	if not creature or not creature:isMonster() then
 		return false
 	end
 

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/foreshock_transform.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/foreshock_transform.lua
@@ -1,5 +1,5 @@
 function onThink(creature)
-	if not creature:isCreature() then
+	if not creature:isMonster() then
 		return false
 	end
 

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/foreshock_transform.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/foreshock_transform.lua
@@ -7,7 +7,6 @@ function onThink(creature)
 	if realityQuakeStage == 0 then
 		if hp <= 80 and foreshockStage == 0 then
 			foreshockHealth = creature:getHealth()
-			local from = creature:getId()
 			creature:remove()
 			local monster = Game.createMonster("aftershock", {x = 32208, y = 31248, z = 14}, false, true)
 			monster:addHealth(-monster:getHealth() + aftershockHealth, false)
@@ -18,7 +17,6 @@ function onThink(creature)
 			foreshockStage = 1
 		elseif hp <= 60 and foreshockStage == 1 then
 			foreshockHealth = creature:getHealth()
-			local from = creature:getId()
 			creature:remove()
 			local monster = Game.createMonster("aftershock", {x = 32208, y = 31248, z = 14}, false, true)
 			monster:addHealth(-monster:getHealth() + aftershockHealth, false)
@@ -29,7 +27,6 @@ function onThink(creature)
 			foreshockStage = 2
 		elseif hp <= 40 and foreshockStage == 2 then
 			foreshockHealth = creature:getHealth()
-			local from = creature:getId()
 			creature:remove()
 			local monster = Game.createMonster("Aftershock", {x = 32208, y = 31248, z = 14}, false, true)
 			monster:addHealth(-monster:getHealth() + aftershockHealth, false)
@@ -40,7 +37,6 @@ function onThink(creature)
 			foreshockStage = 3
 		elseif hp <= 25 and foreshockStage == 3 then
 			foreshockHealth = creature:getHealth()
-			local from = creature:getId()
 			creature:remove()
 			local monster = Game.createMonster("aftershock", {x = 32208, y = 31248, z = 14}, false, true)
 			monster:addHealth(-monster:getHealth() + aftershockHealth, false)
@@ -51,7 +47,6 @@ function onThink(creature)
 			foreshockStage = 4
 		elseif hp <= 10 and foreshockStage == 4 then
 			foreshockHealth = creature:getHealth()
-			local from = creature:getId()
 			creature:remove()
 			local monster = Game.createMonster("aftershock", {x = 32208, y = 31248, z = 14}, false, true)
 			monster:addHealth(-monster:getHealth() + aftershockHealth, false)

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/heart_boss_death.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/heart_boss_death.lua
@@ -8,9 +8,9 @@ function clearDevourer()
 				if tile then
 					local creatures = tile:getCreatures()
 					if creatures and #creatures > 0 then
-						for _, c in pairs(creatures) do
-							if isMonster(c) then
-								c:remove()
+						for _, creature in pairs(creatures) do
+							if creature:isMonster() then -- éMonstro
+								creature:remove()
 							end
 						end
 					end
@@ -34,11 +34,11 @@ local function setStorageDevourer()
 				if tile then
 					local creatures = tile:getCreatures()
 					if creatures and #creatures > 0 then
-						for _, c in pairs(creatures) do
-							if isPlayer(c) then
-								c:setStorageValue(60835, 1)
-								c:setStorageValue(60814, 1)
-								c:setStorageValue(60828, 1)
+						for _, creature in pairs(creatures) do
+							if creature:isPlayer() then -- éPlayer
+								creature:setStorageValue(60835, 1)
+								creature:setStorageValue(60814, 1)
+								creature:setStorageValue(60828, 1)
 							end
 						end
 					end
@@ -60,11 +60,9 @@ local function setStorage(fromPos, toPos, storage)
 				if tile then
 					local creatures = tile:getCreatures()
 					if creatures and #creatures > 0 then
-						for _, c in pairs(creatures) do
-							if isPlayer(c) then
-								if c:getStorageValue(storage) < 1 then
-									c:setStorageValue(storage, 1) -- Access to boss Anomaly
-								end
+						for _, creature in pairs(creatures) do
+							if creature:isPlayer() and creature:getStorageValue(storage) < 1 then
+								creature:setStorageValue(storage, 1) -- Access to boss Anomaly
 							end
 						end
 					end

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/heart_minion_death.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/heart_minion_death.lua
@@ -1,5 +1,5 @@
 function onDeath(creature)
-	if not creature:isMonster() then -- éMonstro!
+	if not creature or not creature:isMonster() then -- éMonstro!
 		return true
 	end
 	local monster = creature:getName():lower()

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/heart_minion_death.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/heart_minion_death.lua
@@ -1,4 +1,7 @@
 function onDeath(creature)
+	if not creature:isMonster() then -- éMonstro!
+		return true
+	end
 	local monster = creature:getName():lower()
 	if monster == "frenzy" then
 		rageSummon = rageSummon - 1

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/outburst_charge.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/outburst_charge.lua
@@ -1,5 +1,5 @@
 function onThink(creature)
-	if not creature:isMonster() then
+	if not creature or not creature:isMonster() then
 		return false
 	end
 

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/outburst_charge.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/outburst_charge.lua
@@ -1,5 +1,5 @@
 function onThink(creature)
-	if not creature:isCreature() then
+	if not creature:isMonster() then
 		return false
 	end
 

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/outburst_charge.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/outburst_charge.lua
@@ -4,7 +4,6 @@ function onThink(creature)
 	end
 
 	local hp = (creature:getHealth() / creature:getMaxHealth()) * 100
-	local from = creature:getId()
 	if hp <= 80 and outburstStage == 0 then
 		outburstHealth = creature:getHealth()
 		creature:remove()
@@ -12,7 +11,7 @@ function onThink(creature)
 		Game.createMonster("spark of destruction", {x = 32230, y = 31287, z = 14}, false, true)
 		Game.createMonster("spark of destruction", {x = 32237, y = 31287, z = 14}, false, true)
 		Game.createMonster("spark of destruction", {x = 32238, y = 31282, z = 14}, false, true)
-		local monster = Game.createMonster("charging outburst", {x = 32234, y = 31284, z = 14}, false, true)
+		Game.createMonster("charging outburst", {x = 32234, y = 31284, z = 14}, false, true)
 		outburstStage = 1
 		chargingOutKilled = false
 	elseif hp <= 60 and outburstStage == 1 then
@@ -22,7 +21,7 @@ function onThink(creature)
 		Game.createMonster("spark of destruction", {x = 32230, y = 31287, z = 14}, false, true)
 		Game.createMonster("spark of destruction", {x = 32237, y = 31287, z = 14}, false, true)
 		Game.createMonster("spark of destruction", {x = 32238, y = 31282, z = 14}, false, true)
-		local monster = Game.createMonster("charging outburst", {x = 32234, y = 31284, z = 14}, false, true)
+		Game.createMonster("charging outburst", {x = 32234, y = 31284, z = 14}, false, true)
 		outburstStage = 2
 		chargingOutKilled = false
 	elseif hp <= 40 and outburstStage == 2 then
@@ -32,7 +31,7 @@ function onThink(creature)
 		Game.createMonster("spark of destruction", {x = 32230, y = 31287, z = 14}, false, true)
 		Game.createMonster("spark of destruction", {x = 32237, y = 31287, z = 14}, false, true)
 		Game.createMonster("spark of destruction", {x = 32238, y = 31282, z = 14}, false, true)
-		local monster = Game.createMonster("charging outburst", {x = 32234, y = 31284, z = 14}, false, true)
+		Game.createMonster("charging outburst", {x = 32234, y = 31284, z = 14}, false, true)
 		outburstStage = 3
 		chargingOutKilled = false
 	elseif hp <= 20 and outburstStage == 3 then
@@ -42,7 +41,7 @@ function onThink(creature)
 		Game.createMonster("spark of destruction", {x = 32230, y = 31287, z = 14}, false, true)
 		Game.createMonster("spark of destruction", {x = 32237, y = 31287, z = 14}, false, true)
 		Game.createMonster("spark of destruction", {x = 32238, y = 31282, z = 14}, false, true)
-		local monster = Game.createMonster("charging outburst", {x = 32234, y = 31284, z = 14}, false, true)
+		Game.createMonster("charging outburst", {x = 32234, y = 31284, z = 14}, false, true)
 		outburstStage = 4
 		chargingOutKilled = false
 	end

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/overcharge_death.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/overcharge_death.lua
@@ -12,7 +12,7 @@ local function setStorage()
 					local creatures = tile:getCreatures()
 					if creatures and #creatures > 0 then
 						for _, creature in pairs(creatures) do
-							if creature:isPlayer() and creature:getStorageValue(14320) < 1then
+							if creature:isPlayer() and creature:getStorageValue(14320) < 1 then
 								creature:setStorageValue(14320, 1) -- Access to boss Anomaly
 							end
 						end

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/overcharge_death.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/overcharge_death.lua
@@ -11,11 +11,9 @@ local function setStorage()
 				if tile then
 					local creatures = tile:getCreatures()
 					if creatures and #creatures > 0 then
-						for _, c in pairs(creatures) do
-							if isPlayer(c) then
-								if c:getStorageValue(14320) < 1 then
-									c:setStorageValue(14320, 1) -- Access to boss Anomaly
-								end
+						for _, creature in pairs(creatures) do
+							if creature:isPlayer() and creature:getStorageValue(14320) < 1then
+								creature:setStorageValue(14320, 1) -- Access to boss Anomaly
 							end
 						end
 					end
@@ -36,11 +34,9 @@ local function setStorage()
 				if tile then
 					local creatures = tile:getCreatures()
 					if creatures and #creatures > 0 then
-						for _, c in pairs(creatures) do
-							if isPlayer(c) then
-								if c:getStorageValue(14320) < 1 then
-									c:setStorageValue(14320, 1) -- Access to boss Anomaly
-								end
+						for _, creature in pairs(creatures) do
+							if creature:isPlayer() and creature:getStorageValue(14320) < 1 then -- hardcoded storges
+								creature:setStorageValue(14320, 1) -- Access to boss Anomaly
 							end
 						end
 					end

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/rupture_heal.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/rupture_heal.lua
@@ -1,8 +1,8 @@
 function onHealthChange(creature, attacker, primaryDamage, primaryType, secondaryDamage, secondaryType, origin)
-	local healthGain = math.random(5000,10000)
+	local healthGain = math.random(5000, 10000)
 	if attacker and attacker:isPlayer() and resonanceActive == true then
 		creature:addHealth(healthGain)
-		creature:getPosition():sendMagicEffect(15)
+		creature:getPosition():sendMagicEffect(CONST_ME_MAGIC_GREEN)
 	end
 	return primaryDamage, primaryType, secondaryDamage, secondaryType
 end

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/rupture_resonance.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/rupture_resonance.lua
@@ -1,6 +1,5 @@
 function onThink(creature)
-
-	if not creature:isMonster() then
+	if not creature or not creature:isMonster() then
 		return false
 	end
 

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/rupture_resonance.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/rupture_resonance.lua
@@ -1,6 +1,6 @@
 function onThink(creature)
 
-	if not creature:isCreature() then
+	if not creature:isMonster() then
 		return false
 	end
 

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/shocks_death.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/shocks_death.lua
@@ -1,5 +1,5 @@
 function onDeath(creature)
-	if not creature:isMonster() then
+	if not creature or not creature:isMonster() then
 		return true
 	end
 

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/shocks_death.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/shocks_death.lua
@@ -1,9 +1,11 @@
 function onDeath(creature)
+	if not creature:isMonster() then
+		return true
+	end
 
 	local name = creature:getName():lower()
 	if name == "foreshock" and realityQuakeStage == 0 then
 		if realityQuakeStage == 0 then
-			local from = creature:getId()
 			local monster = Game.createMonster("aftershock", {x = 32208, y = 31248, z = 14}, false, true)
 			monster:addHealth(-monster:getHealth() + aftershockHealth, false)
 			Game.createMonster("spark of destruction", {x = 32203, y = 31246, z = 14}, false, true)
@@ -12,7 +14,6 @@ function onDeath(creature)
 			Game.createMonster("spark of destruction", {x = 32212, y = 31246, z = 14}, false, true)
 		end
 	elseif name == "aftershock" and realityQuakeStage == 0 then
-		local from = creature:getId()
 		local monster = Game.createMonster("foreshock", {x = 32208, y = 31248, z = 14}, false, true)
 		monster:addHealth(-monster:getHealth() + aftershockHealth, false)
 		Game.createMonster("spark of destruction", {x = 32203, y = 31246, z = 14}, false, true)
@@ -23,7 +24,6 @@ function onDeath(creature)
 	realityQuakeStage = realityQuakeStage + 1
 
 	if realityQuakeStage == 2 then
-		local from = creature:getId()
 		local pos = creature:getPosition()
 		local monster = Game.createMonster("realityquake", pos, false, true)
 		Game.createMonster("spark of destruction", {x = 32203, y = 31246, z = 14}, false, true)

--- a/data/creaturescripts/scripts/quests/heart_of_destruction/spark_death.lua
+++ b/data/creaturescripts/scripts/quests/heart_of_destruction/spark_death.lua
@@ -9,11 +9,9 @@ local function setStorage()
 				if tile then
 					local creatures = tile:getCreatures()
 					if creatures and #creatures > 0 then
-						for _, c in pairs(creatures) do
-							if isPlayer(c) then
-								if c:getStorageValue(14324) < 1 then
-									c:setStorageValue(14324, 1) -- Access to boss realityquake
-								end
+						for _, creature in pairs(creatures) do
+							if creature:isPlayer() and creature:getStorageValue(14324) < 1 then -- hardcoded storges
+								creature:setStorageValue(14324, 1) -- Access to boss realityquake
 							end
 						end
 					end

--- a/data/movements/scripts/quests/heart_of_destruction/teleport_heart.lua
+++ b/data/movements/scripts/quests/heart_of_destruction/teleport_heart.lua
@@ -61,9 +61,10 @@ function onStepIn(creature, item, position, fromPosition)
 	end
 
 	local normalVortex = vortex[item.actionid]
+	local bossVortex = accessVortex[item.actionid]
+	local uBosses = finalBosses[item.actionid]
 	if normalVortex then
 		player:teleportTo(normalVortex)
-	local bossVortex = accessVortex[item.actionid]
 	elseif bossVortex then
 		if player:getStorageValue(bossVortex.storage) >= 1 then
 			if player:getStorageValue(bossVortex.storageTime) < os.time() then
@@ -76,7 +77,6 @@ function onStepIn(creature, item, position, fromPosition)
 			player:teleportTo(fromPosition)
 			player:sendTextMessage(19, "You don't have access to this portal.")
 		end
-	local uBosses = finalBosses[item.actionid]
 	elseif uBosses then
 		if player:getStorageValue(uBosses.storage1) >= 1
 		and player:getStorageValue(uBosses.storage2) >= 1

--- a/data/movements/scripts/quests/heart_of_destruction/vortex_anomaly.lua
+++ b/data/movements/scripts/quests/heart_of_destruction/vortex_anomaly.lua
@@ -1,6 +1,6 @@
 function onStepIn(creature, item, position, fromPosition)
 	if item.itemid == 25550 then
-		if isMonster(creature) then
+		if creature:isMonster() then
 			if creature:getName():lower() == "charged anomaly" then
 				creature:addHealth(-6000, true, COMBAT_DROWNDAMAGE)
 			end

--- a/data/movements/scripts/quests/heart_of_destruction/vortex_crackler.lua
+++ b/data/movements/scripts/quests/heart_of_destruction/vortex_crackler.lua
@@ -37,7 +37,7 @@ function onStepIn(creature, item, position, fromPosition)
 			local storePlayers, playerTile = {}
 			for i = 1, #positions1 do
 				playerTile = Tile(positions1[i]):getTopCreature()
-				if isPlayer(playerTile) then
+				if playerTile:isPlayer() then
 					storePlayers[#storePlayers + 1] = playerTile
 				end
 			end
@@ -48,7 +48,7 @@ function onStepIn(creature, item, position, fromPosition)
 			local storePlayers, playerTile = {}
 			for i = 1, #positions2 do
 				playerTile = Tile(positions2[i]):getTopCreature()
-				if isPlayer(playerTile) then
+				if playerTile:isPlayer() then
 					storePlayers[#storePlayers + 1] = playerTile
 				end
 			end
@@ -59,7 +59,7 @@ function onStepIn(creature, item, position, fromPosition)
 			local storePlayers, playerTile = {}
 			for i = 1, #positions3 do
 				playerTile = Tile(positions3[i]):getTopCreature()
-				if isPlayer(playerTile) then
+				if playerTile:isPlayer() then
 					storePlayers[#storePlayers + 1] = playerTile
 				end
 			end
@@ -70,7 +70,7 @@ function onStepIn(creature, item, position, fromPosition)
 			local storePlayers, playerTile = {}
 			for i = 1, #positions4 do
 				playerTile = Tile(positions4[i]):getTopCreature()
-				if isPlayer(playerTile) then
+				if playerTile:isPlayer() then
 					storePlayers[#storePlayers + 1] = playerTile
 				end
 			end
@@ -78,8 +78,8 @@ function onStepIn(creature, item, position, fromPosition)
 				cracklerTransform = true
 			end
 		end
-		creature:sendTextMessage(MESSAGE_INFO_DESCR, "Your presence begins to polarize the area!")
-		creature:getPosition():sendMagicEffect(48)
+		player:sendTextMessage(MESSAGE_INFO_DESCR, "Your presence begins to polarize the area!")
+		player:getPosition():sendMagicEffect(48)
 	end
 	return true
 end

--- a/data/movements/scripts/quests/heart_of_destruction/vortex_hunger.lua
+++ b/data/movements/scripts/quests/heart_of_destruction/vortex_hunger.lua
@@ -5,7 +5,7 @@ function onStepIn(creature, item, position, fromPosition)
 	end
 
 	if item.itemid == 26125 then
-		if creature:getName():lower() == "the hunger" then
+		if monster:getName():lower() == "the hunger" then
 			local tile = Tile({x = 32244, y = 31371, z = 14})
 			if tile then
 				local ground = tile:getGround()
@@ -14,7 +14,7 @@ function onStepIn(creature, item, position, fromPosition)
 					ground:decay()
 				end
 			end
-		elseif creature:getName():lower() == "world devourer" then
+		elseif monster:getName():lower() == "world devourer" then
 			local tile = Tile({x = 32271, y = 31346, z = 14})
 			if tile then
 				local ground = tile:getGround()
@@ -25,12 +25,10 @@ function onStepIn(creature, item, position, fromPosition)
 			end
 		end
 	elseif item.itemid == 26126 then
-		if isMonster(creature) then
-			if creature:getName():lower() == "greed" then
-				creature:remove()
-				hungerSummon = hungerSummon - 1
-				devourerSummon = devourerSummon - 1
-			end
+		if monster:getName():lower() == "greed" then
+			monster:remove()
+			hungerSummon = hungerSummon - 1
+			devourerSummon = devourerSummon - 1
 		end
 	end
 	return true


### PR DESCRIPTION
Remove unused variable from aftershock_transform
Remove unused variable from anomaly_transform
Remove unused variable from charging_out_death
Move creature:remove() to the end of the file on crackler_transform and depolarized_transform
Remove unused variable from eradicator_transform
Remove unused variable from foreshock_transform
Change few checks at heart_boss_death
Check if creature is a monster before taking and process its name at heart_minion_death
Remove unused variable from outburst_charge
Change few checks at overcharge_death
Hardcoded magic effect at rupture_heal
Check if it's monster at rupture_resonance
Remove unused variables at shocks_death