### PR TITLE
feat: golden anchor, resolves #2213

### DIFF
--- a/data/scripts/actions/quests/deepling_worldchange/golden_anchor.lua
+++ b/data/scripts/actions/quests/deepling_worldchange/golden_anchor.lua
@@ -1,0 +1,21 @@
+
+local anchorIds = {15358, 15359}
+local navigatorNpc = Position(33640, 31379, 9)
+local goldenAnchorTeleport = Action()
+
+function goldenAnchorTeleport.onUse(creature, item, fromPosition, target, toPosition, isHotkey)
+    if not creature:isPlayer() then
+        return
+    end
+
+    if target and table.contains(anchorIds, target.itemid) then
+        creature:teleportTo(navigatorNpc)
+        navigatorNpc:sendMagicEffect(CONST_ME_TELEPORT)
+        return true
+    end
+
+	return true
+end
+
+goldenAnchorTeleport:id(15432)
+goldenAnchorTeleport:register()


### PR DESCRIPTION
current behavior:
go to position 33505, 31251, 11
create item `small golden anchor`
use it, small golden anchor, on golden anchor
nothing happens.

expected behaivor:
get teleported to Navigator's Room when using the small golden anchor on the golden anchor
