### PR TITLE
Adding worldType "retro-pvp" by default

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -1,6 +1,6 @@
 -- Combat settings
--- NOTE: valid values for worldType are: "pvp", "no-pvp" and "pvp-enforced"
-worldType = "pvp"
+-- NOTE: valid values for worldType are: "pvp", "no-pvp", "pvp-enforced" and "retro-pvp"
+worldType = "retro-pvp"
 hotkeyAimbotEnabled = true
 protectionLevel = 7
 pzLocked = 60 * 1000

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1465,7 +1465,7 @@ void MagicField::onStepInField(Creature* creature)
 {
 	//remove magic walls/wild growth
 	if (id == ITEM_MAGICWALL || id == ITEM_WILDGROWTH || id == ITEM_MAGICWALL_SAFE || id == ITEM_WILDGROWTH_SAFE || isBlocking()) {
-		if (!creature->isInGhostMode()) {
+		if (!creature->isInGhostMode() && g_game.getWorldType() == WORLD_TYPE_RETRO_PVP) {
 			g_game.internalRemoveItem(this, 1);
 		}
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -667,7 +667,7 @@ void Creature::onDeath()
 		if (mostDamageCreature != lastHitCreature && mostDamageCreature != lastHitCreatureMaster) {
 			Creature* mostDamageCreatureMaster = mostDamageCreature->getMaster();
 			if (lastHitCreature != mostDamageCreatureMaster && (lastHitCreatureMaster == nullptr || mostDamageCreatureMaster != lastHitCreatureMaster)) {
-				mostDamageUnjustified = mostDamageCreature->onKilledCreature(this, false);
+				mostDamageUnjustified = mostDamageCreature->onKilledCreature(this, g_game.getWorldType() == WORLD_TYPE_RETRO_PVP);
 			}
 		}
 	}

--- a/src/game.h
+++ b/src/game.h
@@ -51,6 +51,7 @@ enum WorldType_t {
 	WORLD_TYPE_NO_PVP = 1,
 	WORLD_TYPE_PVP = 2,
 	WORLD_TYPE_PVP_ENFORCED = 3,
+	WORLD_TYPE_RETRO_PVP = 4
 };
 
 enum GameState_t {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1791,6 +1791,7 @@ void LuaScriptInterface::registerFunctions()
 	registerEnum(WORLD_TYPE_NO_PVP)
 	registerEnum(WORLD_TYPE_PVP)
 	registerEnum(WORLD_TYPE_PVP_ENFORCED)
+	registerEnum(WORLD_TYPE_RETRO_PVP)
 
 	// Use with container:addItem, container:addItemEx and possibly other functions.
 	registerEnum(FLAG_NOLIMIT)

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -272,6 +272,8 @@ void mainLoader(int, char*[], ServiceManager* services) {
 		g_game.setWorldType(WORLD_TYPE_NO_PVP);
 	} else if (worldType == "pvp-enforced") {
 		g_game.setWorldType(WORLD_TYPE_PVP_ENFORCED);
+	} else if (worldType == "retro-pvp") {
+		g_game.setWorldType(WORLD_TYPE_RETRO_PVP);
 	} else {
 		std::cout << std::endl;
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2042,9 +2042,12 @@ void Player::death(Creature* lastHitCreature)
 			}
 		}
 		bool pvpDeath = false;
-		if(playerDmg > 0 || othersDmg > 0){
-			pvpDeath = (Player::lastHitIsPlayer(lastHitCreature) || playerDmg / (playerDmg + static_cast<double>(othersDmg)) >= 0.05);
+		bool deathPlayer = false;
+		if (playerDmg > 0 || othersDmg > 0) {
+			pvpDeath = (g_game.getWorldType() != WORLD_TYPE_RETRO_PVP && (Player::lastHitIsPlayer(lastHitCreature) || playerDmg / (playerDmg + static_cast<double>(othersDmg)) >= 0.05));
+			deathPlayer = (Player::lastHitIsPlayer(lastHitCreature) || playerDmg / (playerDmg + static_cast<double>(othersDmg)) >= 0.05);
 		}
+
 		if (pvpDeath && sumLevels > level) {
 			double reduce = level / static_cast<double>(sumLevels);
 			unfairFightReduction = std::max<uint8_t>(20, std::floor((reduce * 100) + 0.5));
@@ -2060,6 +2063,10 @@ void Player::death(Creature* lastHitCreature)
 		}
 
 		sumMana += manaSpent;
+
+		if (g_game.getWorldType() == WORLD_TYPE_RETRO_PVP && getSkull() == SKULL_WHITE) {
+			setSkull(SKULL_NONE);
+		}
 
 		double deathLossPercent = getLostPercent() * (unfairFightReduction / 100.);
 
@@ -3586,8 +3593,8 @@ void Player::onAttackedCreature(Creature* target)
 	}
 
 	Player* targetPlayer = target->getPlayer();
-	if (targetPlayer && !isPartner(targetPlayer) && !isGuildMate(targetPlayer)) {
-		if (!pzLocked && g_game.getWorldType() == WORLD_TYPE_PVP_ENFORCED) {
+	if (targetPlayer && (g_game.getWorldType() == WORLD_TYPE_RETRO_PVP || !isPartner(targetPlayer)) && !isGuildMate(targetPlayer)) {
+		if (!pzLocked && (g_game.getWorldType() == WORLD_TYPE_PVP_ENFORCED || g_game.getWorldType() == WORLD_TYPE_RETRO_PVP)) {
 			pzLocked = true;
 			sendIcons();
 		}
@@ -3693,14 +3700,21 @@ bool Player::onKilledCreature(Creature* target, bool lastHit/* = true*/)
 			targetPlayer->setDropLoot(false);
 			targetPlayer->setSkillLoss(false);
 		} else if (!hasFlag(PlayerFlag_NotGainInFight) && !isPartner(targetPlayer)) {
-			if (!Combat::isInPvpZone(this, targetPlayer) && hasAttacked(targetPlayer) && !targetPlayer->hasAttacked(this) && !isGuildMate(targetPlayer) && targetPlayer != this) {
-				if (targetPlayer->hasKilled(this)) {
+			bool canGainUnjust = hasAttacked(targetPlayer);
+			if (!canGainUnjust && g_game.getWorldType() == WORLD_TYPE_RETRO_PVP) {
+				canGainUnjust = lastHit;
+			}
+
+			if (!Combat::isInPvpZone(this, targetPlayer) && canGainUnjust && !targetPlayer->hasAttacked(this) && !isGuildMate(targetPlayer) && targetPlayer != this) {
+				if (targetPlayer->hasKilled(this) && hasAttacked(targetPlayer)) {
 					for (auto& kill : targetPlayer->unjustifiedKills) {
 						if (kill.target == getGUID() && kill.unavenged) {
-							kill.unavenged = false;
 							auto it = attackedSet.find(targetPlayer->guid);
-							attackedSet.erase(it);
-							break;
+							if (it != attackedSet.end()) {
+								kill.unavenged = false;
+								attackedSet.erase(it);
+								break;
+							}
 						}
 					}
 				} else if (targetPlayer->getSkull() == SKULL_NONE && !isInWar(targetPlayer)) {


### PR DESCRIPTION
This will put an end to some complaints regarding the type of world, which by default will now be retro-pvp.
Until we have the other types of worlds working normally, since it is very difficult to maintain compatibility between all types of world.

This related to the #1445 