### PR TITLE
Feat: Cobra flask caldron

### DIFF
--- a/data/actions/actions.xml
+++ b/data/actions/actions.xml
@@ -65,6 +65,7 @@
 	<action itemid="23422" script="oramond/elevator.lua" />
 	<action itemid="23429" script="oramond/elevator.lua" />
 	<!-- others -->
+	<action fromid="36131" toid="36132" script="others/cobra_flask.lua" />	
 	<action itemid="6558" script="others/concentrated_demonic_blood.lua" />
 	<action fromid="11258" toid="11262" script="others/blessing_charms.lua" />
 	<action fromid="28036" toid="28037" script="others/blessing_charms.lua" />

--- a/data/actions/scripts/others/cobra_flask.lua
+++ b/data/actions/scripts/others/cobra_flask.lua
@@ -1,0 +1,14 @@
+function onUse(player, item, fromPosition, target, toPosition, isHotkey)
+	if (item.itemid == 36132) and (target.itemid == 3007) then
+		item:transform(36131)
+		target:transform(3008)
+		target:decay()
+		return
+	elseif (item.itemid == 36131) and ((target.itemid == 36119) or (target.itemid == 36120) or (target.itemid == 36121) or (target.itemid == 36122)) then 
+		doSendMagicEffect(target:getPosition(), CONST_ME_GREENSMOKE)
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You carefully pour just a tiny, little, finely dosed... and there goes the whole content of the bottle. Stand back!")
+		item:transform(36132)
+		setGlobalStorageValue(GlobalStorage.CobraBastionFlask, os.time() + 1800) -- 30 minutes
+	end
+	return
+end

--- a/data/lib/core/storages.lua
+++ b/data/lib/core/storages.lua
@@ -2258,7 +2258,8 @@ GlobalStorage = {
 	TheMummysCurse = 65008,
 	OberonEventTime = 65009,
 	PrinceDrazzakEventTime = 65010,
-	ScarlettEtzelEventTime = 65011
+	ScarlettEtzelEventTime = 65011,
+	CobraBastionFlask = 65012
 }
 
 

--- a/data/monster/humans/cobra_assassin.xml
+++ b/data/monster/humans/cobra_assassin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Cobra Assassin" nameDescription="a cobra assassin" race="blood" experience="7560" speed="280">
+<monster name="Cobra Assassin" nameDescription="a cobra assassin" race="blood" experience="7560" speed="280" script="flask.lua">
 	<health now="8200" max="8200" />
 	<look type="1217" head="2" body="2" legs="77" feet="1" addons="1" corpse="36382" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/humans/cobra_scout.xml
+++ b/data/monster/humans/cobra_scout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Cobra Scout" nameDescription="a cobra scout" race="blood" experience="7920" speed="300">
+<monster name="Cobra Scout" nameDescription="a cobra scout" race="blood" experience="7920" speed="300" script="flask.lua">
 	<health now="8500" max="8500" />
 	<look type="1217" head="1" body="1" legs="101" feet="78" addons="2" corpse="36470" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/humans/cobra_vizier.xml
+++ b/data/monster/humans/cobra_vizier.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<monster name="Cobra Vizier" nameDescription="a cobra vizier" race="blood" experience="7920" speed="320">
+<monster name="Cobra Vizier" nameDescription="a cobra vizier" race="blood" experience="7920" speed="320" script="flask.lua">
 	<health now="8500" max="8500" />
 	<look type="1217" head="19" body="19" legs="86" feet="19" addons="0" corpse="36474" />
 	<targetchange interval="4000" chance="10" />

--- a/data/monster/scripts/flask.lua
+++ b/data/monster/scripts/flask.lua
@@ -3,10 +3,8 @@ function onThink(monster, creature, type, message)
 		return
 	end
 	if monster:getStorageValue(GlobalStorage.CobraBastionFlask) < 0 then -- Reutilizing storage value
-		local percentageHealth = monster:getMaxHealth() * (7/10)
-		if monster:getHealth() > percentageHealth then
-			monster:setHealth(percentageHealth)
-		end
+		local percentageHealth = monster:getHealth() * (7/10)
+		monster:setHealth(percentageHealth)
 		doSendMagicEffect(monster:getPosition(), CONST_ME_GREENSMOKE)
 		monster:setStorageValue(GlobalStorage.CobraBastionFlask, 0) -- Reutilizing storage value
 	end

--- a/data/monster/scripts/flask.lua
+++ b/data/monster/scripts/flask.lua
@@ -1,0 +1,13 @@
+function onThink(monster, creature, type, message)
+	if getGlobalStorageValue(GlobalStorage.CobraBastionFlask) < os.time() then
+		return
+	end
+	if monster:getStorageValue(GlobalStorage.CobraBastionFlask) < 0 then -- Reutilizing storage value
+		local percentageHealth = monster:getMaxHealth() * (7/10)
+		if monster:getHealth() > percentageHealth then
+			monster:setHealth(percentageHealth)
+		end
+		doSendMagicEffect(monster:getPosition(), CONST_ME_GREENSMOKE)
+		monster:setStorageValue(GlobalStorage.CobraBastionFlask, 0) -- Reutilizing storage value
+	end
+end


### PR DESCRIPTION
- After using `flask with snake poison` on the `Large Cauldron`, the Cobra monsters will get a debuff on their health for the next 30 minutes.
https://tibia.fandom.com/wiki/Flask_with_Snake_Poison

- To properly work, a map change need to be done too **at position {x = 33399, y = 32662, z = 5}:** 

1. Large caldron itemID: from **ID** 36119 to **ID** 36122. (4 raw parts)
2. Empty flask itemID: 36132.

![caldron](https://user-images.githubusercontent.com/66353315/89466241-d424fe00-d749-11ea-8b6b-957874cb0932.png)
Works better when testing with a regular character.
The flask is a daily respawn, so it should be on the map.