### PR TITLE
Todos os monstros do server no Prey System, já separados por categorias.

### DIFF
--- a/data/globalevents/scripts/others/startup.lua
+++ b/data/globalevents/scripts/others/startup.lua
@@ -1,4 +1,7 @@
 function onStartup()
+	print(">> Loading new prey list monsters")
+		dofile('data/modules/scripts/prey_system/preyMonsters.lua')
+	
 	print(">> Loading map attributes")
 	-- Npc table
 	loadLuaNpcs(NpcTable)

--- a/data/modules/scripts/prey_system/prey.lua
+++ b/data/modules/scripts/prey_system/prey.lua
@@ -6,6 +6,8 @@ Prey = {
 	LastUpdate = "18/07/20",
 }
 
+dofile('data/modules/scripts/prey_system/prey_categories.lua') -- carregar lista de monstros
+
 CONST_PREY_SLOT_FIRST = 0
 CONST_PREY_SLOT_SECOND = 1
 CONST_PREY_SLOT_THIRD = 2
@@ -69,39 +71,6 @@ Prey.Bonuses = {
 	[CONST_BONUS_DAMAGE_REDUCTION] = {12, 14, 16, 18, 20, 22, 24, 26, 28, 30},
 	[CONST_BONUS_XP_BONUS] = {13, 16, 19, 22, 25, 28, 31, 34, 37, 40},
 	[CONST_BONUS_IMPROVED_LOOT] = {13, 16, 19, 22, 25, 28, 31, 34, 37, 40}
-}
-
-Prey.MonsterList = {
-	[CONST_MONSTER_TIER_BRONZE] = {
-		"Rotworm", "Carrion Worm", "Skeleton", "Ghoul", "Cyclops", "Cyclops Drone", "Cyclops Smith", "Dark Magician",
-		"Beholder", "Dragon", "Dragon Hatchling", "Dwarf", "Dwarf Guard", "Dwarf Geomancer", "Dwarf Soldier",
-		"Earth Elemental", "Fire Elemental", "Gargoyle", "Merlkin", "Minotaur", "Minotaur Guard", "Minotaur Mage",
-		"Minotaur Archer", "Nomad", "Amazon", "Hunter", "Orc", "Orc Berserker", "Orc Leader", "Orc Shaman",
-		"Orc Spearman", "Orc Warlord", "Panda", "Rotworm Queen", "Tarantula", "Scarab", "Skeleton Warrior", "Smuggler"
-	},
-	[CONST_MONSTER_TIER_SILVER] = {
-		"Pirate Buccaneer", "Pirate Ghost", "Pirate Marauder", "Pirate Skeleton", "Dragon Lord Hatchling",
-		"Frost Dragon Hatchling", "Behemoth", "Faun", "Dark Faun", "Dragon Lord", "Frost Dragon", "Hydra", "Hero",
-		"Bullwark", "Giant Spider", "Crystal Spider", "Deepling Brawler", "Deepling Elite", "Deepling Guard",
-		"Deepling Master Librarian", "Deepling Tyrant", "Deepling Warrior", "Wyrm", "Elder Wyrm", "Fleshslicer",
-		"Frost Giant", "Ghastly Dragon", "Ice Golem", "Infernalist", "Warlock", "Lich", "Lizard Chosen",
-		"Lizard Dragon Priest", "Lizard High Guard", "Lizard Legionnaire", "Lizard Zaogun", "Massive Energy Elemental",
-		"Massive Fire Elemental", "Massive Water Elemental", "Minotaur Amazon", "Execowtioner", "Minotaur Hunter",
-		"Mooh'Tah Warrior", "Mutated Bat", "Mutated Human", "Necromancer", "Nightmare", "Nightmare Scion", "Ogre Brute",
-		"Ogre Savage", "Ogre Shaman", "Orclops Doomhauler", "Orclops Ravager", "Quara Constrictor",
-		"Quara Constrictor Scout", "Quara Hydromancer", "Quara Mantassin", "Quara Pincher", "Quara Predator",
-		"Sea Serpent", "Shaper Matriarch", "Silencer", "Spitter", "Worker Golem", "Werewolf",
-		"Hellspawn", "Shadow Tentacle", "Vampire Bride", "Dragonling", "Shock Head", "Frazzlemaw",
-	},
-	[CONST_MONSTER_TIER_GOLD] = {
-		"Plaguesmith", "Demon", "Crystal Spider", "Defiler", "Destroyer", "Diamond Servant", "Draken Elite",
-		"Draken Spellweaver", "Draken Warmaster", "Draken Abomination", "Feversleep", "Terrorsleep", "Draptor",
-		"Grim Reaper", "Guzzlemaw", "Hellfire Fighter", "Hand of Cursed Fate", "Hellhound", "Juggernaut",
-		"Sparkion", "Dark Torturer", "Undead Dragon", "Retching Horror", "Choking Fear", "Choking Fear",
-		"Shiversleep", "Sight Of Surrender", "Demon Outcast", "Blightwalker", "Grimeleech", "Vexclaw", "Grimeleech",
-		"Dawnfire Asura", "Midnight Asura", "Frost Flower Asura", "True Dawnfire Asura", "True Frost Flower Asura",
-		"True Midnight Asura"
-	}
 }
 
 -- Communication functions
