### PR TITLE
Fixed missing shoot type effect for scripted ammunitions

### DIFF
--- a/data/scripts/weapons/scripts/burst_arrow.lua
+++ b/data/scripts/weapons/scripts/burst_arrow.lua
@@ -7,6 +7,7 @@ local area = createCombatArea({
 local combat = Combat()
 combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_EXPLOSIONAREA)
+combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_BURSTARROW)
 combat:setParameter(COMBAT_PARAM_BLOCKARMOR, true)
 combat:setFormula(COMBAT_FORMULA_SKILL, 0, 0, 1, 0)
 combat:setArea(area)

--- a/data/scripts/weapons/scripts/diamond_arrow.lua
+++ b/data/scripts/weapons/scripts/diamond_arrow.lua
@@ -6,18 +6,19 @@ local area = createCombatArea({
 	{0, 1, 1, 1, 0},
  })
 
- local combat = Combat()
- combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
- combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ENERGYHIT)
- combat:setParameter(COMBAT_PARAM_BLOCKARMOR, true)
- combat:setFormula(COMBAT_FORMULA_SKILL, 0, 0, 1, 0)
- combat:setArea(area)
+local combat = Combat()
+combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
+combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ENERGYHIT)
+combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_DIAMONDARROW)
+combat:setParameter(COMBAT_PARAM_BLOCKARMOR, true)
+combat:setFormula(COMBAT_FORMULA_SKILL, 0, 0, 1, 0)
+combat:setArea(area)
 
 local diamondArrow = Weapon(WEAPON_AMMO)
 
- function diamondArrow.onUseWeapon(player, variant)
- 	return combat:execute(player, variant)
- end
+function diamondArrow.onUseWeapon(player, variant)
+	return combat:execute(player, variant)
+end
 
 diamondArrow:id(29057)
 diamondArrow:level(150)

--- a/data/scripts/weapons/scripts/viper_star.lua
+++ b/data/scripts/weapons/scripts/viper_star.lua
@@ -1,5 +1,6 @@
 local combat = Combat()
 combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
+combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_GREENSTAR)
 combat:setParameter(COMBAT_PARAM_BLOCKARMOR, true)
 combat:setFormula(COMBAT_FORMULA_SKILL, 0, 0, 1, 0)
 


### PR DESCRIPTION
Added paramenter COMBAT_PARAM_DISTANCEEFFECT to combat object due seems weapon:shootType not working as intended.

Closes #2018 