### PR TITLE
Revert "Ferumbras Ascendant Quest - Fix StepIn"

### DIFF
--- a/data/scripts/movements/quests/ferumbras_ascendant/entrance.lua
+++ b/data/scripts/movements/quests/ferumbras_ascendant/entrance.lua
@@ -56,5 +56,6 @@ function entrance.onStepIn(creature, item, position, fromPosition)
 end
 
 entrance:type("stepin")
+entrance:id(24813)
 entrance:aid(24837, 24838)
 entrance:register()


### PR DESCRIPTION
Reverts opentibiabr/otservbr-global#1971

I noticed that, in fact, the check on the stairway of position 33271, 32395, 7: was removed

This ladder, depending on storage, leads to the -8 or -9 floor

What happened was that by removing the id, it stopped leading to -9. I think it's not really buggy, but Lucas Oliveira did not access it correctly. It is necessary to test.