### PR TITLE
Fix rate spawn

### DIFF
--- a/src/spawn.cpp
+++ b/src/spawn.cpp
@@ -91,7 +91,7 @@ bool Spawns::loadFromXml(const std::string& fromFilename)
 					centerPos.y + pugi::cast<uint16_t>(childNode.attribute("y").value()),
 					centerPos.z
 				);
-				uint32_t interval = pugi::cast<uint32_t>(childNode.attribute("spawntime").value()) * 1000;
+				uint32_t interval = pugi::cast<uint32_t>(childNode.attribute("spawntime").value()) * 1000 / g_config.getNumber(ConfigManager::RATE_SPAWN);
 				if (interval > MINSPAWN_INTERVAL) {
 					spawn.addMonster(nameAttribute.as_string(), pos, dir, interval);
 				} else {


### PR DESCRIPTION
Fix #1454

After this PR, rateSpawn in config.lua let it work properly.

For example, a monster appears every 90 seconds, when rateSpawn = 2, it will appear every 45 seconds