### PR TITLE
Fix: Item loot charges

### DIFF
--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -257,7 +257,7 @@ registerMonsterType.loot = function(mtype, mask)
 			if loot.subType or loot.charges then
 				parent:setSubType(loot.subType or loot.charges)
 			else
-    			local lType = ItemType(loot.id)
+    			local lType = ItemType(loot.name and loot.name or loot.id)
 				if lType and lType:getCharges() > 1 then
         			parent:setSubType(lType:getCharges())
 				end
@@ -310,7 +310,7 @@ registerMonsterType.loot = function(mtype, mask)
 					if children.subType or children.charges then
 						child:setSubType(children.subType or children.charges)
 					else
-    					local cType = ItemType(children.id)
+    					local cType = ItemType(children.name and children.name or children.id)
 						if cType and cType:getCharges() > 1 then
         					child:setSubType(cType:getCharges())
 						end


### PR DESCRIPTION
Resolves #2323 
Due to the recent changes on the loot declaration from the monsters, it was missing this declaration to set item charges if necesary.