### PR TITLE
Fix vocation adjustments + Weapon formula correction

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -23,6 +23,11 @@ orangeSkullDuration = 7
 onlyInvitedCanMoveHouseItems = true
 cleanProtectionZones = false
 
+-- Formula Correction
+formulaCorrection = true
+averageHitChance = 80
+minHitDamage = 35
+
 -- Connection Config
 -- NOTE: maxPlayers set to 0 means no limit
 -- NOTE: MaxPacketsPerSeconds if you change you will be subject to bugs by WPE, keep the default value of 25

--- a/data/scripts/weapons/scripts/burst_arrow.lua
+++ b/data/scripts/weapons/scripts/burst_arrow.lua
@@ -11,6 +11,7 @@ combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_BURSTARROW)
 combat:setParameter(COMBAT_PARAM_BLOCKARMOR, true)
 combat:setFormula(COMBAT_FORMULA_SKILL, 0, 0, 1, 0)
 combat:setArea(area)
+combat:setOrigin(ORIGIN_RANGED)
 
 local burstArrow = Weapon(WEAPON_AMMO)
 

--- a/data/scripts/weapons/scripts/burst_arrow.lua
+++ b/data/scripts/weapons/scripts/burst_arrow.lua
@@ -9,7 +9,7 @@ combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_EXPLOSIONAREA)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_BURSTARROW)
 combat:setParameter(COMBAT_PARAM_BLOCKARMOR, true)
-combat:setFormula(COMBAT_FORMULA_SKILL, 0, 0, 1, 0)
+combat:setFormula(COMBAT_FORMULA_SKILL, 1, 0, 1, 0)
 combat:setArea(area)
 combat:setOrigin(ORIGIN_RANGED)
 

--- a/data/scripts/weapons/scripts/diamond_arrow.lua
+++ b/data/scripts/weapons/scripts/diamond_arrow.lua
@@ -11,7 +11,7 @@ combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_PHYSICALDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ENERGYHIT)
 combat:setParameter(COMBAT_PARAM_DISTANCEEFFECT, CONST_ANI_DIAMONDARROW)
 combat:setParameter(COMBAT_PARAM_BLOCKARMOR, true)
-combat:setFormula(COMBAT_FORMULA_SKILL, 0, 0, 1, 0)
+combat:setFormula(COMBAT_FORMULA_SKILL, 1, 0, 1, 0)
 combat:setArea(area)
 
 local diamondArrow = Weapon(WEAPON_AMMO)

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -62,9 +62,10 @@ CombatDamage Combat::getCombatDamage(Creature* creature, Creature* target) const
 				Item* tool = player->getWeapon();
 				const Weapon* weapon = g_weapons->getWeapon(tool);
 				if (weapon) {
+					int32_t weaponDamage = weapon->getWeaponDamage(player, target, tool, false);
 					damage.primary.value = normal_random(
-						static_cast<int32_t>(minb),
-						static_cast<int32_t>(weapon->getWeaponDamage(player, target, tool, true) * maxa + maxb)
+						static_cast<int32_t>(weaponDamage * mina + minb),
+						static_cast<int32_t>(weaponDamage * maxa + maxb)
 					);
 
 					damage.secondary.type = weapon->getElementType();

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -184,6 +184,8 @@ bool ConfigManager::load()
 
 	boolean[ONLY_PREMIUM_ACCOUNT] = getGlobalBoolean(L, "onlyPremiumAccount", false);
 
+	boolean[FORMULA_CORRECTION] = getGlobalBoolean(L, "formulaCorrection", false);
+
 	string[DEFAULT_PRIORITY] = getGlobalString(L, "defaultPriority", "high");
 	string[SERVER_NAME] = getGlobalString(L, "serverName", "");
 	string[OWNER_NAME] = getGlobalString(L, "ownerName", "");
@@ -231,6 +233,9 @@ bool ConfigManager::load()
 
 	integer[PUSH_DELAY] = getGlobalNumber(L, "pushDelay", 1000);
 	integer[PUSH_DISTANCE_DELAY] = getGlobalNumber(L, "pushDistanceDelay", 1500);
+
+	integer[AVERAGE_HIT_CHANCE] = getGlobalNumber(L, "averageHitChance", 80);
+	integer[MIN_HIT_DAMAGE] = getGlobalNumber(L, "minHitDamage", 35);
 
 	floating[RATE_MONSTER_HEALTH] = getGlobalFloat(L, "rateMonsterHealth", 1.0);
 	floating[RATE_MONSTER_ATTACK] = getGlobalFloat(L, "rateMonsterAttack", 1.0);

--- a/src/configmanager.h
+++ b/src/configmanager.h
@@ -60,6 +60,7 @@ class ConfigManager
 			FREE_QUESTS,
 			ONLY_PREMIUM_ACCOUNT,
 			MAP_CUSTOM_ENABLED,
+			FORMULA_CORRECTION,
 
 			LAST_BOOLEAN_CONFIG /* this must be the last one */
 		};
@@ -139,6 +140,8 @@ class ConfigManager
 			PUSH_DELAY,
 			PUSH_DISTANCE_DELAY,
 			STASH_ITEMS,
+			AVERAGE_HIT_CHANCE,
+			MIN_HIT_DAMAGE,
 
 			LAST_INTEGER_CONFIG /* this must be the last one */
 		};

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2097,6 +2097,10 @@ void LuaScriptInterface::registerFunctions()
 	registerEnumIn("configKeys", ConfigManager::WEATHER_THUNDER)
 	registerEnumIn("configKeys", ConfigManager::FREE_QUESTS)
 
