### PR TITLE
Fix: The Annihilator Quest

### DIFF
--- a/data/scripts/actions/quests/annihilator/lever.lua
+++ b/data/scripts/actions/quests/annihilator/lever.lua
@@ -43,15 +43,15 @@ function lever.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 
 			storePlayers[#storePlayers + 1] = playerTile
 		end
+		local specsP = Game.getSpectators(config.centerDemonRoomPosition, false, true, 3, 3, 2, 2)
+		if #specsP ~= 0 then
+				player:sendTextMessage(MESSAGE_STATUS_SMALL, "A team is already inside the quest room.")
+				return true
+		end
 
 		local specs, spec = Game.getSpectators(config.centerDemonRoomPosition, false, false, 3, 3, 2, 2)
 		for i = 1, #specs do
 			spec = specs[i]
-			if spec:isPlayer() then
-				player:sendTextMessage(MESSAGE_STATUS_SMALL, "A team is already inside the quest room.")
-				return true
-			end
-
 			spec:remove()
 		end
 


### PR DESCRIPTION
With the old model, he checked each of the spectators, if he was a player, he stopped the check, if he was a monster, he removed it, the problem is that not always the first one to be checked was a monster, so the script removed some monsters that the previous team should be killing.
Now he first checks for players, and if not, he removes all monsters.