### PR TITLE
fix: lions rock quest

### DIFF
--- a/data/scripts/actions/other/gems.lua
+++ b/data/scripts/actions/other/gems.lua
@@ -34,6 +34,8 @@ local shrine = {
 
 local lionsRock = {
 	[25006] = {
+		itemId = 23813,
+		itemPos = {x = 33069, y = 32298, z = 9},
 		storage = Storage.LionsRock.Questline,
 		value = 9,
 		item = 2147,
@@ -164,7 +166,7 @@ function gems.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 			if not gemSpot then
 				toPosition:sendMagicEffect(setting.effect)
 				player:sendTextMessage(MESSAGE_EVENT_ADVANCE, setting.message)
-				item:remove()
+				item:remove(1)
 				addEvent(lionsRockCreateField, 2 * 1000, setting.itemPos, setting.fieldId, setting.storage)
 				addEvent(lionsRockFieldReset, 60 * 1000)
 				return true

--- a/data/scripts/actions/quests/lions_rock/lions_rock.lua
+++ b/data/scripts/actions/quests/lions_rock/lions_rock.lua
@@ -13,18 +13,20 @@ local rewards = {
 local UniqueTable = {
 	[40004] = {
 		storage = Storage.LionsRock.LionsStrength,
-		itemPosition = {x = 33134, y = 32289, z = 8},
+		itemPosition = {x = 33137, y = 32291, z = 8},
+		pagodaPosition = { x = 33134, y = 32289, z = 8},
 		item = 10551,
 		storage = Storage.LionsRock.Questline,
 		value = 1,
 		newValue = 2,
 		message = "You have sacrificed a cobra tongue at an ancient statue. The light in the small \z
 		pyramid nearby begins to shine.",
-		effect = CONST_ME_BLOCKHIT
+		effect = CONST_ME_BLOCKHIT,
 	},
 	[40005] = {
 		storage = Storage.LionsRock.LionsBeauty,
-		itemPosition = {x = 33136, y = 32369, z = 8},
+		itemPosition = {x = 33138, y = 32369, z = 8},
+		pagodaPosition = { x = 33136, y = 32369, z = 8},
 		item = 23760,
 		storage = Storage.LionsRock.Questline,
 		value = 2,
@@ -34,7 +36,8 @@ local UniqueTable = {
 	},
 	[40006] = {
 		storage = Storage.LionsRock.LionsTears,
-		itemPosition = {x = 33156, y = 32279, z = 8},
+		itemPosition = {x = 33154, y = 32279, z = 8},
+		pagodaPosition = { x = 33156, y = 32279, z = 8},
 		item = 23835,
 		storage = Storage.LionsRock.Questline,
 		value = 3,
@@ -100,17 +103,14 @@ function lionsRockSacrificesTest.onUse(player, item, fromPosition, target, toPos
 
 	if item.itemid == setting.item then
 		if player:getStorageValue(setting.storage) == setting.value then
-			if player:getStorageValue(setting.storage) < 0 then
-				local pagoda = Tile(setting.itemPosition):getItemById(3709)
-				if pagoda then
-					pagoda:transform(3710)
-					player:sendTextMessage(MESSAGE_EVENT_ADVANCE, setting.message)
-					player:setStorageValue(setting.storage, 1)
-					player:setStorageValue(setting.storage, setting.newValue)
-					player:removeItem(setting.item, 1)
-					toPosition:sendMagicEffect(setting.effect)
-					addEvent(reset, 15 * 1000)
-				end
+			local pagoda = Tile(setting.pagodaPosition):getItemById(3709)
+			if pagoda then
+				pagoda:transform(3710)
+				player:sendTextMessage(MESSAGE_EVENT_ADVANCE, setting.message)
+				player:setStorageValue(setting.storage, setting.newValue)
+				player:removeItem(setting.item, 1)
+				toPosition:sendMagicEffect(setting.effect)
+				addEvent(reset, 15 * 1000)
 			end
 		end
 	end
@@ -167,11 +167,6 @@ lionsGetHolyWater:register()
 local lionsRockTranslationScroll = Action()
 
 function lionsRockTranslationScroll.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	local setting = UniqueTable[item.uid]
-	if not setting then
-		return true
-	end
-
 	local amphoraPos = Position(33119, 32247, 9)
 	local amphoraID = 24314
 	local amphoraBrokenID = 24315
@@ -201,7 +196,7 @@ function lionsRockTranslationScroll.onUse(player, item, fromPosition, target, to
 	return true
 end
 
-lionsRockTranslationScroll:id(40008)
+lionsRockTranslationScroll:uid(40008)
 lionsRockTranslationScroll:register()
 
 -- Lions rock fountain
@@ -224,7 +219,7 @@ function lionsRockFountain.onUse(player, item, fromPosition, target, toPosition,
 
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE,
 			"Something sparkles in the fountain's water. You draw out a " .. rewards[reward] .. '.')
-		toPosition:sendMagicEffect(CONST_ME_HOLYAREA)
+		player:sendMagicEffect(CONST_ME_HOLYAREA)
 		player:addAchievement("Lion's Den Explorer")
 		item:transform(lionsRockSanctuaryRockId)
 		player:addItem(rewards[reward], 1)

--- a/data/scripts/movements/quests/lions_rock/lions_rock.lua
+++ b/data/scripts/movements/quests/lions_rock/lions_rock.lua
@@ -53,8 +53,7 @@ function lionsRockEntrance.onStepIn(creature, item, position, fromPosition)
 	if player:getStorageValue(Storage.LionsRock.Questline) >= 4 then
 		player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 		player:teleportTo({x = 33122, y = 32308, z = 8})
-		player:sendTextMessage(MESSAGE_EVENT_ADVANCE,
-					"You have passed the Lion's Tests and are now worthy to enter the inner sanctum!")
+		-- player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have passed the Lion's Tests and are now worthy to enter the inner sanctum!")
 		player:getPosition():sendMagicEffect(CONST_ME_THUNDER)
 	else
 		player:getPosition():sendMagicEffect(CONST_ME_ENERGYHIT)
@@ -81,9 +80,9 @@ function lionsRockSigns.onStepIn(creature, item, position, fromPosition)
 		return true
 	end
 
-	if player:getStorageValue(setting.needStorage) >= setting.value
-					and player:getStorageValue(setting.needStorage) < 10 then
-		if player:getStorageValue(setting.storage) < 0 then
+	local currentStorage = player:getStorageValue(setting.needStorage)
+	if currentStorage >= setting.value and currentStorage < 10 then
+		if player:getStorageValue(setting.storage) < 1 then
 			if player:getItemCount(setting.item) == 1 then
 				player:sendTextMessage(MESSAGE_EVENT_ADVANCE, setting.message1)
 				player:sendTextMessage(MESSAGE_EVENT_ADVANCE, setting.message2)
@@ -92,6 +91,7 @@ function lionsRockSigns.onStepIn(creature, item, position, fromPosition)
 			end
 		end
 	end
+	
 	return true
 end
 

--- a/data/scripts/movements/quests/lions_rock/lions_rock.lua
+++ b/data/scripts/movements/quests/lions_rock/lions_rock.lua
@@ -53,7 +53,7 @@ function lionsRockEntrance.onStepIn(creature, item, position, fromPosition)
 	if player:getStorageValue(Storage.LionsRock.Questline) >= 4 then
 		player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 		player:teleportTo({x = 33122, y = 32308, z = 8})
-		-- player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have passed the Lion's Tests and are now worthy to enter the inner sanctum!")
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have passed the Lion's Tests and are now worthy to enter the inner sanctum!")
 		player:getPosition():sendMagicEffect(CONST_ME_THUNDER)
 	else
 		player:getPosition():sendMagicEffect(CONST_ME_ENERGYHIT)

--- a/data/startup/tables/teleport.lua
+++ b/data/startup/tables/teleport.lua
@@ -67,7 +67,7 @@ TeleportUnique = {
 	-- Lions rock quest
 	-- Path: data\scripts\movements\quests\lions_rock\lions_rock.lua
 	[35009] = {
-		itemId = false,
+		itemId = 8058,
 		itemPos = {x = 33128, y = 32308, z = 8}
 	},
 	-- Dawnport quest

--- a/data/startup/tables/tile.lua
+++ b/data/startup/tables/tile.lua
@@ -277,18 +277,22 @@ TileAction = {
 TileUnique = {
 	-- Lions rock tiles
 	-- data\scripts\movements\quests\lions_rock\lionsrock.lua
+	-- snake sign
 	[25001] = {
 		itemId = 3152,
 		itemPos = {x = 33095, y = 32244, z = 9}
 	},
+	-- lizard sign
 	[25002] = {
 		itemId = 3152,
 		itemPos = {x = 33128, y = 32300, z = 9}
 	},
+	-- scorpion sign
 	[25003] = {
 		itemId = 3152,
 		itemPos = {x = 33109, y = 32329, z = 9}
 	},
+	-- hyena sign
 	[25004] = {
 		itemId = 3152,
 		itemPos = {x = 33127, y = 32340, z = 9}


### PR DESCRIPTION
fixes:
sanctum teleport
player effect when use fountain
amphora uid
remove only 1 gem instead all
pagoda position


---
issue reported by: SergioS