### PR TITLE
Removing redundant flag from monsters "passive"

### DIFF
--- a/data/modules/scripts/bestiary/bestiary.lua
+++ b/data/modules/scripts/bestiary/bestiary.lua
@@ -328,7 +328,7 @@ Bestiary.sendMonsterData = function(player, msg)
 	if currentLevel > 1 then
 		msg:addU16(bestiaryMonster.CharmsPoints)
 		local attackMode = 0
-		if monster:isPassive() then
+		if not monster:isHostile() then
 			attackMode = 2
 		elseif monster:targetDistance() then
 			attackMode = 1

--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -105,9 +105,6 @@ registerMonsterType.flags = function(mtype, mask)
 		if mask.flags.pet then
 			mtype:isPet(mask.flags.pet)
 		end
-		if mask.flags.passive then
-			mtype:isPassive(mask.flags.passive)
-		end
 		if mask.flags.respawntype then
 			mtype:respawnType(mask.flags.respawntype)
 		end

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2919,7 +2919,6 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("MonsterType", "isHealthHidden", LuaScriptInterface::luaMonsterTypeIsHealthHidden);
 
 	registerMethod("MonsterType", "isPet", LuaScriptInterface::luaMonsterTypeIsPet);
-	registerMethod("MonsterType", "isPassive", LuaScriptInterface::luaMonsterTypeIsHostile);
 	registerMethod("MonsterType", "isRewardBoss", LuaScriptInterface::luaMonsterTypeIsRewardBoss);
 
 	registerMethod("MonsterType", "respawnType", LuaScriptInterface::luaMonsterTypeRespawnType);
@@ -14157,23 +14156,6 @@ int LuaScriptInterface::luaMonsterTypeIsPet(lua_State* L)
 			pushBoolean(L, monsterType->info.isPet);
 		} else {
 			monsterType->info.isPet = getBoolean(L, 2);
-			pushBoolean(L, true);
-		}
-	} else {
-		lua_pushnil(L);
-	}
-	return 1;
-}
-
-int LuaScriptInterface::luaMonsterTypeIsPassive(lua_State* L)
-{
-	// get: monsterType:isPassive() set: monsterType:isPassive(bool)
-	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
-	if (monsterType) {
-		if (lua_gettop(L) == 1) {
-			pushBoolean(L, monsterType->info.isPassive);
-		} else {
-			monsterType->info.isPassive = getBoolean(L, 2);
 			pushBoolean(L, true);
 		}
 	} else {

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1342,7 +1342,6 @@ class LuaScriptInterface
 		static int luaMonsterTypeIsHealthHidden(lua_State* L);
 
 		static int luaMonsterTypeIsPet(lua_State* L);
-		static int luaMonsterTypeIsPassive(lua_State* L);
 		static int luaMonsterTypeIsRewardBoss(lua_State* L);
 		static int luaMonsterTypeRespawnType(lua_State* L);
         static int luaMonsterTypeCanSpawn(lua_State* L);

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -693,7 +693,7 @@ bool Monster::selectTarget(Creature* creature)
 		return false;
 	}
 
-	if (isPassive() && !hasBeenAttacked(creature->getID())) {
+	if (!isHostile() && !hasBeenAttacked(creature->getID())) {
 		return false;
 	}
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -98,13 +98,13 @@ class Monster final : public Creature
 		int32_t getDefense() const override {
 			return mType->info.defense;
 		}
+
 		bool isPushable() const override {
 			return mType->info.pushable && baseSpeed != 0;
 		}
 		bool isAttackable() const override {
 			return mType->info.isAttackable;
 		}
-
 		bool canPushItems() const {
 			return mType->info.canPushItems;
 		}
@@ -116,9 +116,6 @@ class Monster final : public Creature
 		}
 		bool isPet() const {
 			return mType->info.isPet;
-		}
-		bool isPassive() const {
-			return mType->info.isPassive;
 		}
 		bool canSee(const Position& pos) const override;
 		bool canSeeInvisibility() const override {

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -856,8 +856,6 @@ MonsterType* Monsters::loadMonster(const std::string& file, const std::string& m
 				mType->info.isHostile = attr.as_bool();
 			} else if (strcasecmp(attrName, "pet") == 0) {
 				mType->info.isPet = attr.as_bool();
-			} else if (strcasecmp(attrName, "passive") == 0) {
-				mType->info.isPassive = attr.as_bool();
 			} else if (strcasecmp(attrName, "illusionable") == 0) {
 				mType->info.isIllusionable = attr.as_bool();
 			} else if (strcasecmp(attrName, "convinceable") == 0) {

--- a/src/monsters.h
+++ b/src/monsters.h
@@ -180,7 +180,6 @@ class MonsterType
 		bool hiddenHealth = false;
 		bool isBlockable = false;
 		bool isPet = false;
-		bool isPassive = false;
 		bool isRewardBoss = false;
 		bool canWalkOnEnergy = true;
 		bool canWalkOnFire = true;


### PR DESCRIPTION
- No monsters had previously used it
- The "hostile" flag already is in place