### PR TITLE
quickloot_fallback is added in migration file

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -152,7 +152,6 @@ CREATE TABLE IF NOT EXISTS `players` (
   `marriage_status` bigint(20) UNSIGNED NOT NULL DEFAULT '0',
   `marriage_spouse` int(11) NOT NULL DEFAULT '-1',
   `bonus_rerolls` bigint(21) NOT NULL DEFAULT '0',
-  `quickloot_fallback` tinyint(1) DEFAULT '0',
   INDEX `account_id` (`account_id`),
   INDEX `vocation` (`vocation`),
   CONSTRAINT `players_pk` PRIMARY KEY (`id`),


### PR DESCRIPTION
In file `data/migrations/5.lua` is `db.query("ALTER TABLE `players` ADD `quickloot_fallback` TINYINT DEFAULT 0")`. That line has error:
```
> Updating database to version 6 (quickloot)
[Error - mysql_real_query] Query: ALTER TABLE `players` ADD `quickloot_fallback` TINYINT DEFAULT 0
Message: Duplicate column name 'quickloot_fallback'
```