### PR TITLE
Improvement: Event scheduler 'scripts'

### DIFF
--- a/data/XML/events.xml
+++ b/data/XML/events.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <events>
-	<event name="Otservbr example 1" startdate="11/03/2020" enddate="11/30/2020" >
+	<event name="Otservbr example 1" startdate="11/03/2020" enddate="11/30/2020" script="example.lua" >
 		<ingame exprate="250" lootrate="200" spawnrate="100" skillrate="200" />
 		<description description="Otserver br example 1 description double exp and a half, double loot !chance!, regular spawn and double skill" />
 		<colors colordark="#235c00" colorlight="#2d7400" />
 		<details displaypriority="6" isseasonal="0" specialevent="0" />
 	</event>
-	<event name="Otservbr example 2" startdate="10/2/2020" enddate="11/7/2020" >
+	<event name="Otservbr example 2" startdate="10/2/2020" enddate="11/7/2020" script="example.lua" >
 		<ingame exprate="50" lootrate="300" spawnrate="150" skillrate="100" />
 		<description description="Otserver br example 2 description 50% less exp, triple loot !chance!, 50% faster spawn and regular skill" />
 		<colors colordark="#735D10" colorlight="#8B6D05" />

--- a/data/events/scripts/scheduler/example.lua
+++ b/data/events/scripts/scheduler/example.lua
@@ -2,7 +2,7 @@
 -- Event scheduler lua scripts, on this file is possible to load any kind
 -- of global values, create functions or create and register GlobalEvents using the revscript system.
 -- For example you can load a 'local Example = GlobalEvent("example")' and register it with 'Example:register()',
--- adding the 'Example.onStartup()', 'Example.onThink(interval)' or 'Example:interval(time)'.
+-- adding the 'Example.onStartup()' or 'Example.onThink(interval)' with 'Example:interval(time)'.
 -- With 'onStartup()' you can load any raid, for example loading a entire map/hunt and the choseen spawns.
 
 -- Examples:

--- a/data/events/scripts/scheduler/example.lua
+++ b/data/events/scripts/scheduler/example.lua
@@ -1,0 +1,25 @@
+-- [OtServerBr]
+-- Event scheduler lua scripts, on this file is possible to load any kind
+-- of global values, create functions or create and register GlobalEvents using the revscript system.
+-- For example you can load a 'local Example = GlobalEvent("example")' and register it with 'Example:register()',
+-- adding the 'Example.onStartup()', 'Example.onThink(interval)' or 'Example:interval(time)'.
+-- With 'onStartup()' you can load any raid, for example loading a entire map/hunt and the choseen spawns.
+
+-- Examples:
+-- Loading map: Game.loadMap('data/world/myMapFolder/myMapFile.otbm')
+-- Loading spawn: addEvent(function() Game.loadSpawnFile('data/world/mySpawnFolder/mySpawnFile.xml) end, 30 * 1000)
+
+local Example_One = GlobalEvent("Example one")
+function Example_One.onStartup()
+	return true
+end
+
+Example_One:register()
+
+local Example_Two = GlobalEvent("Example two")
+function Example_Two.onThink(interval)
+	return true
+end
+
+Example_Two:interval(10000) -- 10 seconds interval
+Example_Two:register()

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -207,31 +207,38 @@ bool Game::loadScheduleEventFromXml()
 			}	
 		}
 
-			for (auto schedENode : schedNode.children()) {
-				if ((schedENode.attribute("exprate"))) {
-					uint16_t exprate = pugi::cast<uint16_t>(schedENode.attribute("exprate").value());
-					g_game.setExpSchedule(exprate);
-					ss << " exp: " << (exprate - 100) << "%";
-				}
-
-				if ((schedENode.attribute("lootrate"))) {
-					uint16_t lootrate = pugi::cast<uint16_t>(schedENode.attribute("lootrate").value());
-					g_game.setLootSchedule(lootrate);
-					ss << ", loot: " << (lootrate - 100) << "%";
-				}
-
-				if ((schedENode.attribute("spawnrate"))) {
-					uint32_t spawnrate = pugi::cast<uint32_t>(schedENode.attribute("spawnrate").value());
-					g_game.setSpawnSchedule(spawnrate);
-					ss << ", spawn: "  << (spawnrate - 100) << "%";
-				}
-
-				if ((schedENode.attribute("skillrate"))) {
-					uint16_t skillrate = pugi::cast<uint16_t>(schedENode.attribute("skillrate").value());
-					g_game.setSkillSchedule(skillrate);
-					ss << ", skill: " << (skillrate - 100) << "%";
-				}
+		if ((attr = schedNode.attribute("script"))) {
+			if (!(g_scripts->loadEventSchedulerScripts(attr.as_string()))) {
+				std::cout << "[Warning - Game::loadScheduleEventFromXml] Can not load the file '" << attr.as_string() << "' on '/events/scripts/scheduler/'." << std::endl;
+				return false;
 			}
+		}
+
+		for (auto schedENode : schedNode.children()) {
+			if ((schedENode.attribute("exprate"))) {
+				uint16_t exprate = pugi::cast<uint16_t>(schedENode.attribute("exprate").value());
+				g_game.setExpSchedule(exprate);
+				ss << " exp: " << (exprate - 100) << "%";
+			}
+
+			if ((schedENode.attribute("lootrate"))) {
+				uint16_t lootrate = pugi::cast<uint16_t>(schedENode.attribute("lootrate").value());
+				g_game.setLootSchedule(lootrate);
+				ss << ", loot: " << (lootrate - 100) << "%";
+			}
+
+			if ((schedENode.attribute("spawnrate"))) {
+				uint32_t spawnrate = pugi::cast<uint32_t>(schedENode.attribute("spawnrate").value());
+				g_game.setSpawnSchedule(spawnrate);
+				ss << ", spawn: "  << (spawnrate - 100) << "%";
+			}
+
+			if ((schedENode.attribute("skillrate"))) {
+				uint16_t skillrate = pugi::cast<uint16_t>(schedENode.attribute("skillrate").value());
+				g_game.setSkillSchedule(skillrate);
+				ss << ", skill: " << (skillrate - 100) << "%";
+			}
+		}
 		std::cout << ss.str() << "." << std::endl;
 	}
 	return true;

