### PR TITLE
fix: correct editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,9 +22,8 @@ indent_size = 2
 indent_style = space
 indent_size = 2
 
-# Google Style
 [*.{cpp,hpp,h}]
-indent_style = space
+indent_style = tab
 indent_size = 2
 indent_brace_style = K&R
 spaces_around_brackets = none


### PR DESCRIPTION
Adjusts the [editorconfig](https://editorconfig.org/) to reflect the actual indentation style of the project.