### PR TITLE
Fix Captain Dreadnought - Fix Dawnport Equipments

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -33958,6 +33958,7 @@
 		<attribute key="loottype" value="wand" />
 		<attribute key="shootType" value="fire" />
 		<attribute key="range" value="3" />
+		<attribute key="description" value="It's warm to the touch." />
 	</item>
 	<item id="23721" article="the" name="chiller">
 		<attribute key="weight" value="1500" />
@@ -33965,6 +33966,7 @@
 		<attribute key="loottype" value="wand" />
 		<attribute key="shootType" value="smallice" />
 		<attribute key="range" value="3" />
+		<attribute key="description" value="It is a little, well, chilly to the touch." />
 	</item>
 	<item id="23722" article="a" name="light stone shower rune">
 		<attribute key="type" value="rune" />
@@ -34044,6 +34046,8 @@
 	</item>
 	<item fromid="23769" toid="23770" article="a" name="dead goblin" />
 	<item id="23771" article="a" name="spellbook of the novice">
+		<attribute key="weight" value="1400" />
+		<attribute key="description" value="It shows your spells and can also shield against attacks when worn." />
 		<attribute key="defense" value="8" />
 		<attribute key="weaponType" value="shield" />
 	</item>

--- a/data/npc/scripts/captain_dreadnought.lua
+++ b/data/npc/scripts/captain_dreadnought.lua
@@ -236,7 +236,7 @@ local function townTravelHandler(cid, message, keywords, parameters, node)
 			end
 		elseif town.isPremium == true and not player:isPremium() then
 			npcHandler:say(
-				"Negative, can't bring you there without a premium account. \
+				"Negative, can't bring you there without a premium account. \z
 				You should be glad you get to travel by ship - usually that's a premium service too, you know.",
 				cid
 			)

--- a/data/npc/scripts/captain_dreadnought.lua
+++ b/data/npc/scripts/captain_dreadnought.lua
@@ -262,7 +262,6 @@ local function townTravelHandler(cid, message, keywords, parameters, node)
 		player:teleportTo(towns[townId].destination)
 		player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 		player:setStorageValue(Storage.Dawnport.Mainland, 1)
-		doCreatureSay(cid, town:getId() .. ":" .. town:getName(), TALKTYPE_SAY)
 		npcHandler:say(
 			"Cast off! Don't forget to talk to the guide at the port for directions to nearest bars... err, shops and \z
 			bank and such!",

--- a/data/scripts/movements/equipment/unscripted_equipments.lua
+++ b/data/scripts/movements/equipment/unscripted_equipments.lua
@@ -5274,34 +5274,6 @@ if not equipmentsTable then
 			slot = "shield"
 		}, -- broken wooden shield
 		{
-			itemid = 23719,
-			type = "equip",
-			slot = "hand",
-			vocation = {
-				{"Sorcerer", true},
-				{"Master Sorcerer"}
-			}
-		}, -- the scorcher
-		{
-			itemid = 23719,
-			type = "deequip",
-			slot = "hand"
-		}, -- the scorcher
-		{
-			itemid = 23721,
-			type = "equip",
-			slot = "hand",
-			vocation = {
-				{"Druid", true},
-				{"Elder Druid"}
-			}
-		}, -- the chiller
-		{
-			itemid = 23721,
-			type = "deequip",
-			slot = "hand"
-		}, -- the chiller
-		{
 			itemid = 23771,
 			type = "equip",
 			slot = "shield",
@@ -5317,6 +5289,34 @@ if not equipmentsTable then
 			type = "deequip",
 			slot = "shield"
 		}, -- spellbook of the novice
+		{
+			itemid = 23721,
+			type = "equip",
+			slot = "hand",
+			vocation = {
+				{"Druid", true},
+				{"Elder Druid"}
+			}
+		}, -- the chiller
+		{
+			itemid = 23721,
+			type = "deequip",
+			slot = "hand"
+		}, -- the chiller
+		{
+			itemid = 23719,
+			type = "equip",
+			slot = "hand",
+			vocation = {
+				{"Sorcerer", true},
+				{"Master Sorcerer"}
+			}
+		}, -- the scorcher
+		{
+			itemid = 23719,
+			type = "deequip",
+			slot = "hand"
+		}, -- the scorcher
 		{
 			itemid = 23666,
 			type = "equip",


### PR DESCRIPTION
Removed debug message from captain dreadnought when travel to a new town.

Fixed \z typo.

Fixed dawnport equipments order at unscripted_equipments.lua.

Added again lost dawnport equipments item properties at items.xml