### PR TITLE
Fix  'getCorpseOwner' (a nil value)

### DIFF
--- a/data/modules/scripts/quickloot/quickloot.lua
+++ b/data/modules/scripts/quickloot/quickloot.lua
@@ -126,7 +126,7 @@ function onRecvbyte(player, msg, byte)
 		end
 
 		local thing = itemTile:getThing(stackPos)
-		if thing then
+		if thing and thing:isItem() then
 			local corpseOwner = thing:getCorpseOwner()
 			if corpseOwner ~= 0 and not player:canOpenCorpse(corpseOwner) then
 				player:sendCancelMessage("You are not the owner.")


### PR DESCRIPTION
Fix for error that method nil in quickloot.lua:130.

The problem is that we are trying to use a function that only exists inside the class Item and we are not checking if the 'thing' that we are picking is an item prior to that.
If the monster doesn't have a corpse it will trigger this error.