### PR TITLE
Fix summon memory leak

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -409,16 +409,12 @@ void Creature::onCreatureAppear(Creature* creature, bool isLogin)
 
 void Creature::onRemoveCreature(Creature* creature, bool)
 {
-	onCreatureDisappear(creature, true);
-	if (creature == this) {
-		if (master && !master->isRemoved()) {
-			setMaster(nullptr);
-		}
-	} else if (isMapLoaded) {
-		if (creature->getPosition().z == getPosition().z) {
-			updateTileCache(creature->getTile(), creature->getPosition());
-		}
-	}
+  onCreatureDisappear(creature, true);
+  if (creature != this && isMapLoaded) {
+    if (creature->getPosition().z == getPosition().z) {
+      updateTileCache(creature->getTile(), creature->getPosition());
+    }
+  }
 }
 
 void Creature::onCreatureDisappear(const Creature* creature, bool isLogout)

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -866,6 +866,10 @@ bool Game::removeCreature(Creature* creature, bool isLogout/* = true*/)
 		spectator->onRemoveCreature(creature, isLogout);
 	}
 
+  if (creature->getMaster() && !creature->getMaster()->isRemoved()) {
+    creature->setMaster(nullptr);
+  }
+
 	creature->getParent()->postRemoveNotification(creature, nullptr, 0);
 
 	creature->removeList();


### PR DESCRIPTION
When summon disappears there's race condition in which surrounding monsters may not remove that summon from their targetlist which results in summon memory leakage and those monsters never will be in idle state again.

**Credits: @SaiyansKing**