### PR TITLE
Fix Rashid's daily travel routine

### DIFF
--- a/data/scripts/globalevents/spawn/rashid.lua
+++ b/data/scripts/globalevents/spawn/rashid.lua
@@ -1,6 +1,3 @@
-local today = os.date("*t").wday
-local todayLabel = os.date("%A")
-
 local positionByDay = {
 	[1] = Position(32328, 31782, 6), -- Sunday
 	[2] = Position(32207, 31155, 7), -- Monday
@@ -14,11 +11,13 @@ local positionByDay = {
 local rashidSpawnOnStartup = GlobalEvent("rashidSpawnOnStartup")
 function rashidSpawnOnStartup.onStartup()
 
+	local today = os.date("*t").wday
+
 	if positionByDay[today] then
 		local rashid = Game.createNpc("rashid", positionByDay[today])
 		rashid:setMasterPos(positionByDay[today])
 		rashid:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
-		print(">> Rashid arrived at " .. todayLabel .. "s destination.")
+		print(">> Rashid arrived at " .. os.date("%A") .. "s destination.")
 	else
 		print("[!] -> Cannot create Rashid. Day: " .. todayLabel .. ".")
 	end
@@ -31,9 +30,12 @@ rashidSpawnOnStartup:register()
 local rashidSpawnOnTime = GlobalEvent("rashidSpawnOnTime")
 function rashidSpawnOnTime.onTime(interval)
 
+	local today = os.date("*t").wday
+
 	local rashidTarget = Npc("rashid")
+
 	if rashidTarget then
-		print(">> Rashid is traveling to " .. todayLabel .. "s location.")
+		print(">> Rashid is traveling to " .. os.date("%A") .. "s location.")
 		rashidTarget:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 		rashidTarget:teleportTo(positionByDay[today])
 		rashidTarget:setMasterPos(positionByDay[today])
@@ -43,5 +45,5 @@ function rashidSpawnOnTime.onTime(interval)
 	return true
 
 end
-rashidSpawnOnTime:time("07:00:00")
+rashidSpawnOnTime:time("07:00")
 rashidSpawnOnTime:register()

--- a/data/scripts/globalevents/spawn/rashid.lua
+++ b/data/scripts/globalevents/spawn/rashid.lua
@@ -45,5 +45,5 @@ function rashidSpawnOnTime.onTime(interval)
 	return true
 
 end
-rashidSpawnOnTime:time("07:00")
+rashidSpawnOnTime:time("00:01")
 rashidSpawnOnTime:register()

--- a/data/scripts/globalevents/spawn/rashid.lua
+++ b/data/scripts/globalevents/spawn/rashid.lua
@@ -15,7 +15,7 @@ local rashidSpawnOnStartup = GlobalEvent("rashidSpawnOnStartup")
 function rashidSpawnOnStartup.onStartup()
 
 	if positionByDay[today] then
-		local rashid = Game.createNpc("Rashid", positionByDay[today])
+		local rashid = Game.createNpc("rashid", positionByDay[today])
 		rashid:setMasterPos(positionByDay[today])
 		rashid:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 		print(">> Rashid arrived at " .. todayLabel .. "s destination.")
@@ -31,7 +31,7 @@ rashidSpawnOnStartup:register()
 local rashidSpawnOnTime = GlobalEvent("rashidSpawnOnTime")
 function rashidSpawnOnTime.onTime(interval)
 
-	local rashidTarget = Npc("Rashid")
+	local rashidTarget = Npc("rashid")
 	if rashidTarget then
 		print(">> Rashid is traveling to " .. todayLabel .. "s location.")
 		rashidTarget:getPosition():sendMagicEffect(CONST_ME_TELEPORT)

--- a/data/scripts/globalevents/spawn/rashid.lua
+++ b/data/scripts/globalevents/spawn/rashid.lua
@@ -1,21 +1,47 @@
-local rashid = GlobalEvent("spawn raids")
-function rashid.onStartup()
-   local days = {
-      [1] = Position(32328, 31782, 6), --sunday
-      [2] = Position(32207, 31155, 7), --monday
-      [3] = Position(32300, 32837, 7), --tuesday
-      [4] = Position(32577, 32753, 7), --wednesday
-      [5] = Position(33066, 32879, 6), --thursday
-      [6] = Position(33235, 32483, 7), --friday
-      [7] = Position(33166, 31810, 6) --saturday
-   }
+local today = os.date("*t").wday
+local todayLabel = os.date("%A")
 
-   local day = os.date("*t").wday
-   if days[day] then
-      doCreateNpc("rashid", days[day])
-   else
-      print("[!] -> Cannot create Rashid. Day: " .. day .. ".")
-   end
-   return true
+local positionByDay = {
+	[1] = Position(32328, 31782, 6), -- Sunday
+	[2] = Position(32207, 31155, 7), -- Monday
+	[3] = Position(32300, 32837, 7), -- Tuesday
+	[4] = Position(32577, 32753, 7), -- Wednesday
+	[5] = Position(33066, 32879, 6), -- Thursday
+	[6] = Position(33235, 32483, 7), -- Friday
+	[7] = Position(33166, 31810, 6)  -- Saturday
+}
+
+local rashidSpawn = GlobalEvent("rashid spawn")
+function rashidSpawn.onStartup()
+
+	if positionByDay[today] then
+		local rashid = Game.createNpc("Rashid", positionByDay[today])
+		rashid:setMasterPos(positionByDay[today])
+		rashid:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+		print(">> Rashid arrived at " .. todayLabel .. "s destination.")
+	else
+		print("[!] -> Cannot create Rashid. Day: " .. todayLabel .. ".")
+	end
+
+	return true
+
 end
-rashid:register()
+rashidSpawn:register()
+
+local rashidSpawn = GlobalEvent("rashid spawn")
+function rashidSpawn.onTime(interval)
+
+	local rashidTarget = Npc("Rashid")
+	if rashidTarget then
+		print(">> Rashid is traveling to " .. todayLabel .. "s location.")
+		rashidTarget:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+		rashidTarget:teleportTo(positionByDay[today])
+		rashidTarget:setMasterPos(positionByDay[today])
+		rashidTarget:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+	end
+
+	return true
+
+end
+rashidSpawn:time("07:00:00")
+rashidSpawn:register()

--- a/data/scripts/globalevents/spawn/rashid.lua
+++ b/data/scripts/globalevents/spawn/rashid.lua
@@ -19,7 +19,7 @@ function rashidSpawnOnStartup.onStartup()
 		rashid:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 		print(">> Rashid arrived at " .. os.date("%A") .. "s destination.")
 	else
-		print("[!] -> Cannot create Rashid. Day: " .. todayLabel .. ".")
+		print("[!] -> Cannot create Rashid. Day: " .. os.date("%A") .. ".")
 	end
 
 	return true

--- a/data/scripts/globalevents/spawn/rashid.lua
+++ b/data/scripts/globalevents/spawn/rashid.lua
@@ -11,8 +11,8 @@ local positionByDay = {
 	[7] = Position(33166, 31810, 6)  -- Saturday
 }
 
-local rashidSpawn = GlobalEvent("rashid spawn")
-function rashidSpawn.onStartup()
+local rashidSpawnOnStartup = GlobalEvent("rashidSpawnOnStartup")
+function rashidSpawnOnStartup.onStartup()
 
 	if positionByDay[today] then
 		local rashid = Game.createNpc("Rashid", positionByDay[today])
@@ -26,10 +26,10 @@ function rashidSpawn.onStartup()
 	return true
 
 end
-rashidSpawn:register()
+rashidSpawnOnStartup:register()
 
-local rashidSpawn = GlobalEvent("rashid spawn")
-function rashidSpawn.onTime(interval)
+local rashidSpawnOnTime = GlobalEvent("rashidSpawnOnTime")
+function rashidSpawnOnTime.onTime(interval)
 
 	local rashidTarget = Npc("Rashid")
 	if rashidTarget then
@@ -43,5 +43,5 @@ function rashidSpawn.onTime(interval)
 	return true
 
 end
-rashidSpawn:time("07:00:00")
-rashidSpawn:register()
+rashidSpawnOnTime:time("07:00:00")
+rashidSpawnOnTime:register()

--- a/data/startup/tables/additional_map.lua
+++ b/data/startup/tables/additional_map.lua
@@ -4,6 +4,6 @@ CustomMapTable = {
 		mapName = "otservbr-custom",
 		mapFile = "data/world/custom/otservbr-custom.otbm",
 		spawnFile = "data/world/custom/otservbr-custom-spawn.xml",
-		enabled = true
+		enabled = false
 	}
 }

--- a/data/startup/tables/additional_map.lua
+++ b/data/startup/tables/additional_map.lua
@@ -4,6 +4,6 @@ CustomMapTable = {
 		mapName = "otservbr-custom",
 		mapFile = "data/world/custom/otservbr-custom.otbm",
 		spawnFile = "data/world/custom/otservbr-custom-spawn.xml",
-		enabled = false
+		enabled = true
 	}
 }


