### PR TITLE
Fix: 'tempo hur' paralyze

### DIFF
--- a/data/spells/scripts/support/charge.lua
+++ b/data/spells/scripts/support/charge.lua
@@ -3,7 +3,6 @@ combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MAGIC_GREEN)
 combat:setParameter(COMBAT_PARAM_AGGRESSIVE, false)
 
 local condition = Condition(CONDITION_HASTE)
-condition:setParameter(CONDITION_PARAM_SUBID, 3)
 condition:setParameter(CONDITION_PARAM_TICKS, 5000)
 condition:setFormula(0.9, -72, 0.9, -72)
 combat:addCondition(condition)


### PR DESCRIPTION
Resolves #1560
Conditions that have a custom SUBID bypass the src check 'hascondition'.

The reason why this SUBID is on 'tempo hur' is unkown, so if you know why this is set for, please leave a comment.