### PR TITLE
Only declared protocol allowed

### DIFF
--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -376,6 +376,13 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 		disconnect();
 		return;
 	}
+	
+	if (clientVersion != CLIENT_VERSION) {
+		std::ostringstream ss;
+		ss << "Only clients with protocol " << CLIENT_VERSION_STR << " allowed!";
+		disconnectClient(ss.str());
+		return;
+	}
 
 	if (g_game.getGameState() == GAME_STATE_STARTUP) {
 		disconnectClient("Gameworld is starting up. Please wait.");

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -376,7 +376,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage& msg)
 		disconnect();
 		return;
 	}
-	
+
 	if (clientVersion != CLIENT_VERSION) {
 		std::ostringstream ss;
 		ss << "Only clients with protocol " << CLIENT_VERSION_STR << " allowed!";


### PR DESCRIPTION
**The older version of the client used the `protocollogin.cpp`. Now we're using login.php so we can only check the protocol in `protocolgame.cpp`**

**I'm using a server with protocol 12.60, so protocol 12.51 is too old = will show a message**

![image](https://user-images.githubusercontent.com/67392692/102801848-13c94b00-43b6-11eb-8499-ae9cdb3dd49d.png)