### PR DESCRIPTION
## Case

Recently I realized that Rashid was being too lazy on my server, I never found him in other places, besides where I saw him for the first time.

Well, at least in my case, he never travels. I tried to figure out if it had something coded in the *save server files* handling this job, but I really haven't found anything in there related or in any other place. 

## Fix

To solve this, I modified `scripts/globalevents/spawn/rashid.lua`  inserting a `GlobalEvent` named "*rashid spawn*", and based on the other project files, I call two methods:

### onStartup()
First, I'm using **onStartup()** to create and position Rashid at the correct position using the array to get the position for the current day of the week. 

### onTime()
After that, I'm using **onTime()** to finally stop Rashid's laziness and put him to travel at 07:00 o'clock in the morning, every day.

Now he travels with the server running without any kind of restarts/reloads to all the cities once a day.

### Modification in additional_map.lua
I noticed that there is a custom map enabled for additional loading, with all important NPCs, probably to some kind of test. To avoid having a second Rashid in the map, I set it to false to disable additional map loading with all these extra NPCs.

Btw, I'm studying LUA and getting to know the organization of your project. Forgive me for some of my mistakes or if my approach is not good, I have other tech backgrounds and through them, I'm trying to learn the type of code you are using here, to contribute with the project in more ways.

If you could point out eventually some mistake that I made or a better approach to do this routine, I will be glad to learn with. Thank you!
