### PR TITLE
Fixed (Clear Weapons RevScripts) by reload weapons

### DIFF
--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -17430,6 +17430,7 @@ int LuaScriptInterface::luaCreateWeapon(lua_State* L)
 				pushUserdata<WeaponMelee>(L, weapon);
 				setMetatable(L, -1, "Weapon");
 				weapon->weaponType = type;
+				weapon->fromLua = true;
 			} else {
 				lua_pushnil(L);
 			}
@@ -17442,6 +17443,7 @@ int LuaScriptInterface::luaCreateWeapon(lua_State* L)
 				pushUserdata<WeaponDistance>(L, weapon);
 				setMetatable(L, -1, "Weapon");
 				weapon->weaponType = type;
+				weapon->fromLua = true;
 			} else {
 				lua_pushnil(L);
 			}
@@ -17453,6 +17455,7 @@ int LuaScriptInterface::luaCreateWeapon(lua_State* L)
 				pushUserdata<WeaponWand>(L, weapon);
 				setMetatable(L, -1, "Weapon");
 				weapon->weaponType = type;
+				weapon->fromLua = true;
 			} else {
 				lua_pushnil(L);
 			}


### PR DESCRIPTION
* Fixed (clear weapons fromLua) by reload weapons

When reloading the weapons module, the weapons created from the module (RevScripts) were deleted, this fixes it!

Credits: [@MillhioreBT](https://github.com/otland/forgottenserver/pull/3123)