### PR TITLE
Fixing respawn type on monsters revsys

### DIFF
--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -108,8 +108,8 @@ registerMonsterType.flags = function(mtype, mask)
 		if mask.flags.passive then
 			mtype:isPassive(mask.flags.passive)
 		end
-		if mask.flags.respawntype then
-			mtype:respawnType(mask.flags.respawntype)
+		if mask.flags.respawntype or mask.flags.respawnType then
+			print("[Error - Loading monsters] Monster: \"".. mtype:name() .. "\". Deprecated flag 'respawnType', use instead table 'respawnType = { period = RespawnPeriod_t, underground = boolean}'")
 		end
 		if mask.flags.canPushCreatures ~= nil then
 			mtype:canPushCreatures(mask.flags.canPushCreatures)
@@ -167,6 +167,16 @@ registerMonsterType.strategiesTarget  = function(mtype, mask)
 		end
 		if mask.strategiesTarget.random then
 			mtype:strategiesTargetRandom(mask.strategiesTarget.random)
+		end
+	end
+end
+registerMonsterType.respawnType = function(mtype, mask)
+	if mask.respawnType then
+		if mask.respawnType.period then
+			mtype:respawnTypePeriod(mask.respawnType.period)
+		end
+		if mask.respawnType.underground then
+			mtype:respawnTypeIsUnderground(mask.respawnType.underground)
 		end
 	end
 end

--- a/data/scripts/monsters/fey/faun.lua
+++ b/data/scripts/monsters/fey/faun.lua
@@ -17,6 +17,11 @@ monster.changeTarget = {
 	chance = 10
 }
 
