### PR TITLE
Fix stamina

### DIFF
--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -730,7 +730,7 @@ function Player:onGainExperience(source, exp, rawExp)
 	if configManager.getBoolean(configKeys.STAMINA_SYSTEM) then
 		useStamina(self)
 		local staminaMinutes = self:getStamina()
-		if staminaMinutes > 2400 and self:isPremium() then
+		if staminaMinutes > 2340 and self:isPremium() then
 			exp = exp * 1.5
 			self:setStaminaXpBoost(150)
 		elseif staminaMinutes <= 840 then

--- a/data/lib/others/daily_reward_lib.lua
+++ b/data/lib/others/daily_reward_lib.lua
@@ -104,7 +104,7 @@ local function regenStamina(id, delay)
 	end
 	if player:getTile():hasFlag(TILESTATE_PROTECTIONZONE) then
 		local actualStamina = player:getStamina()
-		if actualStamina > 2400 and actualStamina < 2520 then
+		if actualStamina > 2340 and actualStamina < 2520 then
 			delay = 6 * 60 * 1000 -- Bonus stamina
 		end
 		if actualStamina < 2520 then
@@ -206,7 +206,7 @@ function Player.loadDailyRewardBonuses(self)
 	local staminaEvent = Daily_Bonus.stamina[self:getId()]
 		if not staminaEvent then
 			local delay = 3
-			if self:getStamina() > 2400 and self:getStamina() <= 2520 then
+			if self:getStamina() > 2340 and self:getStamina() <= 2520 then
 				delay = 6
 			end
 			Daily_Bonus.stamina[self:getId()] = addEvent(regenStamina, delay * 60 * 1000, self:getId(), delay * 60 * 1000)

--- a/data/scripts/creaturescripts/others/login.lua
+++ b/data/scripts/creaturescripts/others/login.lua
@@ -218,7 +218,7 @@ function playerLogin.onLogin(player)
 
 	local staminaMinutes = player:getStamina()
 	local doubleExp = false --Can change to true if you have double exp on the server
-	local staminaBonus = (staminaMinutes > 2400) and 150 or ((staminaMinutes < 840) and 50 or 100)
+	local staminaBonus = (staminaMinutes > 2340) and 150 or ((staminaMinutes < 840) and 50 or 100)
 	if doubleExp then
 		baseExp = baseExp * 2
 	end

--- a/data/scripts/creaturescripts/others/regenerate_stamina.lua
+++ b/data/scripts/creaturescripts/others/regenerate_stamina.lua
@@ -13,11 +13,11 @@ function regenerateStamina.onLogin(player)
 	end
 
 	local staminaMinutes = player:getStamina()
-	local maxNormalStaminaRegen = 2400 - math.min(2400, staminaMinutes)
+	local maxNormalStaminaRegen = 2340 - math.min(2340, staminaMinutes)
 	local regainStaminaMinutes = offlineTime / 180
 	if regainStaminaMinutes > maxNormalStaminaRegen then
-		local happyHourStaminaRegen = (offlineTime - (maxNormalStaminaRegen * 180)) / 600
-		staminaMinutes = math.min(2520, math.max(2400, staminaMinutes) + happyHourStaminaRegen)
+		local happyHourStaminaRegen = (offlineTime - (maxNormalStaminaRegen * 180)) / 360
+		staminaMinutes = math.min(2520, math.max(2340, staminaMinutes) + happyHourStaminaRegen)
 	else
 		staminaMinutes = staminaMinutes + regainStaminaMinutes
 	end


### PR DESCRIPTION
Fix for #2163 

According to TibiaWiki (https://tibia.fandom.com/wiki/Stamina)
To regenerate stamina, you must be logged out (of the character you wish to regenerate stamina for — NOT the whole account). For every 3 minutes you are logged off your character will gain 1 minute of stamina. However, it will take even longer to regenerate the stamina for the bonus hours since you gain way more experience in them. For every 6 minutes you are logged off you get 1 minute added to the character’s bonus stamina. You need to be logged off for 10 minutes before you start to regain any stamina. **To go from 39 hours of stamina to the maximum of 42 hours (bonus) it would take you 18 hours and 10 minutes of being offline.**

More info on happy hour 39:
On April, 2020, the bonus stamina was temporarily increased from 2 to 3 hours due to many players having more time to play as a consequence of the COVID-19 pandemic. On June 25 it was announced that this change would be permanent.
