### PR TITLE
Fix: Arachnophobica wave spell

### DIFF
--- a/data/spells/scripts/monster/arachnophobica waveenergy.lua
+++ b/data/spells/scripts/monster/arachnophobica waveenergy.lua
@@ -1,5 +1,5 @@
 local combat = createCombatObject()
-combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_ENERGY)
+combat:setParameter(COMBAT_PARAM_TYPE, COMBAT_ENERGYDAMAGE)
 combat:setParameter(COMBAT_PARAM_EFFECT, CONST_ME_ENERGYAREA)
 
 	arr = {


### PR DESCRIPTION
The damage type was in a outdated typo.
Resolves #2364