### PR TITLE
Removing items amount limitation

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -1,5 +1,26 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <items>
+	<!-- liquids vial -->
+	<item id="1" name="water" />
+	<item id="2" name="blood" />
+	<item id="3" name="beer" />
+	<item id="4" name="slime" />
+	<item id="5" name="lemonade" />
+	<item id="6" name="milk" />
+	<item id="7" name="manafluid" />
+	<item id="10" name="lifefluid" />
+	<item id="11" name="oil" />
+	<item id="13" name="urine" />
+	<item id="14" name="coconut milk" />
+	<item id="15" name="wine" />
+	<item id="19" name="mud" />
+	<item id="21" name="fruit juice" />
+	<item id="26" name="lava" />
+	<item id="27" name="rum" />
+	<item id="28" name="swamp" />
+	<item id="35" name="tea" />
+	<item id="43" name="mead" />
+	
 	<item id="100" name="void" />
 	<item id="101" name="earth" />
 	<item id="103" name="dirt" />
@@ -51505,24 +51526,4 @@
 		<attribute key="slotType" value="necklace" />
 		<attribute key="weight" value="430" />
 	</item>	
-	<!-- liquids vial -->
-	<item id="40001" name="water" />
-	<item id="40002" name="blood" />
-	<item id="40003" name="beer" />
-	<item id="40004" name="slime" />
-	<item id="40005" name="lemonade" />
-	<item id="40006" name="milk" />
-	<item id="40007" name="manafluid" />
-	<item id="40010" name="lifefluid" />
-	<item id="40011" name="oil" />
-	<item id="40013" name="urine" />
-	<item id="40014" name="coconut milk" />
-	<item id="40015" name="wine" />
-	<item id="40019" name="mud" />
-	<item id="40021" name="fruit juice" />
-	<item id="40026" name="lava" />
-	<item id="40027" name="rum" />
-	<item id="40028" name="swamp" />
-	<item id="40035" name="tea" />
-	<item id="40043" name="mead" />
 </items>

--- a/src/items.cpp
+++ b/src/items.cpp
@@ -27,11 +27,7 @@
 
 extern Weapons* g_weapons;
 
-Items::Items()
-{
-	items.reserve(40000);
-	nameToItems.reserve(40000);
-}
+Items::Items(){}
 
 void Items::clear()
 {
@@ -182,9 +178,6 @@ FILELOADER_ERRORS Items::loadFromOtb(const std::string& file)
 						return ERROR_INVALID_FORMAT;
 					}
 
-					if (serverId > 40000 && serverId < 40100) {
-						serverId -= 40000;
-					}
 					break;
 				}
 
@@ -393,15 +386,11 @@ void Items::buildInventoryList()
 
 void Items::parseItemNode(const pugi::xml_node& itemNode, uint16_t id)
 {
-	if (id > 40000 && id < 40100) {
-		id -= 40000;
-
-		if (id >= items.size()) {
-			items.resize(id + 1);
-		}
-		ItemType& iType = items[id];
-		iType.id = id;
+	if (id >= items.size()) {
+		items.resize(id + 1);
 	}
+	ItemType& iType = items[id];
+	iType.id = id;
 
 	ItemType& it = getItemType(id);
 	if (it.id == 0) {


### PR DESCRIPTION
I need help to test this one. If you are reading and you can test with multiple players, please do, please try to use vials of fluids, drink water, beer, throw on the floor etc... If instead you know why these id reservations exist, please let us know too :P 

This is a weird change we cannot trace the origin and seems to be repeated over and over, just waiting for next time we need to raise the amount of items. Let's see if we can remove it.