### PR TITLE
Inquisition quest mission 6 fix

### DIFF
--- a/data/scripts/creaturescripts/quests/inquisition/inquisition_boss.lua
+++ b/data/scripts/creaturescripts/quests/inquisition/inquisition_boss.lua
@@ -8,7 +8,7 @@ local bosses = {
 	['hellgorak'] = 205
 }
 
-local inquisitionBossKill = CreatureEvent("UngreezKill")
+local inquisitionBossKill = CreatureEvent("InquisitionBossKill")
 function inquisitionBossKill.onKill(player, target)
 	local targetMonster = target:getMonster()
 	if not targetMonster then


### PR DESCRIPTION
Fixes the issue in the inquisition quest mission 6, not registering Ungreez boss kill due duplicated CreatureEvent name. Check issue #2054 for more detailed info.

Closes #2054