### PR TITLE
Fixed: Monsters stepdancing and place creature in field 

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -231,6 +231,7 @@ bool Map::placeCreature(const Position& centerPos, Creature* creature, bool exte
 			if (monster) {
 				monster->ignoreFieldDamage = false;
 			}
+		}
 	}
 
 	int32_t index = 0;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -213,10 +213,10 @@ bool Map::placeCreature(const Position& centerPos, Creature* creature, bool exte
 				continue;
 			}
 
-      if (monster) {
+			if (monster) {
 				monster->ignoreFieldDamage = true;
 			}
-      
+
 			if (tile->queryAdd(0, *creature, 1, FLAG_IGNOREBLOCKITEM | FLAG_IGNOREFIELDDAMAGE) == RETURNVALUE_NOERROR) {
 				if (!extendedPos || isSightClear(centerPos, tryPos, false)) {
 					foundTile = true;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -160,13 +160,18 @@ void Map::setTile(uint16_t x, uint16_t y, uint8_t z, Tile* newTile)
 
 bool Map::placeCreature(const Position& centerPos, Creature* creature, bool extendedPos/* = false*/, bool forceLogin/* = false*/)
 {
+	Monster* monster = creature->getMonster();
+	if (monster) {
+		monster->ignoreFieldDamage = true;
+	}
+
 	bool foundTile;
 	bool placeInPZ;
 
 	Tile* tile = getTile(centerPos.x, centerPos.y, centerPos.z);
 	if (tile) {
 		placeInPZ = tile->hasFlag(TILESTATE_PROTECTIONZONE);
-		ReturnValue ret = tile->queryAdd(0, *creature, 1, FLAG_IGNOREBLOCKITEM);
+		ReturnValue ret = tile->queryAdd(0, *creature, 1, FLAG_IGNOREBLOCKITEM | FLAG_IGNOREFIELDDAMAGE);
 		foundTile = forceLogin || ret == RETURNVALUE_NOERROR || ret == RETURNVALUE_PLAYERISNOTINVITED;
 	} else {
 		placeInPZ = false;
@@ -205,7 +210,7 @@ bool Map::placeCreature(const Position& centerPos, Creature* creature, bool exte
 				continue;
 			}
 
-			if (tile->queryAdd(0, *creature, 1, 0) == RETURNVALUE_NOERROR) {
+			if (tile->queryAdd(0, *creature, 1, FLAG_IGNOREBLOCKITEM | FLAG_IGNOREFIELDDAMAGE) == RETURNVALUE_NOERROR) {
 				if (!extendedPos || isSightClear(centerPos, tryPos, false)) {
 					foundTile = true;
 					break;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -173,6 +173,9 @@ bool Map::placeCreature(const Position& centerPos, Creature* creature, bool exte
 		placeInPZ = tile->hasFlag(TILESTATE_PROTECTIONZONE);
 		ReturnValue ret = tile->queryAdd(0, *creature, 1, FLAG_IGNOREBLOCKITEM | FLAG_IGNOREFIELDDAMAGE);
 		foundTile = forceLogin || ret == RETURNVALUE_NOERROR || ret == RETURNVALUE_PLAYERISNOTINVITED;
+    if (monster) {
+			monster->ignoreFieldDamage = false;
+		}
 	} else {
 		placeInPZ = false;
 		foundTile = false;
@@ -210,6 +213,10 @@ bool Map::placeCreature(const Position& centerPos, Creature* creature, bool exte
 				continue;
 			}
 
+      if (monster) {
+				monster->ignoreFieldDamage = true;
+			}
+      
 			if (tile->queryAdd(0, *creature, 1, FLAG_IGNOREBLOCKITEM | FLAG_IGNOREFIELDDAMAGE) == RETURNVALUE_NOERROR) {
 				if (!extendedPos || isSightClear(centerPos, tryPos, false)) {
 					foundTile = true;
@@ -220,7 +227,10 @@ bool Map::placeCreature(const Position& centerPos, Creature* creature, bool exte
 
 		if (!foundTile) {
 			return false;
-		}
+		} else {
+			if (monster) {
+				monster->ignoreFieldDamage = false;
+			}
 	}
 
 	int32_t index = 0;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1886,7 +1886,7 @@ bool Monster::canWalkTo(Position pos, Direction moveDirection) const
 		}
 
 		Tile* walkTile = g_game.map.getTile(pos);
-		if (walkTile && walkTile->getTopVisibleCreature(this) == nullptr && walkTile->queryAdd(0, *this, 1, FLAG_PATHFINDING) == RETURNVALUE_NOERROR) {
+		if (tile && tile->getTopVisibleCreature(this) == nullptr && tile->queryAdd(0, *this, 1, FLAG_PATHFINDING | FLAG_IGNOREFIELDDAMAGE) == RETURNVALUE_NOERROR) {
 			return true;
 		}
 	}

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -765,6 +765,7 @@ void Monster::updateIdleStatus()
 void Monster::onAddCondition(ConditionType_t type)
 {
 	if (type == CONDITION_FIRE || type == CONDITION_ENERGY || type == CONDITION_POISON) {
+    ignoreFieldDamage = true;
 		updateMapCache();
 	}
 
@@ -1242,7 +1243,6 @@ bool Monster::getNextStep(Direction& nextDirection, uint32_t& flags)
 			flags |= FLAG_PATHFINDING;
 		} else {
 			if (ignoreFieldDamage) {
-				ignoreFieldDamage = false;
 				updateMapCache();
 			}
 			//target dancing

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1886,7 +1886,8 @@ bool Monster::canWalkTo(Position pos, Direction moveDirection) const
 		}
 
 		Tile* tile = g_game.map.getTile(pos);
-		if (tile && tile->getTopVisibleCreature(this) == nullptr && tile->queryAdd(0, *this, 1, FLAG_PATHFINDING | FLAG_IGNOREFIELDDAMAGE) == RETURNVALUE_NOERROR) {
+		if (tile && tile->getTopVisibleCreature(this) == nullptr &&
+					tile->queryAdd(0, *this, 1, FLAG_PATHFINDING | FLAG_IGNOREFIELDDAMAGE) == RETURNVALUE_NOERROR) {
 			return true;
 		}
 	}

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1885,7 +1885,7 @@ bool Monster::canWalkTo(Position pos, Direction moveDirection) const
 			return false;
 		}
 
-		Tile* walkTile = g_game.map.getTile(pos);
+		Tile* tile = g_game.map.getTile(pos);
 		if (tile && tile->getTopVisibleCreature(this) == nullptr && tile->queryAdd(0, *this, 1, FLAG_PATHFINDING | FLAG_IGNOREFIELDDAMAGE) == RETURNVALUE_NOERROR) {
 			return true;
 		}

--- a/src/monster.h
+++ b/src/monster.h
@@ -291,6 +291,7 @@ class Monster final : public Creature
 		}
 
 		friend class LuaScriptInterface;
+		friend class Map;
 };
 
 #endif

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -580,7 +580,7 @@ ReturnValue Tile::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t tileF
 					//1) Monster is able to walk over field type
 					//2) Being attacked while random stepping will make it ignore field damages
 					if (hasBitSet(FLAG_IGNOREFIELDDAMAGE, tileFlags)) {
-						if (!(monster->canWalkOnFieldType(combatType) || monster->getIgnoreFieldDamage())) {
+						if (!(monster->getIgnoreFieldDamage() || monster->canWalkOnFieldType(combatType))) {
 							return RETURNVALUE_NOTPOSSIBLE;
 						}
 					} else {


### PR DESCRIPTION
- **Monsters can now stepdancing in fields when attacking a foe.**
- **Monsters are now ignoring fields in the ground when they are created.**

**Author:** @FakeShinoda 