### PR TITLE
Fix: moveTo parcel store inbox

### DIFF
--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -398,7 +398,7 @@ function Player:onMoveItem(item, count, fromPosition, toPosition, fromCylinder, 
 
 	local containerTo = self:getContainerById(toPosition.y-64)
 	if (containerTo) then
-		if (containerTo:getId() == ITEM_STORE_INBOX) then
+		if (containerTo:getId() == ITEM_STORE_INBOX) or (containerTo:getParent():isContainer() and containerTo:getParent():getId() == ITEM_STORE_INBOX) then
 			self:sendCancelMessage(RETURNVALUE_CONTAINERNOTENOUGHROOM)
 			return false
 		end


### PR DESCRIPTION
It was possible to move items to the parcel that is on the store inbox.
![moveparcel](https://user-images.githubusercontent.com/66353315/92347832-8f251c00-f0a7-11ea-91b6-efb1d2faf05e.gif)
