### PR TITLE
Don't force summon creature resolves #1423

### DIFF
--- a/data/spells/scripts/summon/summon creature.lua
+++ b/data/spells/scripts/summon/summon creature.lua
@@ -30,7 +30,7 @@ function onCastSpell(player, variant)
 	end
 
 	local position = player:getPosition()
-	local summon = Game.createMonster(monsterName, position, true, true)
+	local summon = Game.createMonster(monsterName, position, true, false)
 	if not summon then
 		player:sendCancelMessage(RETURNVALUE_NOTENOUGHROOM)
 		position:sendMagicEffect(CONST_ME_POFF)


### PR DESCRIPTION
If the force variable is set to true, the game will place a monster on the same position as the player, even if there is not enough room.

Resolves #1423 