### PR TITLE
Fix: shortcut storage

### DIFF
--- a/data/scripts/movements/quests/pits_of_inferno/shortcuts.lua
+++ b/data/scripts/movements/quests/pits_of_inferno/shortcuts.lua
@@ -1,6 +1,6 @@
 local setting = {
 	[8816] = Storage.PitsOfInferno.ShortcutHubDoor,
-	[8817] = Storage.PitsOfInferno.ShortcutLevers
+	[8817] = Storage.PitsOfInferno.ShortcutLeverDoor
 }
 
 local shortcuts = MoveEvent()


### PR DESCRIPTION
Prob: character don't get the shortcut after pass throw the 15 levers rock.
Fix: bad storage on script: ShortcutLevers instead ShortcutLeverDoor

source: on storages.lua