### PR TITLE
Fix Houses/furniture tab on gamestore

### DIFF
--- a/data/modules/scripts/gamestore/gamestore.lua
+++ b/data/modules/scripts/gamestore/gamestore.lua
@@ -3262,7 +3262,7 @@ GameStore.Categories = {
  { 
    icons = { "Category_HouseFurniture.png" },
    name = "Furniture",
-   parent = "House",   
+   parent = "Houses",   
    rookgaard = true,
    state = GameStore.States.STATE_NONE,
    offers = {  


### PR DESCRIPTION
 parent = "House",   - We do not have such a tab in the store
We need to change to "Houses"