@@ -180,7 +149,7 @@ function Player.createMonsterList(self)
 	-- Generating monsterList
 	local monsters = {}
 	while (#monsters ~= 9) do
-		local randomMonster = Prey.MonsterList[self:getMonsterTier()][math.random(#Prey.MonsterList[self:getMonsterTier()])]
+		local randomMonster = self:getMonsterTier()[math.random(#self:getMonsterTier()]
 		-- Verify that monster actually exists
 		if MonsterType(randomMonster) and not table.contains(monsters, randomMonster)
 		and not table.contains(repeatedList, randomMonster) then

--- a/data/modules/scripts/prey_system/preyMonsters.lua
+++ b/data/modules/scripts/prey_system/preyMonsters.lua
@@ -1,0 +1,67 @@
+local xml_monster_dir = 'data/world/otservbr-spawn.xml' -- Diretório do arquivo onde contém os monstros.
+local new_file_name = 'data/modules/scripts/prey_system/prey_AllMonsters.lua'
+local open_file = io.open(xml_monster_dir, "r")
+local writing_file = io.open(new_file_name, "w+")
+local file_read = open_file:read("*all")
+
+open_file:close()
+local monsters = {}
+	for str_match in file_read:gmatch('<monster name="(.-)"') do
+	local ret_table = monsters[str_match]
+		if ret_table then
+			monsters[str_match] = ret_table+1
+		else
+			monsters[str_match] = 1
+		end
+	end
+	
+	writing_file:write('SERVER_ALL_MONSTERS = { ')
+	
+	for monster, count in pairs(monsters) do
+		writing_file:write('"'..monster..'", ')
+	end
+	
+	writing_file:write('}')
+
+	writing_file:close()
+
+
+dofile(new_file_name)
+
+
+------------
+
+local new_file_name2 = 'data/modules/scripts/prey_system/prey_categories.lua'
+local writing_file2 = io.open(new_file_name2, "w+")
+
+local a, b, c = 0
+local txt = ''
+local BRONZE = ''
+local SILVER = ''
+local GOLD = ''
+local PLATINUM = ''
+
+
+for i = 1, #SERVER_ALL_MONSTERS do
+a = SERVER_ALL_MONSTERS[i]
+b = Creature(a)
+c = b:getMaxHealth()
+
+if c >= 4600 then
+PLATINUM = '"'..a..'", '..PLATINUM
+elseif c >= 2600 then
+GOLD =  '"'..a..'", '..GOLD
+elseif c >= 900 then
+SILVER =  '"'..a..'", '..SILVER
+elseif c < 900 then
+BRONZE =  '"'..a..'", '..BRONZE
+end
+
+end
+text = 'CONST_MONSTER_TIER_BRONZE = {'..BRONZE..'}\nCONST_MONSTER_TIER_SILVER = {'..SILVER..'}\nCONST_MONSTER_TIER_GOLD = {'..GOLD..'}\nCONST_MONSTER_TIER_PLATINUM = {'..PLATINUM..'}'
+
+
+writing_file2:write(text)
+writing_file2:close()
+
+dofile(new_file_name2)	

--- a/data/modules/scripts/prey_system/prey_categories.lua
+++ b/data/modules/scripts/prey_system/prey_categories.lua
@@ -1,0 +1,39 @@
+	CONST_MONSTER_TIER_BRONZE = {
+		"Rotworm", "Carrion Worm", "Skeleton", "Ghoul", "Cyclops", "Cyclops Drone", "Cyclops Smith", "Dark Magician",
+		"Beholder", "Dragon", "Dragon Hatchling", "Dwarf", "Dwarf Guard", "Dwarf Geomancer", "Dwarf Soldier",
+		"Earth Elemental", "Fire Elemental", "Gargoyle", "Merlkin", "Minotaur", "Minotaur Guard", "Minotaur Mage",
+		"Minotaur Archer", "Nomad", "Amazon", "Hunter", "Orc", "Orc Berserker", "Orc Leader", "Orc Shaman",
+		"Orc Spearman", "Orc Warlord", "Panda", "Rotworm Queen", "Tarantula", "Scarab", "Skeleton Warrior", "Smuggler"
+	}
+	CONST_MONSTER_TIER_SILVER = {
+		"Pirate Buccaneer", "Pirate Ghost", "Pirate Marauder", "Pirate Skeleton", "Dragon Lord Hatchling",
+		"Frost Dragon Hatchling", "Behemoth", "Faun", "Dark Faun", "Dragon Lord", "Frost Dragon", "Hydra", "Hero",
+		"Bullwark", "Giant Spider", "Crystal Spider", "Deepling Brawler", "Deepling Elite", "Deepling Guard",
+		"Deepling Master Librarian", "Deepling Tyrant", "Deepling Warrior", "Wyrm", "Elder Wyrm", "Fleshslicer",
+		"Frost Giant", "Ghastly Dragon", "Ice Golem", "Infernalist", "Warlock", "Lich", "Lizard Chosen",
+		"Lizard Dragon Priest", "Lizard High Guard", "Lizard Legionnaire", "Lizard Zaogun", "Massive Energy Elemental",
+		"Massive Fire Elemental", "Massive Water Elemental", "Minotaur Amazon", "Execowtioner", "Minotaur Hunter",
+		"Mooh'Tah Warrior", "Mutated Bat", "Mutated Human", "Necromancer", "Nightmare", "Nightmare Scion", "Ogre Brute",
+		"Ogre Savage", "Ogre Shaman", "Orclops Doomhauler", "Orclops Ravager", "Quara Constrictor",
+		"Quara Constrictor Scout", "Quara Hydromancer", "Quara Mantassin", "Quara Pincher", "Quara Predator",
+		"Sea Serpent", "Shaper Matriarch", "Silencer", "Spitter", "Worker Golem", "Werewolf",
+		"Hellspawn", "Shadow Tentacle", "Vampire Bride", "Dragonling", "Shock Head", "Frazzlemaw",
+	}
+	CONST_MONSTER_TIER_GOLD = {
+		"Plaguesmith", "Demon", "Crystal Spider", "Defiler", "Destroyer", "Diamond Servant", "Draken Elite",
+		"Draken Spellweaver", "Draken Warmaster", "Draken Abomination", "Feversleep", "Terrorsleep", "Draptor",
+		"Grim Reaper", "Guzzlemaw", "Hellfire Fighter", "Hand of Cursed Fate", "Hellhound", "Juggernaut",
+		"Sparkion", "Dark Torturer", "Undead Dragon", "Retching Horror", "Choking Fear", "Choking Fear",
+		"Shiversleep", "Sight Of Surrender", "Demon Outcast", "Blightwalker", "Grimeleech", "Vexclaw", "Grimeleech",
+		"Dawnfire Asura", "Midnight Asura", "Frost Flower Asura", "True Dawnfire Asura", "True Frost Flower Asura",
+		"True Midnight Asura"
+	}
+	CONST_MONSTER_TIER_PLATINUM = {
+		"Plaguesmith", "Demon", "Crystal Spider", "Defiler", "Destroyer", "Diamond Servant", "Draken Elite",
+		"Draken Spellweaver", "Draken Warmaster", "Draken Abomination", "Feversleep", "Terrorsleep", "Draptor",
+		"Grim Reaper", "Guzzlemaw", "Hellfire Fighter", "Hand of Cursed Fate", "Hellhound", "Juggernaut",
+		"Sparkion", "Dark Torturer", "Undead Dragon", "Retching Horror", "Choking Fear", "Choking Fear",
+		"Shiversleep", "Sight Of Surrender", "Demon Outcast", "Blightwalker", "Grimeleech", "Vexclaw", "Grimeleech",
+		"Dawnfire Asura", "Midnight Asura", "Frost Flower Asura", "True Dawnfire Asura", "True Frost Flower Asura",
+		"True Midnight Asura"
+	}


### PR DESCRIPTION
A ideia é que ao invés de ter q escrever manualmente uma lista pros monstros de rank bronze, silver, gold e platinum, o sistema identifique todos os spawns possiveis do server, e organize eles de acordo com a quantidade de hp, sendo:
BRONZE: menor que 900 
SILVER: entre 900 e 2600
GOLD: entre 2600 e 4600
PLATINUM: maior que 4600
(configuravel no modules/scripts/prey_system/preyMonsters.lua)
