### PR TITLE
Fix miscount of bestiary count when summon dies with master

### DIFF
--- a/data/scripts/creaturescripts/others/bestiary_kill.lua
+++ b/data/scripts/creaturescripts/others/bestiary_kill.lua
@@ -1,6 +1,6 @@
 local bestiaryOnKill = CreatureEvent("BestiaryOnKill")
 function bestiaryOnKill.onKill(player, creature, lastHit)
-	if not player:isPlayer() or not creature:isMonster() or creature:getMaster() or creature:isPlayer() then
+	if not player:isPlayer() or not creature:isMonster() or creature:hasBeenSummoned() or creature:isPlayer() then
 		return true
 	end
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1145,6 +1145,9 @@ void Creature::onGainExperience(uint64_t gainExp, Creature* target)
 }
 
 bool Creature::setMaster(Creature* newMaster) {
+	// Persists if this creature has ever been a summon
+	this->summoned = true;
+
 	if (!newMaster && !master) {
 		return false;
 	}

--- a/src/creature.h
+++ b/src/creature.h
@@ -296,6 +296,12 @@ class Creature : virtual public Thing
 		bool isSummon() const {
 			return master != nullptr;
 		}
+		/**
+		 * hasBeenSummoned doesn't guarantee master still exists
+		 */ 
+		bool hasBeenSummoned() const {
+			return summoned;
+		}
 		Creature* getMaster() const {
 			return master;
 		}
@@ -504,6 +510,16 @@ class Creature : virtual public Thing
 		Creature* attackedCreature = nullptr;
 		Creature* master = nullptr;
 		Creature* followCreature = nullptr;
+
+		/**
+		 * We need to persist if this creature is summon or not because when we
+		 * increment the bestiary count, the master might be gone before we can
+		 * check if this summon has a master and mistakenly count it kill.
+		 * 
+		 * @see BestiaryOnKill
+		 * @see Monster::death()
+		 */
+		bool summoned = false;
 
 		uint64_t lastStep = 0;
 		uint32_t referenceCounter = 0;

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2406,6 +2406,7 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Creature", "getDamageMap", LuaScriptInterface::luaCreatureGetDamageMap);
 
 	registerMethod("Creature", "getSummons", LuaScriptInterface::luaCreatureGetSummons);
+	registerMethod("Creature", "hasBeenSummoned", LuaScriptInterface::luaCreatureHasBeenSummoned);
 
 	registerMethod("Creature", "getDescription", LuaScriptInterface::luaCreatureGetDescription);
 
@@ -8402,6 +8403,19 @@ int LuaScriptInterface::luaCreatureGetSummons(lua_State* L)
 		setCreatureMetatable(L, -1, summon);
 		lua_rawseti(L, -2, ++index);
 	}
+	return 1;
+}
+
+int LuaScriptInterface::luaCreatureHasBeenSummoned(lua_State* L)
+{
+	// creature:hasBeenSummoned()
+	Creature* creature = getUserdata<Creature>(L, 1);
+	if (creature) {
+		pushBoolean(L, creature->hasBeenSummoned());
+	} else {
+		lua_pushnil(L);
+	}
+
 	return 1;
 }
 

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -837,6 +837,7 @@ class LuaScriptInterface
 		static int luaCreatureGetDamageMap(lua_State* L);
 
 		static int luaCreatureGetSummons(lua_State* L);
+		static int luaCreatureHasBeenSummoned(lua_State* L);
 
 		static int luaCreatureGetDescription(lua_State* L);
 


### PR DESCRIPTION
Fixes #1758.

The issue is that when a master was being killed, it removed references from the summons, which the bestiary was depending on to check if the summon was a summon or not. I think if we persist if a creature was ever a summon may solve that.