### PR TITLE
Implement Exp Boost 50%, 100%

### DIFF
--- a/data/modules/scripts/gamestore/gamestore.lua
+++ b/data/modules/scripts/gamestore/gamestore.lua
@@ -3968,12 +3968,20 @@ GameStore.Categories = {
    offers = { 
         {
           icons = { "XP_Boost.png" },
-          name = "XP Boost",
+          name = "XP Boost 50%",
           price = 30,
           id = 65010,
-          description = "<i>Purchase a boost that increases the experience points your character gains from hunting by 50%!</i>\n\n{character}\n{info} lasts for 1 hour hunting time\n{info} paused if stamina falls under 14 hours\n{info} can be purchased up to 5 times between 2 server saves\n{info} price increases with every purchase\n{info} cannot be purchased if an XP boost is already active",
+          description = "<b>Purchase a boost that increases the experience points your character gains from hunting by 50%!</b>\n\n{character}\n{info} lasts for 1 hour hunting time\n{info} paused if stamina falls under 14 hours\n{info} can be purchased up to 5 times between 2 server saves\n{info} price increases with every purchase\n{info} cannot be purchased if an XP boost is already active",
           type = GameStore.OfferTypes.OFFER_TYPE_EXPBOOST,			
         },
+        {
+          icons = { "XP_Boost.png" },
+          name = "XP Boost 100%",
+          price = 60,
+          id = 65011,
+          description = "<b>Purchase a boost that increases the experience points your character gains from hunting by 100%!</b>\n\n{character}\n{info} lasts for 1 hour hunting time\n{info} paused if stamina falls under 14 hours\n{info} can be purchased up to 5 times between 2 server saves\n{info} price increases with every purchase\n{info} cannot be purchased if an XP boost is already active",
+          type = GameStore.OfferTypes.OFFER_TYPE_EXPBOOST2,			
+        },		
       },
    rookgaard = true,
    state = GameStore.States.STATE_NONE,

--- a/data/scripts/globalevents/others/server_save.lua
+++ b/data/scripts/globalevents/others/server_save.lua
@@ -11,7 +11,8 @@ local function ServerSave()
 	-- Updating daily reward next server save.
 	updateGlobalStorage(DailyReward.storages.lastServerSave, os.time())
 	-- Reset gamestore exp boost count.
-	db.query('UPDATE `player_storage` SET `value` = 0 WHERE `player_storage`.`key` = 51052')
+	db.query('UPDATE `player_storage` SET `value` = 1 WHERE `player_storage`.`key` = 51052')
+	db.query('UPDATE `player_storage` SET `value` = 1 WHERE `player_storage`.`key` = 51053')
 end
 
 local function ServerSaveWarning(time)

--- a/data/scripts/globalevents/others/startup.lua
+++ b/data/scripts/globalevents/others/startup.lua
@@ -64,7 +64,8 @@ function serverstartup.onStartup()
 	db.asyncQuery('TRUNCATE TABLE `players_online`')
 
 	-- reset storages and allow purchase of boost in the store
-	db.query('UPDATE `player_storage` SET `value` = 0 WHERE `player_storage`.`key` = 51052')
+	db.query('UPDATE `player_storage` SET `value` = 1 WHERE `player_storage`.`key` = 51052')
+	db.query('UPDATE `player_storage` SET `value` = 1 WHERE `player_storage`.`key` = 51053')
 
 	-- delete canceled and rejected guilds
 	db.asyncQuery('DELETE FROM `guild_wars` WHERE `status` = 2')


### PR DESCRIPTION
it is not sure that it is bug free but I did all the tests I could to fix it and it worked correctly
Features:
All 50% fixes but implemented at 100% too
Each voucher that is purchased is increased by the amount
A boost can only be purchased and cannot accumulate 50% together with 100%

PT-BR
Não é certeza que esta livre de bugs porém fiz todos os tests que pude para dar fix e funcionou corretamente
Features:
Todas fix do 50% porém implementado no 100% também
Cada voucher que for comprado é aumentado o valor
Só pode ser comprado um boost não podendo acumular 50% junto com 100%