### PR TITLE
Fix: Exercise Weapons Formula.

### DIFF
--- a/data/actions/scripts/others/exercise_training.lua
+++ b/data/actions/scripts/others/exercise_training.lua
@@ -44,9 +44,9 @@ local function start_train(pid,start_pos,itemid,fpos, bonusDummy, dummyId)
                             else
                                 local skillRate = getRateFromTable(skillsStages, player:getEffectiveSkillLevel(skills[itemid].id), skillRateDefault)
                                 if not bonusDummy then
-                                    player:addSkillTries(skills[itemid].id, 1*skillRate)
+                                    player:addSkillTries(skills[itemid].id, 7*skillRate)
                                 else
-                                    player:addSkillTries(skills[itemid].id, (1*skillRate)*1.1) -- 10%
+                                    player:addSkillTries(skills[itemid].id, (7*skillRate)*1.1) -- 10%
                                 end
                             end
                                 fpos:sendMagicEffect(CONST_ME_HITAREA)


### PR DESCRIPTION
Depois de fazer alguns testes no Tibia Global, verifiquei que a cada carga de uma exercise weapon, sobe-se o equivalente a 7 ataques.
*Em relaçao as wands/rods, o valor está correto.

Video demonstrando meu char do global, cada ataque com arma sobe 1.25%, e cada ataque com exercise sobe 8.75% (8.75/1.25 = 7)
https://i.imgur.com/pSVEy1L.mp4