### PR TITLE
Fix: Logout when player is training exercise items

### DIFF
--- a/data/scripts/actions/other/exercise_training.lua
+++ b/data/scripts/actions/other/exercise_training.lua
@@ -35,6 +35,7 @@ local function removeExerciseWeapon(player, exercise)
     player:sendTextMessage(MESSAGE_INFO_DESCR, "Your training weapon vanished.")
     stopEvent(training)
     player:setStorageValue(Storage.isTraining,0)
+    player:setTraining(false)
 end
 
 local function startTraining(playerId, startPosition, itemid, tilePosition, bonusDummy, dummyId)

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -479,6 +479,7 @@ void Player::setTraining(bool value) {
 			it.second->notifyStatusChange(this, value ? VIPSTATUS_TRAINING : VIPSTATUS_ONLINE, false);
 		}
 	}
+	setExerciseTraining(value);
 }
 
 void Player::addSkillAdvance(skills_t skill, uint64_t count)
@@ -1774,7 +1775,7 @@ void Player::onThink(uint32_t interval)
 		addMessageBuffer();
 	}
 
-	if (!getTile()->hasFlag(TILESTATE_NOLOGOUT) && !isAccessPlayer()) {
+	if (!getTile()->hasFlag(TILESTATE_NOLOGOUT) && !isAccessPlayer() && !isExerciseTraining()) {
 		idleTime += interval;
 		const int32_t kickAfterMinutes = g_config.getNumber(ConfigManager::KICK_AFTER_MINUTES);
 		if (idleTime > (kickAfterMinutes * 60000) + 60000) {
@@ -5419,3 +5420,4 @@ error_t Player::GetAccountInterface(account::Account *account) {
   account = account_;
   return account::ERROR_NO;
 }
+

--- a/src/player.h
+++ b/src/player.h
@@ -529,6 +529,12 @@ class Player final : public Creature, public Cylinder
 		void setSupplyStashAvailable(bool value) {
 			supplyStashAvailable = value;
 		}
+		bool isExerciseTraining() {
+			return exerciseTraining;
+		}
+		void setExerciseTraining(bool isTraining) {
+			exerciseTraining = isTraining;
+		}
 		void setLastDepotId(int16_t newId) {
 			lastDepotId = newId;
 		}
@@ -2047,6 +2053,7 @@ class Player final : public Creature, public Cylinder
 		bool scheduledSaleUpdate = false;
 		bool inEventMovePush = false;
 		bool supplyStashAvailable = false;
+		bool exerciseTraining = false;
 
 		static uint32_t playerAutoID;
 
@@ -2097,3 +2104,4 @@ class Player final : public Creature, public Cylinder
 };
 
 #endif  // SRC_PLAYER_H_
+

--- a/src/player.h
+++ b/src/player.h
@@ -2104,4 +2104,3 @@ class Player final : public Creature, public Cylinder
 };
 
 #endif  // SRC_PLAYER_H_
-


### PR DESCRIPTION
Fix logout when training with exercise dummy.

Fix status when weapon is vanished.