+monster.respawnType = {
+	period = RESPAWNPERIOD_DAY,
+	underground = false
+}
+
 monster.flags = {
 	summonable = false,
 	attackable = true,
@@ -28,7 +33,6 @@ monster.flags = {
 	canPushCreatures = false,
 	targetDistance = 1,
 	staticAttackChance = 80,
-	respawnType = RESPAWN_IN_DAY
 }
 
 monster.loot = {

--- a/src/enums.h
+++ b/src/enums.h
@@ -502,6 +502,16 @@ enum SpeechBubble_t
 	SPEECHBUBBLE_QUESTTRADER = 4,
 };
 
+enum RespawnPeriod_t {
+	RESPAWNPERIOD_ALL,
+	RESPAWNPERIOD_DAY,
+	RESPAWNPERIOD_NIGHT
+};
+
+/**
+ * @Deprecated
+ * It will be dropped with monsters. Use RespawnPeriod_t instead.
+ */
 enum SpawnType_t
 {
 	RESPAWN_IN_ALL = 0,
@@ -592,6 +602,11 @@ struct LightInfo {
 	uint8_t color = 0;
 	constexpr LightInfo() = default;
 	constexpr LightInfo(uint8_t newLevel, uint8_t newColor) : level(newLevel), color(newColor) {}
+};
+
+struct RespawnType {
+	RespawnPeriod_t period;
+	bool underground;
 };
 
 struct ShopInfo {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -1672,11 +1672,19 @@ void LuaScriptInterface::registerFunctions()
 	registerEnum(PLAYERSEX_FEMALE)
 	registerEnum(PLAYERSEX_MALE)
 
+	/**
+	 * @Deprecated
+	 * It will be dropped with monsters. Use RESPAWNPERIOD instead
+	 */
 	registerEnum(RESPAWN_IN_ALL)
 	registerEnum(RESPAWN_IN_DAY)
 	registerEnum(RESPAWN_IN_NIGHT)
 	registerEnum(RESPAWN_IN_DAY_CAVE)
 	registerEnum(RESPAWN_IN_NIGHT_CAVE)
+
+	registerEnum(RESPAWNPERIOD_ALL)
+	registerEnum(RESPAWNPERIOD_DAY)
+	registerEnum(RESPAWNPERIOD_NIGHT)
 
 	registerEnum(REPORT_REASON_NAMEINAPPROPRIATE)
 	registerEnum(REPORT_REASON_NAMEPOORFORMATTED)
@@ -2922,7 +2930,6 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("MonsterType", "isPassive", LuaScriptInterface::luaMonsterTypeIsHostile);
 	registerMethod("MonsterType", "isRewardBoss", LuaScriptInterface::luaMonsterTypeIsRewardBoss);
 
-	registerMethod("MonsterType", "respawnType", LuaScriptInterface::luaMonsterTypeRespawnType);
 	registerMethod("MonsterType", "canSpawn", LuaScriptInterface::luaMonsterTypeCanSpawn);
 
 	registerMethod("MonsterType", "canPushItems", LuaScriptInterface::luaMonsterTypeCanPushItems);
@@ -3001,6 +3008,9 @@ void LuaScriptInterface::registerFunctions()
                   LuaScriptInterface::luaMonsterTypeStrategiesTargetDamage);
     registerMethod("MonsterType", "strategiesTargetRandom",
                   LuaScriptInterface::luaMonsterTypeStrategiesTargetRandom);
+
+	registerMethod("MonsterType", "respawnTypePeriod", LuaScriptInterface::luaMonsterTypeRespawnTypePeriod);
+	registerMethod("MonsterType", "respawnTypeIsUnderground", LuaScriptInterface::luaMonsterTypeRespawnTypeIsUnderground);
 
 	// Loot
 	registerClass("Loot", "", LuaScriptInterface::luaCreateLoot);
@@ -8799,24 +8809,6 @@ int LuaScriptInterface::luaMonsterTypeIsRewardBoss(lua_State* L)
 	return 1;
 }
 
-int LuaScriptInterface::luaMonsterTypeRespawnType(lua_State* L)
-{
-	// get: monsterType:respawnType() set: monsterType:respawnType(spawnType)
-	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
-	if (monsterType) {
-		if (lua_gettop(L) == 1) {
-			lua_pushnumber(L, monsterType->info.respawnType);
-		} else {
-			monsterType->info.respawnType = getNumber<SpawnType_t>(L, 2);
-			pushBoolean(L, true);
-		}
-	}
-	else {
-		lua_pushnil(L);
-	}
-	return 1;
-}
-
 int LuaScriptInterface::luaMonsterTypeCanSpawn(lua_State* L)
 {
 	// monsterType:canSpawn(pos)
@@ -11899,13 +11891,17 @@ int LuaScriptInterface::luaMonsterGetRespawnType(lua_State* L)
 {
 	// monster:getRespawnType()
 	Monster* monster = getUserdata<Monster>(L, 1);
-	if (monster) {
-		lua_pushnumber(L, monster->getRespawnType());
-	}
-	else {
+
+	if (!monster) {
 		lua_pushnil(L);
+		return 1;
 	}
-	return 1;
+
+	RespawnType respawnType = monster->getRespawnType();
+	lua_pushnumber(L, respawnType.period);
+	pushBoolean(L, respawnType.underground);
+
+	return 2;
 }
 
 // Npc
@@ -15180,6 +15176,44 @@ int LuaScriptInterface::luaMonsterTypeStrategiesTargetRandom(lua_State* L)
 			lua_pushnumber(L, monsterType->info.changeTargetChance);
 		} else {
 			monsterType->info.changeTargetChance = getNumber<int32_t>(L, 2);
+			pushBoolean(L, true);
+		}
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+/**
+ * Respawn Type
+ */
+
+int LuaScriptInterface::luaMonsterTypeRespawnTypePeriod(lua_State* L)
+{
+	// monsterType:respawnTypePeriod()
+	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
+	if (monsterType) {
+		if (lua_gettop(L) == 1) {
+			lua_pushnumber(L, monsterType->info.respawnType.period);
+		} else {
+			monsterType->info.respawnType.period = getNumber<RespawnPeriod_t>(L, 2);
+			pushBoolean(L, true);
+		}
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int LuaScriptInterface::luaMonsterTypeRespawnTypeIsUnderground(lua_State* L)
+{
+	// monsterType:respawnTypeIsUnderground()
+	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
+	if (monsterType) {
+		if (lua_gettop(L) == 1) {
+			lua_pushnumber(L, monsterType->info.respawnType.underground);
+		} else {
+			monsterType->info.respawnType.underground = getNumber<RespawnPeriod_t>(L, 2);
 			pushBoolean(L, true);
 		}
 	} else {

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -1414,6 +1414,9 @@ class LuaScriptInterface
         static int luaMonsterTypeStrategiesTargetDamage(lua_State* L);
         static int luaMonsterTypeStrategiesTargetRandom(lua_State* L);
 
+		static int luaMonsterTypeRespawnTypePeriod(lua_State* L);
+		static int luaMonsterTypeRespawnTypeIsUnderground(lua_State* L);
+
 		// Loot
 		static int luaCreateLoot(lua_State* L);
 		static int luaDeleteLoot(lua_State* L);

--- a/src/monster.h
+++ b/src/monster.h
@@ -127,7 +127,7 @@ class Monster final : public Creature
 		uint32_t getManaCost() const {
 			return mType->info.manaCost;
 		}
-		uint32_t getRespawnType() const {
+		RespawnType getRespawnType() const {
 			return mType->info.respawnType;
 		}
 		void setSpawn(Spawn* newSpawn) {

--- a/src/monsters.h
+++ b/src/monsters.h
@@ -135,6 +135,7 @@ class MonsterType
 		Skulls_t skull = SKULL_NONE;
 		Outfit_t outfit = {};
 		RaceType_t race = RACE_BLOOD;
+		RespawnType respawnType = {};
 
 		LightInfo light = {};
 		uint16_t lookcorpse = 0;
@@ -150,7 +151,6 @@ class MonsterType
 		uint32_t conditionImmunities = 0;
 		uint32_t damageImmunities = 0;
 		uint32_t baseSpeed = 200;
-		uint32_t respawnType = RESPAWN_IN_ALL;
 
 		int32_t creatureAppearEvent = -1;
 		int32_t creatureDisappearEvent = -1;

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -503,6 +503,11 @@ using CombatTypeNames = std::unordered_map<CombatType_t, std::string, std::hash<
 using AmmoTypeNames = std::unordered_map<std::string, Ammo_t>;
 using WeaponActionNames = std::unordered_map<std::string, WeaponAction_t>;
 using SkullNames = std::unordered_map<std::string, Skulls_t>;
+
+/**
+ * @Deprecated
+ * It will be dropped with monsters. Use RespawnPeriod_t instead.
+ */
 using SpawnTypeNames = std::unordered_map<std::string, SpawnType_t>;
 
 MagicEffectNames magicEffectNames = {
@@ -731,6 +736,10 @@ SkullNames skullNames = {
 	{"white",				SKULL_WHITE},
 };
 
+/**
+ * @Deprecated
+ * It will be dropped with monsters. Use RespawnPeriod_t instead.
+ */
 SpawnTypeNames spawnTypeNames = {
 	{"all",					RESPAWN_IN_ALL },
 	{"day",					RESPAWN_IN_DAY },
@@ -802,6 +811,10 @@ Skulls_t getSkullType(const std::string& strValue)
 	return SKULL_NONE;
 }
 
+/**
+ * @Deprecated
+ * It will be dropped with monsters. Use RespawnPeriod_t instead.
+ */
 SpawnType_t getSpawnType(const std::string& strValue)
 {
 	auto spawnType = spawnTypeNames.find(strValue);

--- a/src/tools.h
+++ b/src/tools.h
@@ -72,6 +72,10 @@ Ammo_t getAmmoType(const std::string& strValue);
 WeaponAction_t getWeaponAction(const std::string& strValue);
 Skulls_t getSkullType(const std::string& strValue);
 std::string getCombatName(CombatType_t combatType);
+/**
+ * @Deprecated
+ * It will be dropped with monsters. Use RespawnPeriod_t instead.
+ */
 SpawnType_t getSpawnType(const std::string& strValue);
 CombatType_t getCombatType(const std::string& combatname);
 


### PR DESCRIPTION
- Breaking change for better respawnType API on lua scripts
- Removed old respawnType flag on monsters
- Deprecated SpawnType_t enum
- Backward compability with XML monsters
- Adding Faun lua sample