### PR TITLE
Fix: magic converter gold

### DIFF
--- a/data/actions/scripts/others/magic_gold_converter.lua
+++ b/data/actions/scripts/others/magic_gold_converter.lua
@@ -1,6 +1,37 @@
-local converterIds = {
-	[32109] = 33299,[33299] = 32109, -- transformar items magic gold converter ativo/inativo
+local data = {
+	converterIds = {
+		[32109] = 33299,
+		[33299] = 32109,
+		},
+	coins = {
+		[ITEM_GOLD_COIN] = ITEM_PLATINUM_COIN,
+		[ITEM_PLATINUM_COIN] = ITEM_CRYSTAL_COIN
+		}
 }
+
+local function finditem(self, cylinder, conv)
+	if cylinder == 0 then
+		cylinder = self:getSlotItem(CONST_SLOT_BACKPACK)
+		finditem(self, self:getSlotItem(CONST_SLOT_STORE_INBOX), conv)
+	end
+	if cylinder and cylinder:isContainer() then
+		for fromid, toid in pairs(data.coins) do
+			for i = 0, cylinder:getSize() - 1 do
+				local item = cylinder:getItem(i)
+				if item:isContainer() then
+					finditem(self, Container(item.uid), conv)		
+				elseif item:getId() == fromid and item:getCount() == 100 then
+					item:remove()
+					if not(cylinder:addItem(toid, 1)) then
+						player:addItem(toid, 1)
+					end
+					conv:setAttribute(ITEM_ATTRIBUTE_CHARGES,(conv:getAttribute(ITEM_ATTRIBUTE_CHARGES)-1))
+					break
+				end
+			end
+		end
+	end
+end
 
 local function start_converter(pid, itemid)
 	local player = Player(pid)
@@ -11,19 +42,10 @@ local function start_converter(pid, itemid)
 			if item:hasAttribute(ITEM_ATTRIBUTE_CHARGES) then
 				local charges_n = item:getAttribute(ITEM_ATTRIBUTE_CHARGES)
 				if charges_n >= 1 then
-					local quickLootBackpacks = player:getQuickLootBackpacks()
-					if player:getItemCount(ITEM_GOLD_COIN) >= 100 then
-						player:removeItem(ITEM_GOLD_COIN, 100)
-						local platitem = player:addItem(ITEM_PLATINUM_COIN, 1)
-						item:setAttribute(ITEM_ATTRIBUTE_CHARGES,(charges_n-1))
-						lootItem(player, quickLootBackpacks, platitem)
-					elseif player:getItemCount(ITEM_PLATINUM_COIN) >= 100 then
-						player:removeItem(ITEM_PLATINUM_COIN, 100)
-						local ccitem = player:addItem(ITEM_CRYSTAL_COIN, 1)
-						item:setAttribute(ITEM_ATTRIBUTE_CHARGES,(charges_n-1))
-						lootItem(player, quickLootBackpacks, ccitem)
+					if player:getItemCount(ITEM_GOLD_COIN) >= 100 or player:getItemCount(ITEM_PLATINUM_COIN) >= 100 then
+						finditem(player, 0, item)
 					end
-					local converting = addEvent(start_converter, 200, pid, itemid)
+					local converting = addEvent(start_converter, 300, pid, itemid)
 				else
 					item:remove(1)
 					stopEvent(converting)
@@ -37,8 +59,8 @@ local function start_converter(pid, itemid)
 end
 
 function onUse(player, item, fromPosition, target, toPosition, isHotkey)
-		item:transform(converterIds[item.itemid])
-		item:decay() 
+		item:transform(data.converterIds[item.itemid])
+		item:decay()
 		start_converter(player:getId(), 33299)
 	return true
 end


### PR DESCRIPTION
Resolves #1704
The converted coin goes to the old coin container. Ex:
- When player have 100 gold coin on any container and turn on the converter, 1 platinum will be add to that specific container.