### PR TITLE
Fix: Bestiary 100% CPU and search method.

### DIFF
--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1899,28 +1899,17 @@ void ProtocolGame::parseBestiarysendCreatures(NetworkMessage &msg)
 	std::string text = "";
 	uint8_t search = msg.getByte();
 
-	if (search == 1)
-	{
+	if (search == 1) {
 		uint16_t monsterAmount = msg.get<uint16_t>();
 		std::map<uint16_t, std::string> mtype_list = g_game.getBestiaryList();
-		uint16_t raceid = msg.get<uint16_t>();
-		MonsterType *mtype = g_monsters.getMonsterTypeByRaceId(raceid);
-		if (!mtype)
-		{
-			return;
-		}
-		text = mtype->info.bestiaryClass;
-		for (int8_t i = 1; i <= monsterAmount; i++)
-		{
+		for (uint16_t monsterCount = 1; monsterCount <= monsterAmount; monsterCount++) {
+			uint16_t raceid = msg.get<uint16_t>();
 			auto it = mtype_list.find(raceid);
-			if (it != mtype_list.end())
-			{
+			if (it != mtype_list.end()) {
 				race.insert({raceid, it->second});
 			}
 		}
-	}
-	else
-	{
+	} else {
 		std::string raceName = msg.getString();
 		race = g_bestiary.findRaceByName(raceName);
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1904,9 +1904,11 @@ void ProtocolGame::parseBestiarysendCreatures(NetworkMessage &msg)
 		std::map<uint16_t, std::string> mtype_list = g_game.getBestiaryList();
 		for (uint16_t monsterCount = 1; monsterCount <= monsterAmount; monsterCount++) {
 			uint16_t raceid = msg.get<uint16_t>();
-			auto it = mtype_list.find(raceid);
-			if (it != mtype_list.end()) {
-				race.insert({raceid, it->second});
+			if (player->getBestiaryKillCount(raceid) > 0) {
+				auto it = mtype_list.find(raceid);
+				if (it != mtype_list.end()) {
+						race.insert({raceid, it->second});
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
Resolves #2319
Fix the error when searching for a big number of monsters on the 'bestiary' window and changing the search method to find all monsters according with the search words.