### PR TITLE
Fixing stackables not being able to be added to full containers

### DIFF
--- a/src/container.cpp
+++ b/src/container.cpp
@@ -412,12 +412,7 @@ ReturnValue Container::queryMaxCount(int32_t index, const Thing& thing, uint32_t
 		} else {
 			const Item* destItem = getItemByIndex(index);
 			if (item->equals(destItem) && destItem->getItemCount() < 100) {
-				uint32_t remainder = 100 - destItem->getItemCount();
-				n = remainder;
-				// Here is "Can we add 98 (ultra heavy) items to player?"
-				// When we could be asking "Can we add the amount players want?"
-				// if (queryAdd(index, *item, remainder, flags) == RETURNVALUE_NOERROR) {
-				// }
+				n = 100 - destItem->getItemCount();
 			}
 		}
 

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -413,12 +413,15 @@ ReturnValue Container::queryMaxCount(int32_t index, const Thing& thing, uint32_t
 			const Item* destItem = getItemByIndex(index);
 			if (item->equals(destItem) && destItem->getItemCount() < 100) {
 				uint32_t remainder = 100 - destItem->getItemCount();
-				if (queryAdd(index, *item, remainder, flags) == RETURNVALUE_NOERROR) {
-					n = remainder;
-				}
+				n = remainder;
+				// Here is "Can we add 98 (ultra heavy) items to player?"
+				// When we could be asking "Can we add the amount players want?"
+				// if (queryAdd(index, *item, remainder, flags) == RETURNVALUE_NOERROR) {
+				// }
 			}
 		}
 
+		// maxQueryCount is the limit of items I can add
 		maxQueryCount = freeSlots * 100 + n;
 		if (maxQueryCount < count) {
 			return RETURNVALUE_CONTAINERNOTENOUGHROOM;


### PR DESCRIPTION
Fixes #1748, **but I have no idea if it is the right approach**. If it's ok, I need to remove the comments from the code.

I removed a check that happened when adding stackables to a full container. The check was calculating if the player could carry the full remaining stackable amount, not what the amount the player wanted to add. 

For example, consider that the player have a container full of ropes and 1 GMP. When the player tries to add another GMP to the container, `queryAdd` tries to see if the player can carry the remaining 100-1 = 99 GMPs, even though the player just wants to add 1. In #1748 what happens is that the player doesn't have the capacity to carry the full amount of the remaining amount (99 GMPs in the example), as `queryAdd` refuses to let the player add it to the container, even though the player would have capacity for just 1 more GMP. 

I think `queryAdd` is unecessary here and I cannot tell if it breaks anything else if it's not present. I tested and if you try to add a resonable amount of items to a full container with the stack, it works. If you try to add too many (no capacity), it fails.
