### PR TITLE
Fix svargrond arena bug

### DIFF
--- a/data/scripts/movements/quests/svargrond_arena/arena_pit.lua
+++ b/data/scripts/movements/quests/svargrond_arena/arena_pit.lua
@@ -71,5 +71,5 @@ function arenaPit.onStepIn(creature, item, position, fromPosition)
 end
 
 arenaPit:type("stepin")
-arenaPit:aid(25200)
+arenaPit:aid(25200, 25300)
 arenaPit:register()

--- a/data/scripts/movements/quests/svargrond_arena/arena_trophy.lua
+++ b/data/scripts/movements/quests/svargrond_arena/arena_trophy.lua
@@ -30,6 +30,5 @@ function arenaTrophy.onStepIn(creature, item, position, fromPosition)
 end
 
 arenaTrophy:type("stepin")
-arenaTrophy:aid(25300)
 arenaTrophy:uid(3264, 3265, 3266)
 arenaTrophy:register()


### PR DESCRIPTION
Moved action id to the correct script
This fixes the bug where it was not possible to get the trophy