### PR TITLE
Fix: NPC speechbubble

### DIFF
--- a/data/npc/lib/npcsystem/npchandler.lua
+++ b/data/npc/lib/npcsystem/npchandler.lua
@@ -384,7 +384,7 @@ if NpcHandler == nil then
 					npc:setSpeechBubble(2)
 				end
 			else
-				if self:getMessage(MESSAGE_GREET) then
+				if self:getMessage(MESSAGE_GREET) and npc:getSpeechBubble() < 1 then
 					npc:setSpeechBubble(1)
 				end
 			end


### PR DESCRIPTION
It only solves one out of two issues reported on #1379.
- If the user choose a custom NPC speechbubble, now it will be working properly on startup or if  player leave the screen.
![image](https://user-images.githubusercontent.com/66353315/89918505-7d4b7880-dbd0-11ea-9a79-08318adfb043.png)
