### PR TITLE
Dawnport poison fluids fix

### DIFF
--- a/data/scripts/actions/other/fluids.lua
+++ b/data/scripts/actions/other/fluids.lua
@@ -34,6 +34,47 @@ local function graveStoneTeleport(cid, fromPosition, toPosition)
 	toPosition:sendMagicEffect(CONST_ME_MORTAREA)
 end
 
+-- Special poison condition used on dawnport residents
+-- Doesnt allow poison yourself when health is <= 10 or your health go low than 10 due poison
+function dawnportPoisonCondition(player)
+	local health = player:getHealth();
+	local minHealth = 10
+	-- Default poison values (not possible read condition parameters)
+	local startValue = 5
+	local minPoisonDamage = 50
+	local maxPoisonDamage = 120
+	
+	-- Special poison
+	if health > minHealth and health < (minHealth + maxPoisonDamage) then
+		local maxValue = health - minHealth
+		local minValue = minPoisonDamage
+		local value = startValue
+		local minRoundsDamage = (startValue * (startValue + 1) / 2)
+		
+		if maxValue < minPoisonDamage then
+			minValue = maxValue
+		end
+		
+		if maxValue < minRoundsDamage then
+			value = math.floor( math.sqrt(maxValue) )
+		end
+		
+		local poisonMod = Condition(CONDITION_POISON)
+		poisonMod:setParameter(CONDITION_PARAM_DELAYED, true)
+		poisonMod:setParameter(CONDITION_PARAM_MINVALUE, -minValue)
+		poisonMod:setParameter(CONDITION_PARAM_MAXVALUE, -maxValue)
+		poisonMod:setParameter(CONDITION_PARAM_STARTVALUE, -value)
+		poisonMod:setParameter(CONDITION_PARAM_TICKINTERVAL, 4000)
+		poisonMod:setParameter(CONDITION_PARAM_FORCEUPDATE, true)
+		
+		player:addCondition(poisonMod)
+	-- Common poison
+	elseif health >= (minHealth + maxPoisonDamage) then
+		player:addCondition(poison)
+	end
+	-- Otherwise no poison
+end
+
 local fluid = Action()
 
 function fluid.onUse(player, item, fromPosition, target, toPosition, isHotkey)
@@ -59,7 +100,13 @@ function fluid.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 				player:addCondition(drunk)
 
 			elseif item.type == 4 then
-				player:addCondition(poison)
+				local town = player:getTown()
+				if town and town:getId() == TOWNS_LIST.DAWNPORT then
+					dawnportPoisonCondition(player)
+				else
+					player:addCondition(poison)
+				end
+				
 
 			elseif item.type == 7 then
 				player:addMana(math.random(50, 150))

--- a/data/scripts/actions/other/fluids.lua
+++ b/data/scripts/actions/other/fluids.lua
@@ -43,22 +43,22 @@ function dawnportPoisonCondition(player)
 	local startValue = 5
 	local minPoisonDamage = 50
 	local maxPoisonDamage = 120
-	
+
 	-- Special poison
 	if health > minHealth and health < (minHealth + maxPoisonDamage) then
 		local maxValue = health - minHealth
 		local minValue = minPoisonDamage
 		local value = startValue
 		local minRoundsDamage = (startValue * (startValue + 1) / 2)
-		
+
 		if maxValue < minPoisonDamage then
 			minValue = maxValue
 		end
-		
+
 		if maxValue < minRoundsDamage then
 			value = math.floor( math.sqrt(maxValue) )
 		end
-		
+
 		local poisonMod = Condition(CONDITION_POISON)
 		poisonMod:setParameter(CONDITION_PARAM_DELAYED, true)
 		poisonMod:setParameter(CONDITION_PARAM_MINVALUE, -minValue)
@@ -66,7 +66,7 @@ function dawnportPoisonCondition(player)
 		poisonMod:setParameter(CONDITION_PARAM_STARTVALUE, -value)
 		poisonMod:setParameter(CONDITION_PARAM_TICKINTERVAL, 4000)
 		poisonMod:setParameter(CONDITION_PARAM_FORCEUPDATE, true)
-		
+
 		player:addCondition(poisonMod)
 	-- Common poison
 	elseif health >= (minHealth + maxPoisonDamage) then
@@ -106,12 +106,9 @@ function fluid.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 				else
 					player:addCondition(poison)
 				end
-				
-
 			elseif item.type == 7 then
 				player:addMana(math.random(50, 150))
 				fromPosition:sendMagicEffect(CONST_ME_MAGIC_BLUE)
-
 			elseif item.type == 10 then
 				player:addHealth(60)
 				fromPosition:sendMagicEffect(CONST_ME_MAGIC_BLUE)


### PR DESCRIPTION
Added an special poison condition to dawnport players, it avoids poison yourself when your health is <= 10 or if its higher it dont goes lower than 10 health.

- I got noticed about this thing some days ago on Official thinking about ways to trick it. I was trying to suicide drinking poison after pass the vocation reward door to get downgraded to level 7, so at level 7 you dont lose items from inventory and then try pass again through the door take the vocation rewards and try suicide again to get back to the temple with the rewards...

- But hey **Cipsoft** seems already handle it avoiding to kill yourself in that way when you reside at dawnport. May be it also was implemented to avoid veteran players kill noob players scamming them with the typical way of "hey dude your health is low... drink this '**potion**'... LOL I used that on rookgaard like 15 years ago xD

![2021-01-16_034907584_Pollicipes_Hotkey](https://user-images.githubusercontent.com/31188201/105507096-137ce200-5ccb-11eb-970e-25e2ccd7b038.png)