+	registerEnumIn("configKeys", ConfigManager::FORMULA_CORRECTION)
+	registerEnumIn("configKeys", ConfigManager::AVERAGE_HIT_CHANCE)
+	registerEnumIn("configKeys", ConfigManager::MIN_HIT_DAMAGE)
+
 	registerEnumIn("configKeys", ConfigManager::SERVER_SAVE_NOTIFY_MESSAGE)
 	registerEnumIn("configKeys", ConfigManager::SERVER_SAVE_NOTIFY_DURATION)
 	registerEnumIn("configKeys", ConfigManager::SERVER_SAVE_CLEAN_MAP)

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -651,6 +651,18 @@ int32_t WeaponMelee::getElementDamage(const Player* player, const Creature*, con
 	int32_t minValue = level / 5;
 
 	int32_t maxValue = Weapons::getMaxWeaponDamage(level, attackSkill, attackValue, attackFactor, true);
+
+	if (g_config.getBoolean(ConfigManager::FORMULA_CORRECTION)) {
+		int32_t chance = normal_random(1, 100);
+		int32_t minHitDamage = g_config.getNumber(ConfigManager::MIN_HIT_DAMAGE);
+		if (chance <= g_config.getNumber(ConfigManager::AVERAGE_HIT_CHANCE)) {
+			minValue = std::round(maxValue * (minHitDamage/100.));
+			maxValue *= (100-minHitDamage)/100.;
+		} else {
+			minValue = std::round(maxValue * (100-minHitDamage)/100. - minValue);
+		}
+	}
+	
 	return -normal_random(minValue, static_cast<int32_t>(maxValue * player->getVocation()->meleeDamageMultiplier));
 }
 
@@ -670,6 +682,17 @@ int32_t WeaponMelee::getWeaponDamage(const Player* player, const Creature*, cons
 	int32_t maxValue = static_cast<int32_t>(Weapons::getMaxWeaponDamage(level, attackSkill, attackValue, attackFactor, true) * player->getVocation()->meleeDamageMultiplier);
 
 	int32_t minValue = level / 5;
+
+	if (g_config.getBoolean(ConfigManager::FORMULA_CORRECTION)) {
+		int32_t chance = normal_random(1, 100);
+		int32_t minHitDamage = g_config.getNumber(ConfigManager::MIN_HIT_DAMAGE);
+		if (chance <= g_config.getNumber(ConfigManager::AVERAGE_HIT_CHANCE)) {
+			minValue = std::round(maxValue * (minHitDamage/100.));
+			maxValue *= (100-minHitDamage)/100.;
+		} else {
+			minValue = std::round(maxValue * (100-minHitDamage)/100. - minValue);
+		}
+	}
 
 	if (maxDamage) {
 		return -maxValue;
@@ -882,6 +905,17 @@ int32_t WeaponDistance::getElementDamage(const Player* player, const Creature* t
   	int32_t minValue = std::round(player->getLevel() / 5);
   	int32_t maxValue = std::round((0.09f * attackFactor) * attackSkill * attackValue + minValue) / 2;
 
+	if (g_config.getBoolean(ConfigManager::FORMULA_CORRECTION)) {
+		int32_t chance = normal_random(1, 100);
+		int32_t minHitDamage = g_config.getNumber(ConfigManager::MIN_HIT_DAMAGE);
+		if (chance <= g_config.getNumber(ConfigManager::AVERAGE_HIT_CHANCE)) {
+			minValue = std::round(maxValue * (minHitDamage/100.));
+			maxValue *= (100-minHitDamage)/100.;
+		} else {
+			minValue = std::round(maxValue * (100-minHitDamage)/100. - minValue);
+		}
+	}
+
   	if (target) {
     	if (target->getPlayer()) {
       		minValue /= 4;
@@ -919,14 +953,23 @@ int32_t WeaponDistance::getWeaponDamage(const Player* player, const Creature* ta
 
 	int32_t attackSkill = player->getSkillLevel(SKILL_DISTANCE);
 	float attackFactor = player->getAttackFactor();
-
-  	int32_t minValue = player->getLevel() / 5;
-  	int32_t maxValue = std::round((0.09f * attackFactor) * attackSkill * attackValue + minValue);
+	int32_t minValue = player->getLevel() / 5;
+	int32_t maxValue = std::round((0.09f * attackFactor) * attackSkill * attackValue + minValue);
+	if (g_config.getBoolean(ConfigManager::FORMULA_CORRECTION)) {
+		int32_t chance = normal_random(1, 100);
+		int32_t minHitDamage = g_config.getNumber(ConfigManager::MIN_HIT_DAMAGE);
+		if (chance <= g_config.getNumber(ConfigManager::AVERAGE_HIT_CHANCE)) {
+			minValue = std::round(maxValue * (minHitDamage/100.));
+			maxValue *= (100-minHitDamage)/100.;
+		} else {
+			minValue = std::round(maxValue * (100-minHitDamage)/100. - minValue);
+		}
+	}
 	if (maxDamage) {
 		return -maxValue;
 	}
 
-  	if (target->getPlayer()) {
+  	if (target && target->getPlayer()) {
     	if (hasElement) {
       	minValue /= 4;
     	} else {


### PR DESCRIPTION
This will fix the following things:
- Burst Arrow not using elemental damage

And will add a feature that was missing that is the formula correction for weapons as Global stated:
"The minimum damage of single target, non-critical physical range and melee attacks has been increased to avoid very low hits. While their maximum damage has not been changed so that occasional high damage spikes are still possible, its probabilities was lowered to ensure that the average damage output remains the same."

The formula isn't that acurrate, it must be optimized to become the same avg hit as the old, though they are similar it must be more precise.

TODO :
- Don't use the formula correction on crit