--- a/src/otserv.cpp
+++ b/src/otserv.cpp
@@ -239,15 +239,15 @@ void mainLoader(int, char*[], ServiceManager* services) {
 		return;
 	}
 
-	std::cout << ">> Loading event scheduler" << std::endl;
-	if (!g_game.loadScheduleEventFromXml()) {
-		startupErrorMessage("Unable to load event schedule!");
-	}
-
 	std::cout << ">> Loading script systems" << std::endl;
 	if (!ScriptingManager::getInstance().loadScriptSystems()) {
 		startupErrorMessage("Failed to load script systems");
 		return;
+	}
+
+	std::cout << ">> Loading event scheduler" << std::endl;
+	if (!g_game.loadScheduleEventFromXml()) {
+		startupErrorMessage("Unable to load event schedule!");
 	}
 
 	std::cout << ">> Loading lua scripts" << std::endl;

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -37,6 +37,32 @@ Scripts::~Scripts()
 	scriptInterface.reInitState();
 }
 
+bool Scripts::loadEventSchedulerScripts(const std::string& fileName)
+{
+	namespace fs = boost::filesystem;
+
+	const auto dir = fs::current_path() / "data" / "events" / "scripts" / "scheduler";
+	if(!fs::exists(dir) || !fs::is_directory(dir)) {
+		std::cout << "[Warning - Scripts::loadEventSchedulerScripts] Can not load folder 'scheduler' on '/data/events/scripts'." << std::endl;
+		return false;
+	}
+
+	fs::recursive_directory_iterator endit;
+	for(fs::recursive_directory_iterator it(dir); it != endit; ++it) {
+		if(fs::is_regular_file(*it) && it->path().extension() == ".lua") {
+			if (it->path().filename().string() == fileName) {
+				if(scriptInterface.loadFile(it->path().string()) == -1) {
+					std::cout << "> " << it->path().string() << " [error]" << std::endl;
+					std::cout << "^ " << scriptInterface.getLastLuaError() << std::endl;
+					continue;
+				}
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 bool Scripts::loadScripts(std::string folderName, bool isLib, bool reload)
 {
 	namespace fs = boost::filesystem;

--- a/src/script.h
+++ b/src/script.h
@@ -29,6 +29,7 @@ class Scripts
 		Scripts();
 		~Scripts();
 
+		bool loadEventSchedulerScripts(const std::string& fileName);
 		bool loadScripts(std::string folderName, bool isLib, bool reload);
 		LuaScriptInterface& getScriptInterface() {
 			return scriptInterface;


### PR DESCRIPTION
Add the possibility to load a custom lua file throught the 'event schedule'.
```
-- Event scheduler lua scripts, on this file is possible to load any kind
-- of global values, create functions or create and register GlobalEvents using the revscript system.
-- For example you can load a 'local Example = GlobalEvent("example")' and register it with 'Example:register()',
-- adding the 'Example.onStartup()' or 'Example.onThink(interval)' with 'Example:interval(time)'.
-- With 'onStartup()' you can load any raid, for example loading a entire map/hunt and the choseen spawns.

-- Examples:
-- Loading map: Game.loadMap('data/world/myMapFolder/myMapFile.otbm')
-- Loading spawn: addEvent(function() Game.loadSpawnFile('data/world/mySpawnFolder/mySpawnFile.xml) end, 30 * 1000)
```

Can configure it to load maps for world change and/or special events (raids).