### PR TITLE
Removing cpplint rule for tab vs spaces

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -39,6 +39,8 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         reporter: github-pr-check
+        flags: --linelength=120
+        filter: -whitespace/tab
 
     - name: cppcheck
       env:

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,1 @@
+filter=-whitespace/line_length

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,1 +1,0 @@
-filter=-whitespace/line_length


### PR DESCRIPTION
I'm removing given plenty of PRs get through with it plainly failing, and it could be nice to take it more serious.