### PR TITLE
Fixed urmahlullu lever

### DIFF
--- a/data/scripts/quests/kilmaresh/1-fafnars-wrath/3-urmahlullu-the-immaculate.lua
+++ b/data/scripts/quests/kilmaresh/1-fafnars-wrath/3-urmahlullu-the-immaculate.lua
@@ -3,82 +3,77 @@
 local config = {
 	requiredLevel = 100,
 	daily = true,
-	centerUrmahlulluRoomPosition = Position(33918, 31649, 8),
+	roomCenterPosition = Position(33919, 31648, 8),
 	playerPositions = {
 		Position(33918, 31626, 8),
 		Position(33919, 31626, 8),
 		Position(33920, 31626, 8),
 		Position(33921, 31626, 8),
-		Position(33922, 31626, 8),
+		Position(33922, 31626, 8)
 	},
-	newPositions = {
-		Position(33919, 31657, 8),
-	},
-	urmahlulluPosition = {
-		Position(33919, 31648, 8),
-	},
-	firstPlayer = {
-		Position(33918, 31626, 8),
-	}
+	teleportPosition = Position(33918, 31657, 8),
+	bossPosition = Position(33918, 31641, 8)
 }
 
 local leverboss = Action()
 
 function leverboss.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	if item.itemid == 9825 then
-		local storePlayers, playerTile = {}
+		-- Check if the player that pulled the lever is on the correct position
+		if player:getPosition() ~= config.playerPositions[1] then
+			player:sendTextMessage(MESSAGE_STATUS_SMALL, "You can\'t start the battle.")
+			return true
+		end
+		
+		local team, participant = {}
 
 		for i = 1, #config.playerPositions do
-			playerTile = Tile(config.firstPlayer[i]):getTopCreature()
-			if not playerTile or not playerTile:isPlayer() then
-				player:sendTextMessage(MESSAGE_STATUS_SMALL, "You need 5 players.")
-				return true
-			end
+			participant = Tile(config.playerPositions[i]):getTopCreature()
+			
+			-- Check there is a participant player
+			if participant and participant:isPlayer() then
+				-- Check participant level
+				if participant:getLevel() < config.requiredLevel then
+					player:sendTextMessage(MESSAGE_STATUS_SMALL,
+						"All the players need to be level ".. config.requiredLevel .." or higher.")
+					return true
+				end
 
-			if playerTile:getLevel() < config.requiredLevel then
-				player:sendTextMessage(MESSAGE_STATUS_SMALL,
-					"All the players need to be level ".. config.requiredLevel .." or higher.")
-				return true
-			end
+				-- Check participant boss timer
+				if config.daily and participant:getStorageValue(Storage.Kilmaresh.UrmahlulluTimer) > os.time() then
+					player:getPosition():sendMagicEffect(CONST_ME_POFF)
+					player:sendCancelMessage("Not all players are ready yet from last battle.")
+					return true
+				end
 
-			if config.daily and playerTile:getStorageValue(Storage.Kilmaresh.UrmahlulluTimer) > os.time() then
-				player:getPosition():sendMagicEffect(CONST_ME_POFF)
-				player:sendCancelMessage('All players are not still ready from last battle yet.')
-				return true
+				team[#team + 1] = participant
 			end
-
-			storePlayers[#storePlayers + 1] = playerTile
 		end
 
-		local specs, spec = Game.getSpectators(config.centerUrmahlulluRoomPosition, false, false, 14, 14, 13, 13)
+		-- Check if a team currently inside the boss room
+		local specs, spec = Game.getSpectators(config.roomCenterPosition, false, false, 14, 14, 13, 13)
 		for i = 1, #specs do
 			spec = specs[i]
 			if spec:isPlayer() then
-				player:sendTextMessage(MESSAGE_STATUS_SMALL, "A team is already inside the quest room.")
+				player:sendTextMessage(MESSAGE_STATUS_SMALL, "A team is already inside the boss room.")
 				return true
 			end
 
 			spec:remove()
 		end
 
-		if player:getPosition()~=config.firstPlayer[1] then
-			player:sendTextMessage(MESSAGE_STATUS_SMALL, "You can't start a battle.")
-			return true
-		end
+		-- Spawn boss
+		Game.createMonster("Urmahlullu the Immaculate", config.bossPosition)
 
-		for i = 1, #config.urmahlulluPosition do
-			Game.createMonster("Urmahlullu the Immaculate", config.urmahlulluPosition[i])
+		-- Teleport team participants
+		for i = 1, #team do
+			team[i]:getPosition():sendMagicEffect(CONST_ME_POFF)
+			team[i]:teleportTo(config.teleportPosition)
+			-- Assign boss timer
+			team[i]:setStorageValue(Storage.Kilmaresh.UrmahlulluTimer, os.time() + 20*60*60) -- 20 hours
 		end
-
-		local players
-		for i = 1, #storePlayers do
-			players = storePlayers[i]
-			config.playerPositions[i]:sendMagicEffect(CONST_ME_POFF)
-			players:teleportTo(config.newPositions[1])
-			config.newPositions[1]:sendMagicEffect(CONST_ME_ENERGYAREA)
-			players:setDirection(DIRECTION_EAST)
-		end
-		player:setStorageValue(Storage.Kilmaresh.UrmahlulluTimer, os.time()+20*60*60) -- 20 hours
+		
+		config.teleportPosition:sendMagicEffect(CONST_ME_ENERGYAREA)
 	end
 
 	item:transform(9825)


### PR DESCRIPTION
Fixed error due wrong config object definition.

Fixed required 5 players to pull the lever.

Fixed only setting the boss timer storage to the player that pulls the lever, now applies to every participant.

Modified some coordinates.