### PR TITLE
Adding lua interface for adding outfit monster spell

### DIFF
--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -365,6 +365,13 @@ registerMonsterType.attacks = function(mtype, mask)
 					if attack.shootEffect then
 						spell:setCombatShootEffect(attack.shootEffect)
 					end
+					if attack.name == "outfit" then
+						if attack.outfit then
+							spell:setOutfit(attack.outfit)
+						elseif attack.item then
+							spell:setItem(attack.item)
+						end
+					end
 				end
 			elseif attack.script then
 				spell:setScriptName(attack.script)
@@ -478,6 +485,13 @@ registerMonsterType.defenses = function(mtype, mask)
 						end
 						if defense.shootEffect then
 							spell:setCombatshootEffect(defense.shootEffect)
+						end
+						if defense.name == "outfit" then
+							if defense.outfit then
+								spell:setOutfit(defense.outfit)
+							elseif defense.item then
+								spell:setItem(defense.item)
+							end
 						end
 					end
 				elseif defense.script then

--- a/data/scripts/monsters/magicals/marid.lua
+++ b/data/scripts/monsters/magicals/marid.lua
@@ -89,15 +89,17 @@ monster.loot = {
 	{id = "noble turban", chance = 530}
 }
 
+rabbitOutfit = {lookType = 74}
+
 monster.attacks = {
 	{name ="melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -90, effect = CONST_ME_DRAWBLOOD},
 	{name ="combat", interval = 2000, chance = 10, minDamage = -100, maxDamage = -250, type = COMBAT_ENERGYDAMAGE, range = 7, shootEffect = CONST_ANI_ENERGYBALL, target = false},
 	{name ="combat", interval = 2000, chance = 15, minDamage = -30, maxDamage = -90, type = COMBAT_LIFEDRAIN, range = 7, effect = CONST_ME_MAGIC_RED, target = false},
 	{name ="speed", interval = 2000, chance = 15, speedChange = -650, duration = 1500},
 	{name ="drunk", interval = 2000, chance = 10, range = 7, shootEffect = CONST_ANI_ENERGY, target = false},
-	{name ="outfit", interval = 2000, chance = 1},
 	{name ="combat", interval = 2000, chance = 15, range = 5, target = false},
 	{name ="combat", interval = 2000, chance = 15, minDamage = -30, maxDamage = -90, type = COMBAT_ENERGYDAMAGE, effect = CONST_ME_ENERGYHIT, target = false}
+	{name ="outfit", interval = 2000, chance = 1, range = 7, duration = 4000, outfit = rabbitOutfit, effect = CONST_ME_MAGIC_BLUE},
 }
 
 monster.defenses = {

--- a/data/scripts/monsters/magicals/marid.lua
+++ b/data/scripts/monsters/magicals/marid.lua
@@ -98,8 +98,8 @@ monster.attacks = {
 	{name ="speed", interval = 2000, chance = 15, speedChange = -650, duration = 1500},
 	{name ="drunk", interval = 2000, chance = 10, range = 7, shootEffect = CONST_ANI_ENERGY, target = false},
 	{name ="combat", interval = 2000, chance = 15, range = 5, target = false},
-	{name ="combat", interval = 2000, chance = 15, minDamage = -30, maxDamage = -90, type = COMBAT_ENERGYDAMAGE, effect = CONST_ME_ENERGYHIT, target = false}
-	{name ="outfit", interval = 2000, chance = 1, range = 7, duration = 4000, outfit = rabbitOutfit, effect = CONST_ME_MAGIC_BLUE},
+	{name ="combat", interval = 2000, chance = 15, minDamage = -30, maxDamage = -90, type = COMBAT_ENERGYDAMAGE, effect = CONST_ME_ENERGYHIT, target = false},
+	{name ="outfit", interval = 2000, chance = 1, range = 7, duration = 4000, outfit = rabbitOutfit, effect = CONST_ME_MAGIC_BLUE}
 }
 
 monster.defenses = {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -3039,6 +3039,8 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("MonsterSpell", "setConditionTickInterval", LuaScriptInterface::luaMonsterSpellSetConditionTickInterval);
 	registerMethod("MonsterSpell", "setCombatShootEffect", LuaScriptInterface::luaMonsterSpellSetCombatShootEffect);
 	registerMethod("MonsterSpell", "setCombatEffect", LuaScriptInterface::luaMonsterSpellSetCombatEffect);
+	registerMethod("MonsterSpell", "setOutfit", LuaScriptInterface::luaMonsterSpellSetOutfit);
+	registerMethod("MonsterSpell", "setItem", LuaScriptInterface::luaMonsterSpellSetItem);
 
 	// Party
 	registerClass("Party", "", LuaScriptInterface::luaPartyCreate);
@@ -15596,6 +15598,33 @@ int LuaScriptInterface::luaMonsterSpellSetCombatEffect(lua_State* L)
 	}
 	return 1;
 }
+
+int LuaScriptInterface::luaMonsterSpellSetOutfit(lua_State* L)
+{
+	// monsterSpell:setOutfit(effect)
+	MonsterSpell* spell = getUserdata<MonsterSpell>(L, 1);
+	if (spell) {
+		spell->outfit = getOutfit(L, 2);
+		pushBoolean(L, true);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaMonsterSpellSetItem(lua_State* L)
+{
+	// monsterSpell:setItem(effect)
+	MonsterSpell* spell = getUserdata<MonsterSpell>(L, 1);
+	if (spell) {
+		spell->item = getNumber<int16_t>(L, 2);
+		pushBoolean(L, true);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
 
 // Party
 int32_t LuaScriptInterface::luaPartyCreate(lua_State* L)

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1448,6 +1448,8 @@ class LuaScriptInterface
 		static int luaMonsterSpellSetConditionTickInterval(lua_State* L);
 		static int luaMonsterSpellSetCombatShootEffect(lua_State* L);
 		static int luaMonsterSpellSetCombatEffect(lua_State* L);
+		static int luaMonsterSpellSetOutfit(lua_State* L);
+		static int luaMonsterSpellSetItem(lua_State* L);
 
 		// Party
 		static int luaPartyCreate(lua_State* L);

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -663,7 +663,18 @@ bool Monsters::deserializeSpell(MonsterSpell* spell, spellBlock_t& sb, const std
 			}
 
 			ConditionOutfit* condition = static_cast<ConditionOutfit*>(Condition::createCondition(CONDITIONID_COMBAT, CONDITION_OUTFIT, duration, 0));
-			condition->setOutfit(spell->outfit);
+
+			if (spell->outfit.lookType != 0) {
+				condition->setOutfit(spell->outfit);
+			} else if (spell->item != 0) {
+				Outfit_t outfit;
+				outfit.lookTypeEx = spell->item;
+
+				condition->setOutfit(outfit);
+			} else {
+				std::cout << "[Error - Monsters::deserializeSpell] - " << description << " - No outfit or item defined for spell: " << spell->name << std::endl;
+			}
+
 			combat->setParam(COMBAT_PARAM_AGGRESSIVE, 0);
 			combat->addCondition(condition);
 		} else if (tmpName == "invisible") {

--- a/src/monsters.h
+++ b/src/monsters.h
@@ -244,7 +244,10 @@ class MonsterSpell
 		bool combatSpell = false;
 		bool isMelee = false;
 
+		// For outfit spells
 		Outfit_t outfit = {};
+		int16_t item = 0;
+
 		ShootType_t shoot = CONST_ANI_NONE;
 		MagicEffectClasses effect = CONST_ME_NONE;
 		ConditionType_t conditionType = CONDITION_NONE;


### PR DESCRIPTION
- Fixing Marid as sample of the fix
- Fixes #1857 outfit attack

I had to add the rabbit outfit directly to the Marid file, as of the moment of loading Marids, the rabbits are still not loaded into memory and I couldn't retrieve their outfits. I couldn't figure out if we have a way of loading a given monster on the fly as the control is inverted with revscripts. It'd be nice to get pointed out if there is a way or where the monsters are getting triggered to load. Maybe then I could load the required monster on the fly, as it was happening with xml.

Also, the Marid is a sample of the fix necessary for making the outfits work again. Are we considering fixing the conversion script and reimporting all monsters or we should do this manually?