### PR TITLE
Fix: Paralyze Rune Formula

### DIFF
--- a/data/spells/scripts/support/paralyze rune.lua
+++ b/data/spells/scripts/support/paralyze rune.lua
@@ -3,7 +3,7 @@ combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_MAGIC_RED)
 
 local condition = Condition(CONDITION_PARALYZE)
 condition:setParameter(CONDITION_PARAM_TICKS, 20000)
-condition:setFormula(-1, 45, -1, 45)
+condition:setFormula(-1, 80, -1, 80)
 combat:addCondition(condition)
 
 function onCastSpell(creature, var)


### PR DESCRIPTION
The Paralyze rune, on Tibia global, changes ur speed to 40, not 22.

A video showing this: https://imgur.com/XH6qDE2