### PR TITLE
Fix for Ferumbras Ascendant Entrance

### DIFF
--- a/data/scripts/movements/quests/ferumbras_ascendant/entrance.lua
+++ b/data/scripts/movements/quests/ferumbras_ascendant/entrance.lua
@@ -46,16 +46,9 @@ function entrance.onStepIn(creature, item, position, fromPosition)
 		player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 		return true
 	end
-	if complete then
-		player:teleportTo(Position(33271, 32396, 9))
-	else
-		player:teleportTo(Position(33271, 32396, 8))
-	end
-	player:setDirection(SOUTH)
 	return true
 end
 
 entrance:type("stepin")
-entrance:id(24813)
 entrance:aid(24837, 24838)
 entrance:register()

--- a/data/scripts/movements/quests/ferumbras_ascendant/stair.lua
+++ b/data/scripts/movements/quests/ferumbras_ascendant/stair.lua
@@ -1,3 +1,13 @@
+local config = {
+	[1] = {storage = Storage.FerumbrasAscension.Razzagorn},
+	[2] = {storage = Storage.FerumbrasAscension.Ragiaz},
+	[3] = {storage = Storage.FerumbrasAscension.Zamulosh},
+	[4] = {storage = Storage.FerumbrasAscension.Mazoran},
+	[5] = {storage = Storage.FerumbrasAscension.Tarbaz},
+	[6] = {storage = Storage.FerumbrasAscension.Shulgrax},
+	[7] = {storage = Storage.FerumbrasAscension.Plagirath}
+}
+
 local stair = MoveEvent()
 
 function stair.onStepIn(creature, item, position, fromPosition)
@@ -5,12 +15,29 @@ function stair.onStepIn(creature, item, position, fromPosition)
 	if not player then
 		return true
 	end
-
-	player:teleportTo(Position(33271, 32394, 7))
-	player:setDirection(NORTH)
+	if item:getId() == 24813 then
+		local complete = false
+		for i = 1, #config do
+			local storage = config[i].storage
+			if player:getStorageValue(storage) ~= 1 then
+				complete = false
+			else
+				complete = true
+			end
+		end
+		if complete then
+			player:teleportTo(Position(33271, 32396, 9))
+		else
+			player:teleportTo(Position(33271, 32396, 8))
+		end
+		player:setDirection(SOUTH)
+	elseif item:getId() == 24812 then
+		player:teleportTo(Position(33271, 32394, 7))
+		player:setDirection(NORTH)
+	end
 	return true
 end
 
 stair:type("stepin")
-stair:id(24812)
+stair:id(24812, 24813)
 stair:register()


### PR DESCRIPTION
Fix for #2048 

Also @dudantas I think you are making the otbm pulls, right? I think the teleport at Pos(33317, 32315, 13) should only have the action id, as you can see it teleports you as well activating the move event, thx in advance
![image](https://user-images.githubusercontent.com/61813040/102879334-59bef700-4428-11eb-950c-04edb376afce.png)
