### PR TITLE
Fixing monsterType register script for scripted spells

### DIFF
--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -367,7 +367,7 @@ registerMonsterType.attacks = function(mtype, mask)
 					end
 				end
 			elseif attack.script then
-				spell:setScriptName(attack.script)
+				spell:setScriptName("monster/" .. attack.script .. ".lua")
 				if attack.interval then
 					spell:setInterval(attack.interval)
 				end
@@ -481,7 +481,7 @@ registerMonsterType.defenses = function(mtype, mask)
 						end
 					end
 				elseif defense.script then
-					spell:setScriptName(defense.script)
+					spell:setScriptName("monster/" .. defense.script .. ".lua")
 					if defense.interval then
 						spell:setInterval(defense.interval)
 					end

--- a/data/scripts/monsters/magicals/marid.lua
+++ b/data/scripts/monsters/magicals/marid.lua
@@ -96,8 +96,8 @@ monster.attacks = {
 	{name ="speed", interval = 2000, chance = 15, speedChange = -650, duration = 1500},
 	{name ="drunk", interval = 2000, chance = 10, range = 7, shootEffect = CONST_ANI_ENERGY, target = false},
 	{name ="outfit", interval = 2000, chance = 1},
-	{name ="combat", interval = 2000, chance = 15, minDamage = -30, maxDamage = -90, type = COMBAT_ENERGYDAMAGE, effect = CONST_ME_ENERGYHIT, target = false}
-	{script ="djinn electrify", interval = 2000, chance = 15, range = 5},
+	{name ="combat", interval = 2000, chance = 15, minDamage = -30, maxDamage = -90, type = COMBAT_ENERGYDAMAGE, effect = CONST_ME_ENERGYHIT, target = false},
+	{script ="djinn electrify", interval = 2000, chance = 15, range = 5}
 }
 
 monster.defenses = {

--- a/data/scripts/monsters/magicals/marid.lua
+++ b/data/scripts/monsters/magicals/marid.lua
@@ -96,8 +96,8 @@ monster.attacks = {
 	{name ="speed", interval = 2000, chance = 15, speedChange = -650, duration = 1500},
 	{name ="drunk", interval = 2000, chance = 10, range = 7, shootEffect = CONST_ANI_ENERGY, target = false},
 	{name ="outfit", interval = 2000, chance = 1},
-	{name ="combat", interval = 2000, chance = 15, range = 5, target = false},
 	{name ="combat", interval = 2000, chance = 15, minDamage = -30, maxDamage = -90, type = COMBAT_ENERGYDAMAGE, effect = CONST_ME_ENERGYHIT, target = false}
+	{script ="djinn electrify", interval = 2000, chance = 15, range = 5},
 }
 
 monster.defenses = {


### PR DESCRIPTION
- Fixed Marid as sample monster with missing scripted spell

Another probable problem with the converted XML monsters.