### PR TITLE
Fix possible crash on addGuild

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6520,6 +6520,9 @@ Guild* Game::getGuild(uint32_t id) const
 
 void Game::addGuild(Guild* guild)
 {
+  if (!guild) {
+    return;
+  }
 	guilds[guild->getId()] = guild;
 }
 


### PR DESCRIPTION
I've managed to cast a powerful spell on this code, so, from now on, it will check if the pointer point to something before trying to add it. Do you get the point?
Extremely powerful magics happening!