### PR TITLE
Accurate magic level and skill level percentages

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2050,13 +2050,13 @@ void Player::removeExperience(uint64_t exp, bool sendText/* = false*/)
 	sendStats();
 }
 
-uint8_t Player::getPercentLevel(uint64_t count, uint64_t nextLevelCount)
+double_t Player::getPercentLevel(uint64_t count, uint64_t nextLevelCount)
 {
 	if (nextLevelCount == 0) {
 		return 0;
 	}
 
-	uint8_t result = (count * 100) / nextLevelCount;
+  double_t result = round( ((count * 100.) / nextLevelCount) * 100.) / 100.;
 	if (result > 100) {
 		return 0;
 	}

--- a/src/player.h
+++ b/src/player.h
@@ -112,7 +112,7 @@ struct OutfitEntry {
 struct Skill {
 	uint64_t tries = 0;
 	uint16_t level = 10;
-	uint8_t percent = 0;
+	double_t percent = 0;
 };
 
 struct Kill {
@@ -555,7 +555,7 @@ class Player final : public Creature, public Cylinder
 		uint32_t getBaseMagicLevel() const {
 			return magLevel;
 		}
-		uint8_t getMagicLevelPercent() const {
+		double_t getMagicLevelPercent() const {
 			return magLevelPercent;
 		}
 		uint8_t getSoul() const {
@@ -795,7 +795,7 @@ class Player final : public Creature, public Cylinder
 		uint16_t getBaseSkill(uint8_t skill) const {
 			return skills[skill].level;
 		}
-		uint8_t getSkillPercent(uint8_t skill) const {
+		double_t getSkillPercent(uint8_t skill) const {
 			return skills[skill].percent;
 		}
 
@@ -1987,7 +1987,7 @@ class Player final : public Creature, public Cylinder
 
 		uint8_t soul = 0;
 		uint8_t levelPercent = 0;
-		uint8_t magLevelPercent = 0;
+		double_t magLevelPercent = 0;
 
 		PlayerSex_t sex = PLAYERSEX_FEMALE;
 		OperatingSystem_t operatingSystem = CLIENTOS_NONE;
@@ -2033,7 +2033,7 @@ class Player final : public Creature, public Cylinder
 			return vocation->getAttackSpeed();
 		}
 
-		static uint8_t getPercentLevel(uint64_t count, uint64_t nextLevelCount);
+		static double_t getPercentLevel(uint64_t count, uint64_t nextLevelCount);
 		double getLostPercent() const;
 		uint64_t getLostExperience() const override {
 			return skillLoss ? static_cast<uint64_t>(experience * getLostPercent()) : 0;


### PR DESCRIPTION
Changed fields types for magic level percentage and skills level percentage from integer to double to use and show accurate values like Official.

Updated getMagicLevelPercent, getSkillPercent and getPercentLevel functions to return double values instead of integers.

Official results:

Magic level
![2021-01-03_144052065_Poecilia Reticulata_Hotkey](https://user-images.githubusercontent.com/31188201/103486683-ce6a3c00-4dff-11eb-82b8-2c03b16e159f.png)

Skills level
![2021-01-03_144210825_Poecilia Reticulata_Hotkey - copia](https://user-images.githubusercontent.com/31188201/103486858-49802200-4e01-11eb-8945-72ac9a03637a.png)

Current OTServBR results:

Magic level
![otservbr-ml-percent](https://user-images.githubusercontent.com/31188201/103486720-1be6a900-4e00-11eb-8199-c45d3535e86a.png)

Skills level
![otservbr-skill-percent](https://user-images.githubusercontent.com/31188201/103486729-3587f080-4e00-11eb-9ab7-2da12e02b159.png)

Fixed OTServBR results:

Magic level
![otservbr-ml-percent-fix](https://user-images.githubusercontent.com/31188201/103486754-7122ba80-4e00-11eb-8334-fdfa54339d91.png)

Skills level
![otservbr-skill-percent-fix](https://user-images.githubusercontent.com/31188201/103486766-80a20380-4e00-11eb-9c52-725488dfb724.png)
