### PR TITLE
Fix unescaped boosted creature name

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -120,7 +120,7 @@ void Game::loadBoostedCreature()
 		query.str(std::string());
 		query << "UPDATE `boosted_creature` SET ";
 		query << "`date` = '" << ltm->tm_mday << "',";
-		query << "`boostname` = '" << name << "',";
+		query << "`boostname` = " << db.escapeString(name) << ",";
 		query << "`raceid` = '" << newrace << "'";
 
 		if (!db.executeQuery(query.str())) {


### PR DESCRIPTION
Hi, there is a SQL problem at the update statement of boosting creatures when they have apostrophes in their names.

## How to reproduce:

Start the server forcing Mooh'Tah Warrior as boosted creature:

> ...
> Loading lua libs
> Loading lua scripts
> Loading lua monsters
> Loading outfits

`[Error - mysql_real_query] Query: UPDATE boosted_creature SET date = '18', boostname = 'Mooh'Tah Warrior', raceid = '`

`Message: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'Mooh'Tah Warrior'at line 1`

`[Warning - Boosted creature] Failed to detect boosted creature database. (CODE 02)`

## Expected behavior:
> ...
> Loading lua libs
> Loading lua scripts
> Loading lua monsters
> Loading outfits
> Boosted creature: Mooh'Tah Warrior