### PR TITLE
Fix: Monsters custom spells

### DIFF
--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -381,7 +381,7 @@ function readSpell(incomingLua)
 				spell:setOutfitItem(incomingLua.outfitItem)
 			end
 			if incomingLua.minDamage and incomingLua.maxDamage then
-				if incomingLua.name == "combat" then
+				if incomingLua.name == "combat" or Spell(incomingLua.name) then
 					spell:setCombatValue(incomingLua.minDamage, incomingLua.maxDamage)
 				else
 					local startDamage = 0


### PR DESCRIPTION
Custom spells on data/spells that didn't have default damage wasn't dealing any damage at all.
Example: Aftershock (aftershock wave)

Before this PR:
![before](https://user-images.githubusercontent.com/66353315/100297330-301bc880-2f6d-11eb-889c-325697f842e7.gif)

With this PR:
![after](https://user-images.githubusercontent.com/66353315/100297350-3dd14e00-2f6d-11eb-9985-4cb81ac3d536.gif)

