### PR TITLE
Fix loadLuaMapBook function

### DIFF
--- a/data/scripts/globalevents/others/startup.lua
+++ b/data/scripts/globalevents/others/startup.lua
@@ -8,10 +8,10 @@ function serverstartup.onStartup()
 	print("> Loaded " .. (#SignTable) .. " signs in the map")
 	-- Book table
 	loadLuaMapBook(BookTable)
-	print("> Loaded " .. (#BookTable) .. " books in the map")
+	--print("> Loaded " .. (#BookTable) .. " books in the map")
 	-- Documents table
 	loadLuaMapBook(DocumentsTable)
-	print("> Loaded " .. (#DocumentsTable) .. " documents in the map")
+	--print("> Loaded " .. (#DocumentsTable) .. " documents in the map")
 
 	-- Action and unique tables
 	-- Chest table

--- a/data/scripts/globalevents/others/startup.lua
+++ b/data/scripts/globalevents/others/startup.lua
@@ -6,12 +6,8 @@ function serverstartup.onStartup()
 	-- Sign table
 	loadLuaMapSign(SignTable)
 	print("> Loaded " .. (#SignTable) .. " signs in the map")
-	-- Book table
-	loadLuaMapBook(BookTable)
-	--print("> Loaded " .. (#BookTable) .. " books in the map")
-	-- Documents table
-	loadLuaMapBook(DocumentsTable)
-	--print("> Loaded " .. (#DocumentsTable) .. " documents in the map")
+	-- Book/Document table
+	loadLuaMapBookDocument(BookDocumentTable)
 
 	-- Action and unique tables
 	-- Chest table

--- a/data/startup/others/functions.lua
+++ b/data/startup/others/functions.lua
@@ -89,20 +89,13 @@ end
 function loadLuaMapBookDocument(tablename)
 	-- Index 1: total valid, index 2: total loaded
 	local totals = {0, 0}
-	
-	-- Use ipairs to follow an numeric order (pairs order is unspecified)
-	-- So if we want create items in specific order, just have to define them on that order
-	-- (Although it only works for map items, container items are always added at first index. TO BE HANDLED)
 	for index, value in ipairs(tablename) do
 		-- Skip silently (some items dont have a know position yet defined, lets ignore them)
 		if not value.position then
 			goto skip
 		end
-		
 		totals[1] = totals[1] + 1
-		
 		local tile = Tile(value.position)
-		
 		-- Check if is a valid tile
 		if tile then
 			local item
@@ -110,24 +103,20 @@ function loadLuaMapBookDocument(tablename)
 			if value.containerId then
 				-- Try find the container on the map
 				local container = tile:getItemById(value.containerId)
-				
 				if not container then
 					print(string.format("> loadLuaMapBookDocument container not found! index: %d, containerId: %d", index, value.containerId))
 					goto skip
 				end
-				
 				-- Create the item inside the container
 				item = container:addItem(value.itemId, 1, INDEX_WHEREEVER, FLAG_NOLIMIT)
 			else
 				-- Try first find the item on the map (in some cases the item is already on the map)
 				item = tile:getItemById(value.itemId)
-				
 				-- Create the item at map position
 				if not item then
 					item = Game.createItem(value.itemId, 1, value.position)
 				end
 			end
-			
 			-- If the item exists, add the text
 			if item then
 				item:setAttribute(ITEM_ATTRIBUTE_TEXT, value.text)
@@ -138,11 +127,9 @@ function loadLuaMapBookDocument(tablename)
 		else
 			print(string.format("> loadLuaMapBookDocument tile not found! index: %d, position: x=%d y=%d z=%d", index, value.position.x, value.position.y, value.position.z))
 		end
-		
 		-- Use goto to jump next item due Lua loops dont have continue
 		::skip::
 	end
-	
 	if totals[1] == totals[2] then
 		print(string.format("> Loaded %d books and documents in the map", totals[2]))
 	else

--- a/data/startup/others/functions.lua
+++ b/data/startup/others/functions.lua
@@ -93,36 +93,37 @@ function loadLuaMapBook(tablename)
 	
 	-- Use ipairs to follow an numeric order (pairs order is unspecified)
 	for index, value in ipairs(tablename) do
-		-- Skip silently (some books dont have a know position yet defined, lets ignore them)
-		if not value.itemPos then
+		-- Skip silently (some items dont have a know position yet defined, lets ignore them)
+		if not value.position then
 			goto skip
 		end
 		
 		totals[1] = totals[1] + 1
 		
-		local tile = Tile(value.itemPos)
+		local tile = Tile(value.position)
 		
 		-- Check if is a valid tile/position
 		if tile then
 			local item
-			-- Check if is a contained book (itemId is the container and bookId is the book)
-			if value.containerBook == true then
-				local container = tile:getItemById(value.itemId)
+			-- Check if is a contained item
+			if value.containerId then
+				-- Try find the container on the map
+				local container = tile:getItemById(value.containerId)
 				
 				if not container then
-					print(string.format("> loadLuaMapBook container item not found id: %d, item id: %d", index, value.itemId))
+					print(string.format("> loadLuaMapBook container not found! index: %d, containerId: %d", index, value.containerId))
 					goto skip
 				end
 				
-				-- Create the book item inside the container
-				item = container:addItem(value.bookId, 1, INDEX_WHEREEVER)
+				-- Create the item inside the container
+				item = container:addItem(value.itemId, 1, INDEX_WHEREEVER)
 			else
-				-- Try find existing item on the map (itemId is the book)
-				if tile:getItemCountById(value.itemId) == 1 then
-					item = tile:getItemById(value.itemId)
-				else
-					-- Create book item at map position
-					item = Game.createItem(value.itemId, 1, value.itemPos)
+				-- Try first find the item on the map
+				item = tile:getItemById(value.itemId)
+				
+				-- Create item at map position
+				if not item then
+					item = Game.createItem(value.itemId, 1, value.position)
 				end
 			end
 			
@@ -131,10 +132,10 @@ function loadLuaMapBook(tablename)
 				item:setAttribute(ITEM_ATTRIBUTE_TEXT, value.text)
 				totals[2] = totals[2] + 1
 			else
-				print(string.format("> loadLuaMapBook book item not found id: %d, item id: %d", index, value.itemId))
+				print(string.format("> loadLuaMapBook item not found or created! index: %d, itemId: %d", index, value.itemId))
 			end
 		else
-			print(string.format("> loadLuaMapBook tile not found id: %d, item id: %d", index, value.itemId))
+			print(string.format("> loadLuaMapBook tile not found! index: %d, position: x=%d y=%d z=%d", index, value.position.x, value.position.y, value.position.z))
 		end
 		
 		-- Use goto to jump next item due Lua loops dont have continue

--- a/data/startup/others/functions.lua
+++ b/data/startup/others/functions.lua
@@ -133,7 +133,7 @@ function loadLuaMapBookDocument(tablename)
 	if totals[1] == totals[2] then
 		print(string.format("> Loaded %d books and documents in the map", totals[2]))
 	else
-		print(string.format("> Loaded %d of %d books and documents in the map", totals[1], totals[2]))
+		print(string.format("> Loaded %d of %d books and documents in the map", totals[2], totals[1]))
 	end
 end
 

--- a/data/startup/others/functions.lua
+++ b/data/startup/others/functions.lua
@@ -86,12 +86,13 @@ function loadLuaMapSign(tablename)
 	end
 end
 
--- Creates books on the map from the BookTable
-function loadLuaMapBook(tablename)
+function loadLuaMapBookDocument(tablename)
 	-- Index 1: total valid, index 2: total loaded
 	local totals = {0, 0}
 	
 	-- Use ipairs to follow an numeric order (pairs order is unspecified)
+	-- So if we want create items in specific order, just have to define them on that order
+	-- (Although it only works for map items, container items are always added at first index. TO BE HANDLED)
 	for index, value in ipairs(tablename) do
 		-- Skip silently (some items dont have a know position yet defined, lets ignore them)
 		if not value.position then
@@ -102,7 +103,7 @@ function loadLuaMapBook(tablename)
 		
 		local tile = Tile(value.position)
 		
-		-- Check if is a valid tile/position
+		-- Check if is a valid tile
 		if tile then
 			local item
 			-- Check if is a contained item
@@ -111,17 +112,17 @@ function loadLuaMapBook(tablename)
 				local container = tile:getItemById(value.containerId)
 				
 				if not container then
-					print(string.format("> loadLuaMapBook container not found! index: %d, containerId: %d", index, value.containerId))
+					print(string.format("> loadLuaMapBookDocument container not found! index: %d, containerId: %d", index, value.containerId))
 					goto skip
 				end
 				
 				-- Create the item inside the container
-				item = container:addItem(value.itemId, 1, INDEX_WHEREEVER)
+				item = container:addItem(value.itemId, 1, INDEX_WHEREEVER, FLAG_NOLIMIT)
 			else
-				-- Try first find the item on the map
+				-- Try first find the item on the map (in some cases the item is already on the map)
 				item = tile:getItemById(value.itemId)
 				
-				-- Create item at map position
+				-- Create the item at map position
 				if not item then
 					item = Game.createItem(value.itemId, 1, value.position)
 				end
@@ -132,10 +133,10 @@ function loadLuaMapBook(tablename)
 				item:setAttribute(ITEM_ATTRIBUTE_TEXT, value.text)
 				totals[2] = totals[2] + 1
 			else
-				print(string.format("> loadLuaMapBook item not found or created! index: %d, itemId: %d", index, value.itemId))
+				print(string.format("> loadLuaMapBookDocument item not found or created! index: %d, itemId: %d", index, value.itemId))
 			end
 		else
-			print(string.format("> loadLuaMapBook tile not found! index: %d, position: x=%d y=%d z=%d", index, value.position.x, value.position.y, value.position.z))
+			print(string.format("> loadLuaMapBookDocument tile not found! index: %d, position: x=%d y=%d z=%d", index, value.position.x, value.position.y, value.position.z))
 		end
 		
 		-- Use goto to jump next item due Lua loops dont have continue
@@ -143,9 +144,9 @@ function loadLuaMapBook(tablename)
 	end
 	
 	if totals[1] == totals[2] then
-		print(string.format("> Loaded %d books in the map", totals[2]))
+		print(string.format("> Loaded %d books and documents in the map", totals[2]))
 	else
-		print(string.format("> Loaded %d of %d books in the map", totals[1], totals[2]))
+		print(string.format("> Loaded %d of %d books and documents in the map", totals[1], totals[2]))
 	end
 end
 

--- a/data/startup/others/functions.lua
+++ b/data/startup/others/functions.lua
@@ -90,45 +90,57 @@ function loadLuaMapBookDocument(tablename)
 	-- Index 1: total valid, index 2: total loaded
 	local totals = {0, 0}
 	for index, value in ipairs(tablename) do
-		-- Skip silently (some items dont have a know position yet defined, lets ignore them)
-		if not value.position then
-			goto skip
-		end
-		totals[1] = totals[1] + 1
 		local tile = Tile(value.position)
-		-- Check if is a valid tile
-		if tile then
-			local item
-			-- Check if is a contained item
-			if value.containerId then
-				-- Try find the container on the map
-				local container = tile:getItemById(value.containerId)
-				if not container then
-					print(string.format("> loadLuaMapBookDocument container not found! index: %d, containerId: %d", index, value.containerId))
-					goto skip
+		-- Check position (some items dont have a know position yet defined, lets ignore them)
+		if value.position then
+			totals[1] = totals[1] + 1
+			-- Check if is a valid tile
+			if tile then
+				-- Try find the container on the map if containerId is set
+				local container = (value.containerId and tile:getItemById(value.containerId) or nil)
+				-- Check if cotainerId is not set or if containerId is set also if the container exists
+				if not value.containerId or value.containerId and container then
+					local item
+					-- Check if the item need to be in a container
+					if container then
+						-- Create the item inside the container
+						item = container:addItem(value.itemId, 1, INDEX_WHEREEVER, FLAG_NOLIMIT)
+					else
+						-- Try first find the item on the map (in some cases the item is already on the map)
+						item = tile:getItemById(value.itemId)
+						-- Create the item at map position if dont was found
+						if not item then
+							item = Game.createItem(value.itemId, 1, value.position)
+						end
+					end
+					-- If the item exists, add the text
+					if item then
+						item:setAttribute(ITEM_ATTRIBUTE_TEXT, value.text)
+						totals[2] = totals[2] + 1
+					else
+						print(string.format(
+							"> loadLuaMapBookDocument item not found or created! index: %d, itemId: %d",
+							index,
+							value.itemId
+						))
+					end
+				else
+					print(string.format(
+						"> loadLuaMapBookDocument container not found! index: %d, containerId: %d",
+						index,
+						value.containerId
+					))
 				end
-				-- Create the item inside the container
-				item = container:addItem(value.itemId, 1, INDEX_WHEREEVER, FLAG_NOLIMIT)
 			else
-				-- Try first find the item on the map (in some cases the item is already on the map)
-				item = tile:getItemById(value.itemId)
-				-- Create the item at map position
-				if not item then
-					item = Game.createItem(value.itemId, 1, value.position)
-				end
+				print(string.format(
+					"> loadLuaMapBookDocument tile not found! index: %d, position: x=%d y=%d z=%d",
+					index,
+					value.position.x,
+					value.position.y,
+					value.position.z
+				))
 			end
-			-- If the item exists, add the text
-			if item then
-				item:setAttribute(ITEM_ATTRIBUTE_TEXT, value.text)
-				totals[2] = totals[2] + 1
-			else
-				print(string.format("> loadLuaMapBookDocument item not found or created! index: %d, itemId: %d", index, value.itemId))
-			end
-		else
-			print(string.format("> loadLuaMapBookDocument tile not found! index: %d, position: x=%d y=%d z=%d", index, value.position.x, value.position.y, value.position.z))
 		end
-		-- Use goto to jump next item due Lua loops dont have continue
-		::skip::
 	end
 	if totals[1] == totals[2] then
 		print(string.format("> Loaded %d books and documents in the map", totals[2]))

--- a/data/startup/tables/writeable.lua
+++ b/data/startup/tables/writeable.lua
@@ -1,9 +1,13 @@
+-- Guidelines for BookTable:
+-- containerId: id of the container item (bookcase, shelf, etc). Optional.
+-- itemId: id of item (book, scroll, etc).
+-- position: position of the container or of the item (depending on if the item is on a container or not).
+-- text: text of item (book, scroll, etc).
 BookTable = {
 	[1] = {
-		containerBook = true,
-		itemId = 1718,
-		bookId = 1962,
-		itemPos = {x = 32063, y = 31884, z = 4},
+		containerId = 1718,
+		itemId = 1962,
+		position = {x = 32063, y = 31884, z = 4},
 		text = [[
 MONSTERS AND FOES OF DAWNPORT I
 
@@ -21,10 +25,9 @@ Other beasts - It is certain that other beasts live in the dungeons of our isle.
 		]]
 	},
 	[2] = {
-		containerBook = true,
-		itemId = 1718,
-		bookId = 1962,
-		itemPos = {x = 32063, y = 31884, z = 4},
+		containerId = 1718,
+		itemId = 1962,
+		position = {x = 32063, y = 31884, z = 4},
 		text = [[
 MONSTERS AND FOES OF DAWNPORT II
 
@@ -42,10 +45,9 @@ The rat - Whether humans brought this pest with them on the isle or whether rats
 		]]
 	},
 	[3] = {
-		containerBook = true,
-		itemId = 1718,
-		bookId = 1962,
-		itemPos = {x = 32063, y = 31884, z = 4},
+		containerId = 1718,
+		itemId = 1962,
+		position = {x = 32063, y = 31884, z = 4},
 		text = [[
 MONSTERS AND FOES OF DAWNPORT III
 
@@ -59,10 +61,9 @@ The poison spider - Though only slightly tougher than an ordinary spider, this o
 		]]
 	},
 	[4] = {
-		containerBook = true,
-		itemId = 1719,
-		bookId = 1962,
-		itemPos = {x = 32064, y = 31884, z = 4},
+		containerId = 1719,
+		itemId = 1962,
+		position = {x = 32064, y = 31884, z = 4},
 		text = [[
 MONSTERS AND FOES OF DAWNPORT IV
 
@@ -76,10 +77,9 @@ The Meadow strider - A giant bird that stalks the marshes and meadows, the meado
 		]]
 	},
 	[5] = {
-		containerBook = true,
-		itemId = 1719,
-		bookId = 1962,
-		itemPos = {x = 32064, y = 31884, z = 4},
+		containerId = 1719,
+		itemId = 1962,
+		position = {x = 32064, y = 31884, z = 4},
 		text = [[
 MONSTERS AND FOES OF DAWNPORT V
 
@@ -98,10 +98,9 @@ The squirrel - Swift and impish, squirrels will run from any human they see. Hun
 	},
 	--The isle of the kings (need position)
 	[6] = {
-		containerBook = true,
-		itemId = 1720,
-		bookId = 1955,
-		--itemPos = {x = xxxxx, y = xxxxx, z = x},
+		containerId = 1720,
+		itemId = 1955,
+		--position = {x = xxxxx, y = xxxxx, z = x},
 		text = [[
 Kazordoon, the hidden city
 In the blocklike Mountain, known as the big old one, the hidden city of kazordoon is nestled. Its the last refuge of the ancient race of dwarves. Hidden and heavily fortified it was the last stand of dwarvenhood in the wars of creation and the last hope of that race to adapt to and survive the new ages. The famous giant statue, known as colossus guards its entry, alhough the narrow valley makes it difficult to see that fortress-statue and admire its beauty. Kazordoon is known for its safety and masterful smithery throughout the lands.
@@ -109,10 +108,9 @@ Since some generations the dwarven city (whose ruler claims a title that might b
 ]]
 	},
 	[7] = {
-		containerBook = true,
-		itemId = 1720,
-		bookId = 1959,
-		itemPos = {x = 32065, y = 31884, z = 4},
+		containerId = 1720,
+		itemId = 1959,
+		position = {x = 32065, y = 31884, z = 4},
 		text = [[
 Kazordoon, the hidden city
 In the blocklike Mountain, known as the big old one, the hidden city of kazordoon is nestled. Its the last refuge of the ancient race of dwarves. Hidden and heavily fortified it was the last stand of dwarvenhood in the wars of creation and the last hope of that race to adapt to and survive the new ages. The famous giant statue, known as colossus guards its entry, alhough the narrow valley makes it difficult to see that fortress-statue and admire its beauty. Kazordoon is known for its safety and masterful smithery throughout the lands.
@@ -120,10 +118,9 @@ Since some generations the dwarven city (whose ruler claims a title that might b
 		]]
 	},
 	[8] = {
-		containerBook = true,
-		itemId = 1720,
-		bookId = 1965,
-		itemPos = {x = 32066, y = 31884, z = 4},
+		containerId = 1720,
+		itemId = 1965,
+		position = {x = 32066, y = 31884, z = 4},
 		text = [[
 Genesis I. The Awakening of the Gods
 
@@ -140,10 +137,9 @@ Unfortunately, their combined efforts were hardly more successful. Just like bef
 		]]
 	},
 	[9] = {
-		containerBook = true,
-		itemId = 1720,
-		bookId = 1965,
-		itemPos = {x = 32066, y = 31884, z = 4},
+		containerId = 1720,
+		itemId = 1965,
+		position = {x = 32066, y = 31884, z = 4},
 		text = [[
 Genesis IV. The First Creatures
 
@@ -156,10 +152,9 @@ Zathroth watched Brog's experiments with great interest. So far he had not held 
 		]]
 	},
 	[10] = {
-		containerBook = true,
-		itemId = 1718,
-		bookId = 1955,
-		--itemPos = (isle of the kings),
+		containerId = 1718,
+		itemId = 1955,
+		--position = (isle of the kings),
 		text = [[
 The Minotaurs by Iregarn Pt. 1
 The minotaurs claimed that they were once the marshals and favoured people of Blog, the raging one. In the wars over creation they were one of the most successful races. But as the war grew more and more fierce it were the wild and raging minotaurs that had to pay the worst blood toll. The berserker rage inherent to their race made them a formidable opponent but also very vulnerable.
@@ -168,10 +163,9 @@ He looked upon the world and for the first time in aeons a minotaurean warrior s
 ]]
 	},
 	[11] = {
-		containerBook = true,
-		itemId = 1718,
-		bookId = 1959,
-		itemPos = {x = 32061, y = 31889, z = 4},
+		containerId = 1718,
+		itemId = 1959,
+		position = {x = 32061, y = 31889, z = 4},
 		text = [[
 The Minotaurs by Iregarn Pt. 1
 The minotaurs claimed that they were once the marshals and favoured people of Blog, the raging one. In the wars over creation they were one of the most successful races. But as the war grew more and more fierce it were the wild and raging minotaurs that had to pay the worst blood toll. The berserker rage inherent to their race made them a formidable opponent but also very vulnerable.
@@ -180,38 +174,34 @@ He looked upon the world and for the first time in aeons a minotaurean warrior s
 ]]
 	},
 	[12] = {
-		containerBook = true,
-		itemId = 1720,
-		bookId = 1950,
-		--itemPos = (Rookgaard Academy),
+		containerId = 1720,
+		itemId = 1950,
+		--position = (Rookgaard Academy),
 		text = [[
 Orcs ARE intelligent. Though some dwarves mumble about a shared hivemind of the greenskins, there is no evidence for that. Orcs have speech and are capable to learn other humanoids language quite well ... if they want, what almost never is the case. They lack a written language though. Some of the more educated orcs use human letters to write down orcish texts. Its rumored that the orcs we encounter now and then are just barbarians of their own kind and that there is a more 'civilized' orcish culture somewhere. There are some clues that the orcs indeed had a written language, but the modern orcs is unable to read it as we are.
 ]]
 	},
 	[13] = {
-		containerBook = true,
-		itemId = 1720,
-		bookId = 1981,
-		itemPos = {x = 32062, y = 31889, z = 4},
+		containerId = 1720,
+		itemId = 1981,
+		position = {x = 32062, y = 31889, z = 4},
 		text = [[
 Orcs ARE intelligent. Though some dwarves mumble about a shared hivemind of the greenskins, there is no evidence for that. Orcs have speech and are capable to learn other humanoids language quite well ... if they want, what almost never is the case. They lack a written language though. Some of the more educated orcs use human letters to write down orcish texts. Its rumored that the orcs we encounter now and then are just barbarians of their own kind and that there is a more 'civilized' orcish culture somewhere. There are some clues that the orcs indeed had a written language, but the modern orcs is unable to read it as we are.
 		]]
 	},
 	[14] = {
-		containerBook = true,
-		itemId = 1718,
-		bookId = 1964,
-		itemPos = {x = 32068, y = 31889, z = 4},
+		containerId = 1718,
+		itemId = 1964,
+		position = {x = 32068, y = 31889, z = 4},
 		text = [[
 There are two kinds of spells: rune spells and spontaneous spells. Rune spells are cast on blank rune stones, which requires mana. Rune stones can easily be carried around and store the specific spell. It can be used at any time, and only some spells require further investment of mana.
 Spontaneous spells are cast in the heartbeat they are needed, and take effect instantly. Most of these are healing spells, but there are also aggressive spells, invisibility or shape change spells, and more.
 ]]
 	},
 	[15] = {
-		containerBook = true,
-		itemId = 1718,
-		bookId = 1950,
-	   --itemPos = (Rookgaard Libraries),
+		containerId = 1718,
+		itemId = 1950,
+	   --position = (Rookgaard Libraries),
 		text = [[
 Magic
 
@@ -223,10 +213,9 @@ Instant spells are cast in the heartbeat they are needed and take effect instant
 		]]
 	},
 	[16] = {
-		containerBook = true,
-		itemId = 1718,
-		bookId = 1955,
-		--itemPos = (Isle of the Kings Library),
+		containerId = 1718,
+		itemId = 1955,
+		--position = (Isle of the Kings Library),
 		text = [[
 Magic by Puffels
 There are two kinds of spells: rune-spells, and spontaneous spells.
@@ -235,10 +224,9 @@ Spontaneous spells are cased in the heartbeat they are needed and take effect in
 ]]
 	},
 	[17] = {
-		containerBook = true,
-		itemId = 1719,
-		bookId = 1955,
-		itemPos = {x = 32069, y = 31889, z = 4},
+		containerId = 1719,
+		itemId = 1955,
+		position = {x = 32069, y = 31889, z = 4},
 		text = [[
 Combat Tactics
 
@@ -246,28 +234,25 @@ Most monsters are far more dangerous when you're attacked by more of them. Keep 
 ]]
 	},
 	[18] = {
-		containerBook = true,
-		itemId = 1718,
-		bookId = 1950,
-		--itemPos = (Rookgaard Libraries),
+		containerId = 1718,
+		itemId = 1950,
+		--position = (Rookgaard Libraries),
 		text = [[
 As we traveled through the dungeon tunnels we came to a big cave. In the light of our torches we saw several eyes glowing in the darknes, then the trolls attacked, silent as usual. We imediately dropped our torches and raised our shields to block the first attack, then we counterattacked. Soon the floor was wet with blood, ours and theirs. They were verry skilled in blocking our blows and I am sure with inferior weapons we would have hacked on this beasts for an eternity.
 ]]
 	},
 	[19] = {
-		containerBook = true,
-		itemId = 1719,
-		bookId = 1961,
-		itemPos = {x = 32069, y = 31889, z = 4},
+		containerId = 1719,
+		itemId = 1961,
+		position = {x = 32069, y = 31889, z = 4},
 		text = [[
 As we traveled through the dungeon tunnels we came to a big cave. In the light of our torches we saw several eyes glowing in the darknes, then the trolls attacked, silent as usual. We imediately dropped our torches and raised our shields to block the first attack, then we counterattacked. Soon the floor was wet with blood, ours and theirs. They were verry skilled in blocking our blows and I am sure with inferior weapons we would have hacked on this beasts for an eternity.
 		]]
 	},
 	[20] = {
-		containerBook = true,
-		itemId = 1719,
-		bookId = 1950,
-		itemPos = {x = 32069, y = 31889, z = 4},
+		containerId = 1719,
+		itemId = 1950,
+		position = {x = 32069, y = 31889, z = 4},
 		text = [[
 Tactics for close-ranged combat
 - Use the terrain to your advantage: always know the way to the nearest ropespot, and make sure you are not surrounded by enemies - that can be a death trap!
@@ -279,10 +264,9 @@ Tactics for close-ranged combat
 ]]
 	},
 	[21] = {
-		containerBook = true,
-		itemId = 1719,
-		bookId = 1950,
-		--itemPos = (Isle of the Kings Library),
+		containerId = 1719,
+		itemId = 1950,
+		--position = (Isle of the Kings Library),
 		text = [[
 The Tibian Wonders of the World!
 The known and acknowledged wonders of the world are:
@@ -297,10 +281,9 @@ The pyramid city of Ankrahmun
 		]]
 	},
 	[22] = {
-		containerBook = true,
-		itemId = 1719,
-		bookId = 1960,
-		--itemPos = (Ankrahmun great pyramid),
+		containerId = 1719,
+		itemId = 1960,
+		--position = (Ankrahmun great pyramid),
 		text = [[
 The Tibian Wonders of the World!
 The known and acknowledged wonders of the world are:
@@ -315,10 +298,9 @@ The pyramid city of Ankrahmun
 		]]
 	},
 	[23] = {
-		containerBook = true,
-		itemId = 1719,
-		bookId = 1959,
-		itemPos = {x = 32069, y = 31889, z = 4},
+		containerId = 1719,
+		itemId = 1959,
+		position = {x = 32069, y = 31889, z = 4},
 		text = [[
 The Tibian Wonders of the World!
 The known and acknowledged wonders of the world are:
@@ -334,7 +316,7 @@ The pyramid city of Ankrahmun
 	},
 	[24] = {
 		itemId = 1965,
-		itemPos = {x = 32068, y = 31880, z = 3},
+		position = {x = 32068, y = 31880, z = 3},
 		text = [[
 Genesis VII, ii. Tibia's Renewal
 
@@ -345,7 +327,7 @@ It may be that this is yet another one of Zathroth's wicked ploys. It is well kn
 	},
 	[25] = {
 		itemId = 1965,
-		itemPos = {x = 32054, y = 31894, z = 4},
+		position = {x = 32054, y = 31894, z = 4},
 		text = [[
 GV.i Part 1: The Age of Chaos
 
@@ -357,19 +339,17 @@ While Fardos and Uman were working hard on their spell, Zathroth's minions went 
 		]]
 	},
 	[26] = {
-		containerBook = true,
-		itemId = 1718,
-		bookId = 7492,
-		itemPos = {x = 32061, y = 31894, z = 4},
+		containerId = 1718,
+		itemId = 7492,
+		position = {x = 32061, y = 31894, z = 4},
 		text = [[
 This is written proof that Captain Plunderpurse gave away all the cursed gold to the little kiddies, bless his generous heart. No torture, extortion, cut off limbs, manipulation or embezzlement at all was involved in my testimony, I swear! And I am very thankful not to make the acquaintance of the Captain's pet sharks, lovely beasts though they are. Signed, Triomon Tangleweed, certifying notary.
 		]]
 	},
 	[27] = {
-		containerBook = true,
-		itemId = 1718,
-		bookId = 1960,
-		itemPos = (Nagor),
+		containerId = 1718,
+		itemId = 1960,
+		position = (Nagor),
 		text = [[
 Treasures of the Southern Isles
 
@@ -379,10 +359,9 @@ If anyone ever is looking for treasures, then those isles are the best place to 
 		]]
 	},
 	[28] = {
-		containerBook = true,
-		itemId = 1718,
-		bookId = 1955,
-		--itemPos = (Isle of the Kings Library),
+		containerId = 1718,
+		itemId = 1955,
+		--position = (Isle of the Kings Library),
 		text = [[
 Treasures of the Southern Isles
 
@@ -392,10 +371,9 @@ If anyone ever is looking for treasures, then those isles are the best place to 
 		]]
 	},
 	[29] = {
-		containerBook = true,
-		itemId = 1718,
-		bookId = 1961,
-		itemPos = {x = 32061, y = 31894, z = 4},
+		containerId = 1718,
+		itemId = 1961,
+		position = {x = 32061, y = 31894, z = 4},
 		text = [[
 Treasures of the Southern Isles
 
@@ -405,10 +383,9 @@ If anyone ever is looking for treasures, then those isles are the best place to 
 		]]
 	},
 	[30] = {
-		containerBook = true,
-		itemId = 1718,
-		bookId = 1963,
-		itemPos = {x = 32061, y = 31894, z = 4},
+		containerId = 1718,
+		itemId = 1963,
+		position = {x = 32061, y = 31894, z = 4},
 		text = [[
 The Great Sea Serpents
 
@@ -416,10 +393,9 @@ The Sea Serpent is as huge as a house and can swallow a small ship in one bite. 
 ]]
 	},
 	[31] = {
-		containerBook = true,
-		itemId = 1718,
-		bookId = 1960,
-		--itemPos = (Nagor),
+		containerId = 1718,
+		itemId = 1960,
+		--position = (Nagor),
 		text = [[
 The Great Sea Serpents
 
@@ -427,10 +403,9 @@ The Sea Serpent is as huge as a house and can swallow a small ship in one bite. 
 		]]
 	},
 	[32] = {
-		containerBook = true,
-		itemId = 1718,
-		bookId = 1955,
-		--itemPos = (Liberty Bay freedom street),
+		containerId = 1718,
+		itemId = 1955,
+		--position = (Liberty Bay freedom street),
 		text = [[
 The Great Sea Serpents
 
@@ -438,10 +413,9 @@ The Sea Serpent is as huge as a house and can swallow a small ship in one bite. 
 		]]
 	},
 	[33] = {
-		containerBook = true,
-		itemId = 1718,
-		bookId = 1950,
-		--itemPos = (Isle of the Kings Library),
+		containerId = 1718,
+		itemId = 1950,
+		--position = (Isle of the Kings Library),
 		text = [[
 The Great Sea Serpents
 
@@ -449,10 +423,9 @@ The Sea Serpent is as huge as a house and can swallow a small ship in one bite. 
 		]]
 	},
 	[34] = {
-		containerBook = true,
-		itemId = 1718,
-		bookId = 1963,
-		itemPos = (kharos),
+		containerId = 1718,
+		itemId = 1963,
+		position = (kharos),
 		text = [[
 The Great Sea Serpents
 
@@ -460,10 +433,9 @@ The Sea Serpent is as huge as a house and can swallow a small ship in one bite. 
 		]]
 	},
 	[35] = {
-		containerBook = true,
-		itemId = 1718,
-		bookId = 1965,
-		itemPos = {x = 32061, y = 31894, z = 4},
+		containerId = 1718,
+		itemId = 1965,
+		position = {x = 32061, y = 31894, z = 4},
 		text = [[
 V.i Part 2: The Age of Chaos
 
@@ -475,10 +447,9 @@ Thus the dragons had taken over the rule of the land, but the war was by no mean
 ]]
 	},
 	[36] = {
-		containerBook = true,
-		itemId = 3826,
-		bookId = 1965,
-		itemPos = {x = 32075, y = 31894, z = 4},
+		containerId = 3826,
+		itemId = 1965,
+		position = {x = 32075, y = 31894, z = 4},
 		text = [[
 V. ii, The Age of Chaos
 
@@ -490,10 +461,9 @@ The elder gods looked at what had happened to their world, and their hearts fill
 		]]
 	},
 	[37] = {
-		containerBook = true,
-		itemId = 3826,
-		bookId = 1964,
-		itemPos = {x = 32075, y = 31894, z = 4},
+		containerId = 3826,
+		itemId = 1964,
+		position = {x = 32075, y = 31894, z = 4},
 		text = [[
 The Shattered Isles
 
@@ -509,10 +479,9 @@ The Laguna Islands are quite often visited by passing ships to refresh their sup
 ]]
 	},
 	[38] = {
-		containerBook = true,
-		itemId = 3826,
-		bookId = 1959,
-		itemPos = (Nagor),
+		containerId = 3826,
+		itemId = 1959,
+		position = (Nagor),
 		text = [[
 The Shattered Isles
 
@@ -528,10 +497,9 @@ The Laguna Islands are quite often visited by passing ships to refresh their sup
 		]]
 	},
 	[39] = {
-		containerBook = true,
-		itemId = 3826,
-		bookId = 1966,
-		--itemPos = (Liberty Bay freedom street),
+		containerId = 3826,
+		itemId = 1966,
+		--position = (Liberty Bay freedom street),
 		text = [[
 The Shattered Isles
 
@@ -547,10 +515,9 @@ The Laguna Islands are quite often visited by passing ships to refresh their sup
 		]]
 	},
 	[40] = {
-		containerBook = true,
-		itemId = 3826,
-		bookId = 1973,
-		--itemPos = (Liberty Bay Malunga),
+		containerId = 3826,
+		itemId = 1973,
+		--position = (Liberty Bay Malunga),
 		text = [[
 The Shattered Isles
 
@@ -566,10 +533,9 @@ The Laguna Islands are quite often visited by passing ships to refresh their sup
 		]]
 	},
 	[41] = {
-		containerBook = true,
-		itemId = 3826,
-		bookId = 1959,
-		--itemPos = (Carlin Congress),
+		containerId = 3826,
+		itemId = 1959,
+		--position = (Carlin Congress),
 		text = [[
 The Shattered Isles
 
@@ -585,10 +551,9 @@ The Laguna Islands are quite often visited by passing ships to refresh their sup
 		]]
 	},
 	[42] = {
-		containerBook = true,
-		itemId = 3826,
-		bookId = 1955,
-		--itemPos = (Carlin Explorer Club),
+		containerId = 3826,
+		itemId = 1955,
+		--position = (Carlin Explorer Club),
 		text = [[
 The Shattered Isles
 
@@ -604,10 +569,9 @@ The Laguna Islands are quite often visited by passing ships to refresh their sup
 ]]
 	},
 	[43] = {
-		containerBook = true,
-		itemId = 3827,
-		bookId = 1966,
-		itemPos = {x = 32068, y = 31898, z = 4},
+		containerId = 3827,
+		itemId = 1966,
+		position = {x = 32068, y = 31898, z = 4},
 		text = [[
 My travels.
 
@@ -615,10 +579,9 @@ As the orcs approached I've hidden myself in the bushes near the lake. I did har
 ]]
 	},
 	[44] = {
-		containerBook = true,
-		itemId = 3827,
-		bookId = 1955,
-		--itemPos = (Rookgaard Academy),
+		containerId = 3827,
+		itemId = 1955,
+		--position = (Rookgaard Academy),
 		text = [[
 My travels.
 
@@ -626,10 +589,9 @@ As the orcs approached I've hidden myself in the bushes near the lake. I did har
 		]]
 	},
 	[45] = {
-		containerBook = true,
-		itemId = 3827,
-		bookId = 1955,
-		itemPos = {x = 32068, y = 31898, z = 4},
+		containerId = 3827,
+		itemId = 1955,
+		position = {x = 32068, y = 31898, z = 4},
 		text = [[
 Tibiantis: Fact and Fiction
 
@@ -637,10 +599,9 @@ In the light of progress made my modern science the tales of Tibiantis can be ch
 ]]
 	},
 	[46] = {
-		containerBook = true,
-		itemId = 3827,
-		bookId = 1960,
-		--itemPos = (Carlin Congress),
+		containerId = 3827,
+		itemId = 1960,
+		--position = (Carlin Congress),
 		text = [[
 Tibiantis: Fact and Fiction
 
@@ -648,10 +609,9 @@ In the light of progress made my modern science the tales of Tibiantis can be ch
 		]]
 	},
 	[47] = {
-		containerBook = true,
-		itemId = 3827,
-		bookId = 1958,
-		--itemPos = (Isle of the Kings Library),
+		containerId = 3827,
+		itemId = 1958,
+		--position = (Isle of the Kings Library),
 		text = [[
 Tibiantis: Fact and Fiction
 
@@ -659,40 +619,36 @@ In the light of progress made my modern science the tales of Tibiantis can be ch
 		]]
 	},
 	[48] = {
-		containerBook = true,
-		itemId = 3827,
-		bookId = 1965,
-		itemPos = {x = 32068, y = 31898, z = 4},
+		containerId = 3827,
+		itemId = 1965,
+		position = {x = 32068, y = 31898, z = 4},
 		text = [[
 You can not even imagine how old I am. In your wildest dreams you won't see the things I have seen. I am the last of my race and even though I am several centuries old I am not immortal and will eventually die. I fear that day. Not for me - I am weary and I don't care much about if I'm alive or dead. But I fear for all these memories that will die with me. For all those who no one will remember anymore.
 Words can't truly preserve their essence so I will leave no books or stone tablets. If I die, everything I have witnessed will die with me as if it has never existed. I was there when Rorak slew Tingil at the stairs of the seven temples. I was there as Riik led his peaceloving people to the far north to find refuge from the war. I was there to witness the betrayal of Asric for the whims of a female that was long dead by then. I fought with the last Frdai a futile battle on the plains of Weskurt against the unseen legion. I witnessed Ss'rar making his move on ascension to become the serpent god. I watched the first elves struggling to form a nation with the help of the lightbearers. It was me who assisted the great calculator to assemble the bonelords language. And you come here to this mountain and ask me how to win the heart of some shepherdess? This world has become a ridiculous mockery.
 ]]
 	},
 	[49] = {
-		containerBook = true,
-		itemId = 3827,
-		bookId = 1950,
-		--itemPos = (Isle of the Kings Library),
+		containerId = 3827,
+		itemId = 1950,
+		--position = (Isle of the Kings Library),
 		text = [[
 You can not even imagine how old I am. In your wildest dreams you won't see the things I have seen. I am the last of my race and even though I am several centuries old I am not immortal and will eventually die. I fear that day. Not for me - I am weary and I don't care much about if I'm alive or dead. But I fear for all these memories that will die with me. For all those who no one will remember anymore.
 Words can't truly preserve their essence so I will leave no books or stone tablets. If I die, everything I have witnessed will die with me as if it has never existed. I was there when Rorak slew Tingil at the stairs of the seven temples. I was there as Riik led his peaceloving people to the far north to find refuge from the war. I was there to witness the betrayal of Asric for the whims of a female that was long dead by then. I fought with the last Frdai a futile battle on the plains of Weskurt against the unseen legion. I witnessed Ss'rar making his move on ascension to become the serpent god. I watched the first elves struggling to form a nation with the help of the lightbearers. It was me who assisted the great calculator to assemble the bonelords language. And you come here to this mountain and ask me how to win the heart of some shepherdess? This world has become a ridiculous mockery.
 		]]
 	},
 	[50] = {
-		containerBook = true,
-		itemId = 3827,
-		bookId = 1963,
-		itemPos = {x = 32068, y = 31898, z = 4},
+		containerId = 3827,
+		itemId = 1963,
+		position = {x = 32068, y = 31898, z = 4},
 		text = [[
 The Lighthouse in the Middle of Nowhere
 Sailors claim to have travelled as far as the end of the world where the water pours down into nothingness. Although it is easily recognizable during daylight it poses a special threat at night. To make matters worse, a spooky lighthouse sometimes appears out of nowhere to lure ships over the edge of the world. Whether it is really a lighthouse or some other source of light differs from story to story and remains to be determined.
 ]]
 	},
 	[51] = {
-		containerBook = true,
-		itemId = 3827,
-		bookId = 1961,
-		--itemPos = (Liberty Bay),
+		containerId = 3827,
+		itemId = 1961,
+		--position = (Liberty Bay),
 		text = [[
 The Lighthouse in the Middle of Nowhere
 Sailors claim to have travelled as far as the end of the world where the water pours down into nothingness. Although it is easily recognizable during daylight it poses a special threat at night. To make matters worse, a spooky lighthouse sometimes appears out of nowhere to lure ships over the edge of the world. Whether it is really a lighthouse or some other source of light differs from story to story and remains to be determined.
@@ -700,12 +656,12 @@ Sailors claim to have travelled as far as the end of the world where the water p
 	},
 	[52] = {
 		itemId = 12397,
-		itemPos = {x = 32075, y = 31898, z = 4},
+		position = {x = 32075, y = 31898, z = 4},
 		text = "Personal log book of Mr Morris. (The following lines are written in a code that you cannot make out. It seems Mr Morris is a very distrustful person.)"
 	},
 	[53] = {
 		itemId = 1958,
-		itemPos = {x = 32070, y = 31900, z = 4},
+		position = {x = 32070, y = 31900, z = 4},
 		text = [[
 The .........
 Some of he ancients formed .......amlands. They build mighty fortresses to ........................, conscious or not. It was then, when the mysteri............... and his anger shook the foundation of .....................................awakened screaming in fear and pain. And after the ................................................................................ were gone! All of them with all ..........................................................ost their best men in theese days and never recovered from the ........................................... for the other ancients and so the time of the first dreammasters ended.
@@ -713,10 +669,9 @@ From this time on ............. manipulate little of the matter of the dreamland
 ]]
 	},
 	[54] = {
-		containerBook = true,
-		itemId = 3827,
-		bookId = 1950,
-		--itemPos = (Isle of the Kings Library),
+		containerId = 3827,
+		itemId = 1950,
+		--position = (Isle of the Kings Library),
 		text = [[
 The .........
 Some of he ancients formed .......amlands. They build mighty fortresses to ........................, conscious or not. It was then, when the mysteri............... and his anger shook the foundation of .....................................awakened screaming in fear and pain. And after the ................................................................................ were gone! All of them with all ..........................................................ost their best men in theese days and never recovered from the ........................................... for the other ancients and so the time of the first dreammasters ended.
@@ -725,14 +680,14 @@ From this time on ............. manipulate little of the matter of the dreamland
 	},
 	[55] = {
 		itemId = 7724,
-		itemPos = {x = 32070, y = 31900, z = 4},
+		position = {x = 32070, y = 31900, z = 4},
 		text = [[
 (It is covered with a strange language that you cannot make out.)
 		]]
 	},
 	[56] = {
 		itemId = 1966,
-		itemPos = {x = 32052, y = 31898, z = 6},
+		position = {x = 32052, y = 31898, z = 6},
 		text = [[
 ...
 
@@ -742,17 +697,15 @@ The elder gods looked at what had happened to their world, and their hearts fill
 		]]
 	},
 	[57] = {
-		containerBook = true,
-		itemId = 3827,
-		bookId = 1963,
-		itemPos = {x = 32052, y = 31896, z = 6},
+		containerId = 3827,
+		itemId = 1963,
+		position = {x = 32052, y = 31896, z = 6},
 		text = "Cooking Recipes for the Wildlife (excepting Squirrels!), by Richard"
 	},
 	[58] = {
-		containerBook = true,
-		itemId = 3827,
-		bookId = 1965,
-		itemPos = {x = 32052, y = 31896, z = 6},
+		containerId = 3827,
+		itemId = 1965,
+		position = {x = 32052, y = 31896, z = 6},
 		text = [[
 V. iii, The Age of Chaos
 
@@ -762,10 +715,9 @@ For all their strength, these races had one important flaw in common: They lacke
 		]]
 	},
 	[59] = {
-		containerBook = true,
-		itemId = 3827,
-		bookId = 1961,
-		itemPos = {x = 32052, y = 31896, z = 6},
+		containerId = 3827,
+		itemId = 1961,
+		position = {x = 32052, y = 31896, z = 6},
 		text = [[
 Thoughts and Notations on the Noble Craft of Potion-Making, by Grandsieur Haruvan of Drefia (the way of writing and the pages look very, very old)
 
@@ -780,7 +732,7 @@ But still, they can drink, and appreciate, the brews we make to keep a warrior's
 	[60] = {
 	-- Hiding the Amulet (Dawnport quest)
 		itemId = 23764,
-		itemPos = {x = 32046, y = 31915, z = 7},
+		position = {x = 32046, y = 31915, z = 7},
 		text = [[
 (You can barely read the following words on this soiled piece of paper)
 
@@ -888,7 +840,7 @@ Not mine!
 DocumentsTable = {
 	[1] = {
 		itemId = 1953,
-		itemPos = {x = 32854, y = 31992, z = 11},
+		position = {x = 32854, y = 31992, z = 11},
 		text = [[
 What I thought to be digging men are in fact strange green creatures with many arms or eyestalks, who can dig very fast. I think they are called "Beholders".
 They did not attack me yet, although I am sure they can sense me. Who knows, maybe they have no interest in me, and I can use their tunnels to get out of here? I will not attack them, unless I have to defend myself.
@@ -898,7 +850,7 @@ Oh, how I long to see humans again!]]
 	},
 	[2] = {
 		itemId = 1953,
-		itemPos = {x = 33063, y = 31624, z = 15},
+		position = {x = 33063, y = 31624, z = 15},
 		text = "Buried forever that he never shall return. Don't remove this seal or bad things may happen."
 	}
 }

--- a/data/startup/tables/writeable.lua
+++ b/data/startup/tables/writeable.lua
@@ -1,8 +1,8 @@
 -- Guidelines for BookDocumentTable:
--- containerId: id of the container item (bookcase, shelf, etc). Optional.
--- itemId: id of item (book, scroll, etc).
+-- containerId: id of the container item (bookcase, shelf, corpse, etc). Optional.
+-- itemId: id of item (book, scroll, letter, etc).
 -- position: position of the container or of the item (depending on if the item is on a container or not).
--- text: text of item (book, scroll, etc).
+-- text: text of item (book, scroll, letter, etc).
 BookDocumentTable = {
 	[1] = {
 		containerId = 1718,

--- a/data/startup/tables/writeable.lua
+++ b/data/startup/tables/writeable.lua
@@ -101,7 +101,7 @@ The squirrel - Swift and impish, squirrels will run from any human they see. Hun
 		containerBook = true,
 		itemId = 1720,
 		bookId = 1955,
-		itemPos = {x = xxxxx, y = xxxxx, z = x},
+		--itemPos = {x = xxxxx, y = xxxxx, z = x},
 		text = [[
 Kazordoon, the hidden city
 In the blocklike Mountain, known as the big old one, the hidden city of kazordoon is nestled. Its the last refuge of the ancient race of dwarves. Hidden and heavily fortified it was the last stand of dwarvenhood in the wars of creation and the last hope of that race to adapt to and survive the new ages. The famous giant statue, known as colossus guards its entry, alhough the narrow valley makes it difficult to see that fortress-statue and admire its beauty. Kazordoon is known for its safety and masterful smithery throughout the lands.
@@ -333,8 +333,7 @@ The pyramid city of Ankrahmun
 		]]
 	},
 	[24] = {
-		itemId = 1718,
-		bookId = 1965,
+		itemId = 1965,
 		itemPos = {x = 32068, y = 31880, z = 3},
 		text = [[
 Genesis VII, ii. Tibia's Renewal
@@ -345,8 +344,7 @@ It may be that this is yet another one of Zathroth's wicked ploys. It is well kn
 		]]
 	},
 	[25] = {
-		itemId = 1718,
-		bookId = 1965,
+		itemId = 1965,
 		itemPos = {x = 32054, y = 31894, z = 4},
 		text = [[
 GV.i Part 1: The Age of Chaos
@@ -701,14 +699,12 @@ Sailors claim to have travelled as far as the end of the world where the water p
 		]]
 	},
 	[52] = {
-		itemId = 3827,
-		bookId = 12397,
+		itemId = 12397,
 		itemPos = {x = 32075, y = 31898, z = 4},
 		text = "Personal log book of Mr Morris. (The following lines are written in a code that you cannot make out. It seems Mr Morris is a very distrustful person.)"
 	},
 	[53] = {
-		itemId = 3827,
-		bookId = 1958,
+		itemId = 1958,
 		itemPos = {x = 32070, y = 31900, z = 4},
 		text = [[
 The .........
@@ -728,16 +724,14 @@ From this time on ............. manipulate little of the matter of the dreamland
 		]]
 	},
 	[55] = {
-		itemId = 3827,
-		bookId = 7724,
+		itemId = 7724,
 		itemPos = {x = 32070, y = 31900, z = 4},
 		text = [[
 (It is covered with a strange language that you cannot make out.)
 		]]
 	},
 	[56] = {
-		itemId = 3827,
-		bookId = 1966,
+		itemId = 1966,
 		itemPos = {x = 32052, y = 31898, z = 6},
 		text = [[
 ...

--- a/data/startup/tables/writeable.lua
+++ b/data/startup/tables/writeable.lua
@@ -1,9 +1,9 @@
--- Guidelines for BookTable:
+-- Guidelines for BookDocumentTable:
 -- containerId: id of the container item (bookcase, shelf, etc). Optional.
 -- itemId: id of item (book, scroll, etc).
 -- position: position of the container or of the item (depending on if the item is on a container or not).
 -- text: text of item (book, scroll, etc).
-BookTable = {
+BookDocumentTable = {
 	[1] = {
 		containerId = 1718,
 		itemId = 1962,
@@ -750,6 +750,21 @@ To any adventurer friend: ... shovel... beach...
 Signed
 Dormovo the Impetuous
 		]]
+	},
+	[61] = {
+		itemId = 1953,
+		position = {x = 32854, y = 31992, z = 11},
+		text = [[
+What I thought to be digging men are in fact strange green creatures with many arms or eyestalks, who can dig very fast. I think they are called "Beholders".
+They did not attack me yet, although I am sure they can sense me. Who knows, maybe they have no interest in me, and I can use their tunnels to get out of here? I will not attack them, unless I have to defend myself.
+I stopped counting the days, because I lost all feeling for time down here.
+
+Oh, how I long to see humans again!]]
+	},
+	[62] = {
+		itemId = 1953,
+		position = {x = 33063, y = 31624, z = 15},
+		text = "Buried forever that he never shall return. Don't remove this seal or bad things may happen."
 	}
 }
 
@@ -834,23 +849,5 @@ Not mine!
 		itemId = 1444,
 		itemPos = {x = 32481, y = 31900, z = 3},
 		text = "Tristan, the black knight"
-	}
-}
-
-DocumentsTable = {
-	[1] = {
-		itemId = 1953,
-		position = {x = 32854, y = 31992, z = 11},
-		text = [[
-What I thought to be digging men are in fact strange green creatures with many arms or eyestalks, who can dig very fast. I think they are called "Beholders".
-They did not attack me yet, although I am sure they can sense me. Who knows, maybe they have no interest in me, and I can use their tunnels to get out of here? I will not attack them, unless I have to defend myself.
-I stopped counting the days, because I lost all feeling for time down here.
-
-Oh, how I long to see humans again!]]
-	},
-	[2] = {
-		itemId = 1953,
-		position = {x = 33063, y = 31624, z = 15},
-		text = "Buried forever that he never shall return. Don't remove this seal or bad things may happen."
 	}
 }


### PR DESCRIPTION
Fixes the loadLuaMapBook function not working properly. Is generating containers on the map when book item need to be generated at a map position and when the book item need to be in a container it isnt generated inside. Only works on existing already on map items.

- Fixed the issues, now generate new book items at map and inside containers, and still working on existing map items.
- Moved the loading console message inside the function.
- Merged the BookTable and DocumentTable. IMHO they are like the same, items that can be on map or inside a container that when are used they show a window with a readable text.
- Renamed function name and some changes on table variables.

NOTE: Although it said before there are 60 books and 2 documents, some books dont have position, so arent useable there are like 35, plus 2 documents. 37 now.

Now:
![1](https://user-images.githubusercontent.com/31188201/105569727-71014500-5d44-11eb-8afb-99059ef03052.png)
![2](https://user-images.githubusercontent.com/31188201/105569730-7494cc00-5d44-11eb-90a3-200335998267.png)


Fixed:
![3](https://user-images.githubusercontent.com/31188201/105569744-9c842f80-5d44-11eb-9441-549328ce617e.png)
![4](https://user-images.githubusercontent.com/31188201/105569745-a017b680-5d44-11eb-9281-94ea9df6945b.png)

