### PR TITLE
Enhancement: Improvements in loot-analyser and monster corpse.

### DIFF
--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -335,16 +335,6 @@ function Player:onMoveItem(item, count, fromPosition, toPosition, fromCylinder, 
 		return false
 	end
 
-	-- Loot Analyser
-	local t = Tile(fromCylinder:getPosition())
-	local corpse = t:getTopDownItem()
-	if corpse then
-		local itemType = corpse:getType()
-		if itemType:isCorpse() and toPosition.x == CONTAINER_POSITION then
-			self:sendLootStats(item)
-		end
-	end
-
 	-- Cults of Tibia begin
 	local frompos = Position(33023, 31904, 14) -- Checagem
 	local topos = Position(33052, 31932, 15) -- Checagem

--- a/src/container.h
+++ b/src/container.h
@@ -128,7 +128,7 @@ class Container : public Item, public Cylinder
 		uint32_t getWeight() const override final;
 
 		bool isUnlocked() const {
-			return unlocked;
+			return !this->isCorpse() && unlocked;
 		}
 		bool hasPagination() const {
 			return pagination;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1578,6 +1578,11 @@ void Game::playerMoveItem(Player* player, const Position& fromPos,
 	if (ret != RETURNVALUE_NOERROR) {
 		player->sendCancelMessage(ret);
 	} else {
+		if (toCylinder->getContainer() != nullptr && fromCylinder->getContainer() != nullptr
+			&& fromCylinder->getContainer()->isCorpse() 
+			&& toCylinder->getContainer()->getTopParent() == player) {
+			player->sendLootStats(item, count);
+		}
 		player->cancelPush();
 
 		g_events->eventPlayerOnItemMoved(player, item, count, fromPos, toPos, fromCylinder, toCylinder);
@@ -2370,7 +2375,7 @@ void Game::internalQuickLootCorpse(Player* player, Container* corpse)
 		if (worth != 0) {
 			missedAnyGold = missedAnyGold || !success;
 			if (success) {
-				player->sendLootStats(item);
+				player->sendLootStats(item, worth);
 				totalLootedGold += worth;
 			} else {
 				// item is not completely moved
@@ -2380,7 +2385,7 @@ void Game::internalQuickLootCorpse(Player* player, Container* corpse)
 			missedAnyItem = missedAnyItem || !success;
 			if (success || item->getItemCount() != baseCount) {
 				totalLootedItems++;
-				player->sendLootStats(item);
+				player->sendLootStats(item, totalLootedItems);
 			}
 		}
 	}
@@ -4428,7 +4433,7 @@ void Game::playerQuickLoot(uint32_t playerId, const Position& pos, uint16_t spri
 			ss << "Attention! The container for " << getObjectCategoryName(category) << " is full.";
 		} else {
 			if (ret == RETURNVALUE_NOERROR) {
-				player->sendLootStats(item);
+				player->sendLootStats(item, item->getItemCount());
 				ss << "You looted ";
 			} else {
 				ss << "You could not loot ";

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1579,7 +1579,7 @@ void Game::playerMoveItem(Player* player, const Position& fromPos,
 		player->sendCancelMessage(ret);
 	} else {
 		if (toCylinder->getContainer() != nullptr && fromCylinder->getContainer() != nullptr
-			&& fromCylinder->getContainer()->isCorpse() 
+			&& fromCylinder->getContainer()->isCorpse()
 			&& toCylinder->getContainer()->getTopParent() == player) {
 			player->sendLootStats(item, count);
 		}

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -4127,7 +4127,7 @@ int LuaScriptInterface::luaPlayerSendLootStats(lua_State* L)
 	}
 
 	uint8_t count = getNumber<uint8_t>(L, 3, 0);
-	if(count == 0){
+	if(count == 0) {
 		lua_pushnil(L);
 		return 1;
 	}

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -4113,7 +4113,7 @@ int LuaScriptInterface::luaPlayerSendInventory(lua_State* L)
 
 int LuaScriptInterface::luaPlayerSendLootStats(lua_State* L)
 {
-	// player:sendLootStats(item)
+	// player:sendLootStats(item, count)
 	Player* player = getUserdata<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
@@ -4126,7 +4126,13 @@ int LuaScriptInterface::luaPlayerSendLootStats(lua_State* L)
 		return 1;
 	}
 
- 	player->sendLootStats(item);
+	uint8_t count = getNumber<uint8_t>(L, 3, 0);
+	if(count == 0){
+		lua_pushnil(L);
+		return 1;
+	}
+
+ 	player->sendLootStats(item, count);
 	pushBoolean(L, true);
 
  	return 1;

--- a/src/player.h
+++ b/src/player.h
@@ -1128,7 +1128,7 @@ class Player final : public Creature, public Cylinder
 				client->sendLootContainers();
 			}
 		}
-		void sendLootStats(Item* item, u_int8_t count) {
+		void sendLootStats(Item* item, uint8_t count) {
 			if (client) {
 				client->sendLootStats(item, count);
 			}

--- a/src/player.h
+++ b/src/player.h
@@ -1128,9 +1128,9 @@ class Player final : public Creature, public Cylinder
 				client->sendLootContainers();
 			}
 		}
-		void sendLootStats(Item* item) {
+		void sendLootStats(Item* item, u_int8_t count) {
 			if (client) {
-				client->sendLootStats(item);
+				client->sendLootStats(item, count);
 			}
 		}
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3295,18 +3295,22 @@ void ProtocolGame::sendLootContainers()
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendLootStats(Item *item)
+void ProtocolGame::sendLootStats(Item *item, u_int8_t count)
 {
 	if (!item)
 	{
 		return;
 	}
+	Item* lootedItem = nullptr;
+	lootedItem = item->clone();
+	lootedItem->setItemCount(count);
 
 	NetworkMessage msg;
 	msg.addByte(0xCF);
-	AddItem(msg, item);
-	msg.addString(item->getName());
+	AddItem(msg, lootedItem);
+	msg.addString(lootedItem->getName());
 
+	lootedItem = nullptr;
 	writeToOutputBuffer(msg);
 }
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -3295,7 +3295,7 @@ void ProtocolGame::sendLootContainers()
 	writeToOutputBuffer(msg);
 }
 
-void ProtocolGame::sendLootStats(Item *item, u_int8_t count)
+void ProtocolGame::sendLootStats(Item *item, uint8_t count)
 {
 	if (!item)
 	{

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -374,7 +374,7 @@ private:
 
 	//quickloot
 	void sendLootContainers();
-	void sendLootStats(Item *item, u_int8_t count);
+	void sendLootStats(Item *item, uint8_t count);
 
 	//inventory
 	void sendInventoryItem(slots_t slot, const Item *item);

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -374,7 +374,7 @@ private:
 
 	//quickloot
 	void sendLootContainers();
-	void sendLootStats(Item *item);
+	void sendLootStats(Item *item, u_int8_t count);
 
 	//inventory
 	void sendInventoryItem(slots_t slot, const Item *item);


### PR DESCRIPTION
1. Fixed #2017 
2. Fixed bug where you looted some (not all) items manually from a stack (eg. gold, meat, ...), and that counted for all items on loot analyser.
3. It is no longer allowed to move items into monster corpse. (global like).
4. Moved loot analyser to sources.