### PR TITLE
Fix: 'move up' stackable item

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1393,7 +1393,8 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 	}
 
 	// 'Move up' stackable items fix
-	if (item->isStackable() && count == 255) {
+	//  Cip's client never sends the count of stackables when using "Move up" menu option
+	if (item->isStackable() && count == 255 && fromCylinder->getParent() == toCylinder) {
 		count = item->getItemCount();
 	}
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1392,6 +1392,11 @@ ReturnValue Game::internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder,
 		return RETURNVALUE_NOERROR; //silently ignore move
 	}
 
+	// 'Move up' stackable items fix
+	if (item->isStackable() && count == 255) {
+		count = item->getItemCount();
+	}
+
 	//check if we can add this item
 	ReturnValue ret = toCylinder->queryAdd(index, *item, count, flags, actor);
 	if (ret == RETURNVALUE_NEEDEXCHANGE) {


### PR DESCRIPTION
Resolves #666 :O
 For some reason the client returns count = 255 even on stackable items when using the 'move up' menu function, so to fix this bug we need to recalculate the item count. As this 'move up' option is used to move all items on that specific slot to the item parent container, there is no problem using item:getCount() to move all count.