### PR TITLE
Prevent infinity loop teleports

### DIFF
--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -65,6 +65,22 @@ Cylinder* Teleport::queryDestination(int32_t&, const Thing&, Item**, uint32_t&)
 	return this;
 }
 
+bool Teleport::checkInfinityLoop(Tile* destTile)
+{
+	if (!destTile) {
+		return false;
+	}
+
+	if (Teleport* teleport = destTile->getTeleportItem()) {
+		const Position& nextDestPos = teleport->getDestPos();
+		if (getPosition() == nextDestPos) {
+			return true;
+		}
+		return checkInfinityLoop(g_game.map.getTile(nextDestPos));
+	}
+	return false;
+}
+
 void Teleport::addThing(Thing* thing)
 {
 	return addThing(0, thing);
@@ -74,6 +90,13 @@ void Teleport::addThing(int32_t, Thing* thing)
 {
 	Tile* destTile = g_game.map.getTile(destPos);
 	if (!destTile) {
+		return;
+	}
+
+	// Prevent infinity loop
+	if (checkInfinityLoop(destTile)) {
+		const Position& pos = getPosition();
+		std::cout << "Warning: infinity loop teleport. " << pos << std::endl;
 		return;
 	}
 

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -96,7 +96,7 @@ void Teleport::addThing(int32_t, Thing* thing)
 	// Prevent infinity loop
 	if (checkInfinityLoop(destTile)) {
 		const Position& pos = getPosition();
-		std::cout << "Warning: infinity loop teleport. " << pos << std::endl;
+		std::cout << ""[Warning - Teleport::addThing] Infinity loop teleport at position: " << pos << std::endl;
 		return;
 	}
 

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -95,7 +95,7 @@ void Teleport::addThing(int32_t, Thing* thing)
 	// Prevent infinity loop
 	if (checkInfinityLoop(destTile)) {
 		const Position& pos = getPosition();
-		std::cout << ""[Warning - Teleport::addThing] Infinity loop teleport at position: " << pos << std::endl;
+		std::cout << "[Warning - Teleport::addThing] Infinity loop teleport at position: " << pos << std::endl;
 		return;
 	}
 

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -86,8 +86,7 @@ void Teleport::addThing(Thing* thing)
 	return addThing(0, thing);
 }
 
-void Teleport::addThing(int32_t, Thing* thing)
-{
+void Teleport::addThing(int32_t, Thing* thing) {
 	Tile* destTile = g_game.map.getTile(destPos);
 	if (!destTile) {
 		return;

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -65,8 +65,7 @@ Cylinder* Teleport::queryDestination(int32_t&, const Thing&, Item**, uint32_t&)
 	return this;
 }
 
-bool Teleport::checkInfinityLoop(Tile* destTile)
-{
+bool Teleport::checkInfinityLoop(Tile* destTile) {
 	if (!destTile) {
 		return false;
 	}
@@ -86,7 +85,8 @@ void Teleport::addThing(Thing* thing)
 	return addThing(0, thing);
 }
 
-void Teleport::addThing(int32_t, Thing* thing) {
+void Teleport::addThing(int32_t, Thing* thing)
+{
 	Tile* destTile = g_game.map.getTile(destPos);
 	if (!destTile) {
 		return;

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -45,6 +45,8 @@ class Teleport final : public Item, public Cylinder
 			destPos = std::move(pos);
 		}
 
+		bool checkInfinityLoop(Tile* destTile);
+
 		//cylinder implementations
 		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
 				uint32_t flags, Creature* actor = nullptr) const override;


### PR DESCRIPTION
With this there will be no way to cause a server crash using teleports loops.

Credits: @MillhioreBT
From: https://github.com/otland/forgottenserver/pull/3005