### PR TITLE
Fix: pzLocked on field rune (PVP)

### DIFF
--- a/data/spells/spells.xml
+++ b/data/spells/spells.xml
@@ -455,18 +455,18 @@
 	</instant>
 
 	<!-- Attack Runes -->
-	<rune group="attack" spellid="26" name="Poison Field" id="2285" allowfaruse="1" charges="3" lvl="14" maglv="0" exhaustion="2000" groupcooldown="2000" blocktype="solid" script="attack/poison field.lua" />
-	<rune group="attack" spellid="91" name="Poison Bomb" id="2286" allowfaruse="1" charges="2" lvl="25" maglv="4" exhaustion="2000" groupcooldown="2000" blocktype="solid" script="attack/poison bomb.lua" />
-	<rune group="attack" spellid="32" name="Poison Wall" id="2289" allowfaruse="1" charges="4" lvl="29" maglv="5" exhaustion="2000" groupcooldown="2000" blocktype="solid" script="attack/poison wall.lua" />
-	<rune group="attack" spellid="25" name="Fire Field" id="2301" allowfaruse="1" charges="3" lvl="15" maglv="1" exhaustion="2000" groupcooldown="2000" blocktype="solid" script="attack/fire field.lua" />
-	<rune group="attack" spellid="17" name="Firebomb" id="2305" allowfaruse="1" charges="2" lvl="27" maglv="5" exhaustion="2000" groupcooldown="2000" blocktype="solid" script="attack/fire bomb.lua" />
-	<rune group="attack" spellid="28" name="Fire Wall" id="2303" allowfaruse="1" charges="4" lvl="33" maglv="6" exhaustion="2000" groupcooldown="2000" blocktype="solid" script="attack/fire wall.lua" />
+	<rune group="attack" spellid="26" name="Poison Field" id="2285" allowfaruse="1" setPzLocked="1" charges="3" lvl="14" maglv="0" exhaustion="2000" groupcooldown="2000" blocktype="solid" script="attack/poison field.lua" />
+	<rune group="attack" spellid="91" name="Poison Bomb" id="2286" allowfaruse="1" setPzLocked="1" charges="2" lvl="25" maglv="4" exhaustion="2000" groupcooldown="2000" blocktype="solid" script="attack/poison bomb.lua" />
+	<rune group="attack" spellid="32" name="Poison Wall" id="2289" allowfaruse="1" setPzLocked="1" charges="4" lvl="29" maglv="5" exhaustion="2000" groupcooldown="2000" blocktype="solid" script="attack/poison wall.lua" />
+	<rune group="attack" spellid="25" name="Fire Field" id="2301" allowfaruse="1" setPzLocked="1" charges="3" lvl="15" maglv="1" exhaustion="2000" groupcooldown="2000" blocktype="solid" script="attack/fire field.lua" />
+	<rune group="attack" spellid="17" name="Firebomb" id="2305" allowfaruse="1" setPzLocked="1" charges="2" lvl="27" maglv="5" exhaustion="2000" groupcooldown="2000" blocktype="solid" script="attack/fire bomb.lua" />
+	<rune group="attack" spellid="28" name="Fire Wall" id="2303" allowfaruse="1" setPzLocked="1" charges="4" lvl="33" maglv="6" exhaustion="2000" groupcooldown="2000" blocktype="solid" script="attack/fire wall.lua" />
 	<rune group="attack" spellid="50" name="Soulfire" id="2308" allowfaruse="1" charges="3" lvl="27" maglv="7" exhaustion="2000" groupcooldown="2000" needtarget="1" blocktype="solid" script="attack/soul fire.lua" />
 	<rune group="attack" spellid="15" name="Fireball" id="2302" allowfaruse="1" charges="5" lvl="27" maglv="4" exhaustion="2000" groupcooldown="2000" needtarget="1" blocktype="solid" script="attack/fireball.lua" />
 	<rune group="attack" spellid="16" name="Great Fireball" id="2304" allowfaruse="1" charges="4" lvl="30" maglv="4" exhaustion="2000" groupcooldown="2000" blocktype="solid" script="attack/great fireball.lua" />
