### PR TITLE
Prompt wait for a key to close (if gets an error)

### DIFF
--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -56,6 +56,7 @@ std::unique_lock<std::mutex> g_loaderUniqueLock(g_loaderLock);
 void startupErrorMessage(const std::string& errorStr) {
 	std::cout << "> ERROR: " << errorStr << std::endl;
 	g_loaderSignal.notify_all();
+  system("pause");
 }
 
 void mainLoader(int argc, char* argv[], ServiceManager* servicer);

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -54,9 +54,11 @@ std::condition_variable g_loaderSignal;
 std::unique_lock<std::mutex> g_loaderUniqueLock(g_loaderLock);
 
 void startupErrorMessage(const std::string& errorStr) {
-	std::cout << "> ERROR: " << errorStr << std::endl;
-	g_loaderSignal.notify_all();
-  system("pause");
+  std::cout << "\033[1;31m>> " << errorStr << std::endl;
+  std::cout << ">> The program WILL CLOSE after receiving a key..." << "\033[0m" << std::endl;
+  g_loaderSignal.notify_all();
+  getchar();
+  exit(-1);
 }
 
 void mainLoader(int argc, char* argv[], ServiceManager* servicer);

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -55,7 +55,7 @@ std::unique_lock<std::mutex> g_loaderUniqueLock(g_loaderLock);
 
 void startupErrorMessage(const std::string& errorStr) {
   std::cout << "\033[1;31m>> " << errorStr << std::endl;
-  std::cout << ">> The program WILL CLOSE after receiving a key..." << "\033[0m" << std::endl;
+  std::cout << ">> The program will close after pressing the enter key..." << "\033[0m" << std::endl;
   g_loaderSignal.notify_all();
   getchar();
   exit(-1);


### PR DESCRIPTION
## Description (eng)
If the initialization has a bug the `system("pause")` will make the prompt wait for a key to close.
For me is useful, because I didn’t know what was causing the prompt to close as there wasn’t even time to see what was on it.

## Descrição (ptBr)
Se a inicialização do servidor tiver algum bug, o `system("pause")` irá fazer com que o prompt espere uma tecla para ser finalizado.
Pra mim é útil, porque eu não sabia o que estava causando o fechamento dele na inicialização, já que nem dava tempo de ler.