-	<rune group="attack" spellid="27" name="Energy Field" id="2277" allowfaruse="1" charges="3" lvl="18" maglv="3" exhaustion="2000" groupcooldown="2000" blocktype="solid" script="attack/energy field.lua" />
-	<rune group="attack" spellid="55" name="Energybomb" id="2262" allowfaruse="1" charges="2" lvl="37" maglv="10" exhaustion="2000" groupcooldown="2000" blocktype="solid" script="attack/energy bomb.lua" />
-	<rune group="attack" spellid="33" name="Energy Wall" id="2279" allowfaruse="1" charges="4" lvl="41" maglv="9" exhaustion="2000" groupcooldown="2000" blocktype="solid" script="attack/energy wall.lua" />
+	<rune group="attack" spellid="27" name="Energy Field" id="2277" allowfaruse="1" setPzLocked="1" charges="3" lvl="18" maglv="3" exhaustion="2000" groupcooldown="2000" blocktype="solid" script="attack/energy field.lua" />
+	<rune group="attack" spellid="55" name="Energybomb" id="2262" allowfaruse="1" setPzLocked="1" charges="2" lvl="37" maglv="10" exhaustion="2000" groupcooldown="2000" blocktype="solid" script="attack/energy bomb.lua" />
+	<rune group="attack" spellid="33" name="Energy Wall" id="2279" allowfaruse="1" setPzLocked="1" charges="4" lvl="41" maglv="9" exhaustion="2000" groupcooldown="2000" blocktype="solid" script="attack/energy wall.lua" />
 	<rune group="attack" spellid="7" name="Light Magic Missile" id="2287" allowfaruse="1" charges="10" lvl="15" exhaustion="2000" groupcooldown="2000" maglv="0" needtarget="1" blocktype="solid" script="attack/light magic missile.lua" />
 	<rune group="attack" spellid="8" name="Heavy Magic Missile" id="2311" allowfaruse="1" charges="10" lvl="25" exhaustion="2000" groupcooldown="2000" maglv="3" needtarget="1" blocktype="solid" script="attack/heavy magic missile.lua" />
 	<rune group="attack" spellid="18" name="Explosion" id="2313" allowfaruse="1" charges="6" lvl="31" maglv="6" exhaustion="2000" groupcooldown="2000" blocktype="solid" script="attack/explosion.lua" />

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -524,7 +524,7 @@ bool Spell::configureSpell(const pugi::xml_node& node)
 		cooldown = pugi::cast<uint32_t>(attr.value());
 	}
 
-	if (attr = node.attribute("setPzLocked")) {
+	if ((attr = node.attribute("setPzLocked"))) {
 		pzLocked = attr.as_bool();
 	}
 

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -524,6 +524,10 @@ bool Spell::configureSpell(const pugi::xml_node& node)
 		cooldown = pugi::cast<uint32_t>(attr.value());
 	}
 
+	if (attr = node.attribute("setPzLocked")) {
+		pzLocked = attr.as_bool();
+	}
+
 	if ((attr = node.attribute("premium")) || (attr = node.attribute("prem"))) {
 		premium = attr.as_bool();
 	}
@@ -1248,6 +1252,11 @@ bool RuneSpell::executeUse(Player* player, Item* item, const Position&, Thing* t
 		g_game.transformItem(item, item->getID(), newCount);
 		player->updateSupplyTracker(item);
 	}
+
+	if (getPzOnUse() && g_game.getWorldType() == WORLD_TYPE_PVP) {
+		player->addInFightTicks(true);
+	}
+
 	return true;
 }
 

--- a/src/spells.h
+++ b/src/spells.h
@@ -251,6 +251,9 @@ class Spell : public BaseSpell
 		bool getNeedTarget() const {
 			return needTarget;
 		}
+		bool getPzOnUse() const {
+			return pzLocked;
+		}		
 		void setNeedTarget(bool n) {
 			needTarget = n;
 		}
@@ -328,6 +331,7 @@ class Spell : public BaseSpell
 		bool learnable = false;
 		bool enabled = true;
 		bool premium = false;
+		bool pzLocked = false;
 
 
 	private:


### PR DESCRIPTION
Resolves #946
 Uppon using field runes and with the world type set to 'pvp' (retro-pvp), the user should get pzlocked. Before this PR this feat was missing.

Note: By default, if a player use a field rune (ex: fire bomb rune) on another player, then the first player will get white skull, this PR only affects when the first player uses the field rune on anywhere except on another player.