### PR TITLE
Demon Helmet Quest Wall Fixes

### DIFF
--- a/data/scripts/quests/demon_helmet/movement-walls.lua
+++ b/data/scripts/quests/demon_helmet/movement-walls.lua
@@ -53,7 +53,6 @@ function walls.onStepOut(creature, item, position, fromPosition)
 			Position(wallsPositions[i]):hasCreature({x = 33211, y = 31631, z = 13})
 			Game.createItem(1050, 1, wallsPositions[i])
 		end
-		
 	end
 	return true
 end

--- a/data/scripts/quests/demon_helmet/movement-walls.lua
+++ b/data/scripts/quests/demon_helmet/movement-walls.lua
@@ -17,12 +17,15 @@ function walls.onStepIn(creature, item, position, fromPosition)
 	if not player then
 		return true
 	end
-
-	for i = 1, #tilesPositions do
-		local creature = Tile(tilesPositions[i]):getTopCreature()
-		if creature then
-			for i = 1, #wallsPositions do
-				Tile(wallsPositions[i]):getItemById(1050):remove()
+	local tileCreature1 = Tile(tilesPositions[1]):getTopCreature()
+	local tileCreature2 = Tile(tilesPositions[2]):getTopCreature()
+	-- Check 2 tiles positions have a creature and it is a player
+	if tileCreature1 and tileCreature1:getPlayer() and tileCreature2 and tileCreature2:getPlayer() then
+		for i = 1, #wallsPositions do
+			wall = Tile(wallsPositions[i]):getItemById(1050)
+			-- Check there walls before delete them
+			if wall then
+				wall:remove()
 			end
 		end
 	end
@@ -43,10 +46,14 @@ function walls.onStepOut(creature, item, position, fromPosition)
 	if not player then
 		return true
 	end
-
 	for i = 1, #wallsPositions do
-		Position(wallsPositions[i]):hasCreature({x = 33211, y = 31631, z = 13})
-		Game.createItem(1050, 1, wallsPositions[i])
+		wall = Tile(wallsPositions[i]):getItemById(1050)
+		-- Check there is no walls before create new ones
+		if not wall then
+			Position(wallsPositions[i]):hasCreature({x = 33211, y = 31631, z = 13})
+			Game.createItem(1050, 1, wallsPositions[i])
+		end
+		
 	end
 	return true
 end


### PR DESCRIPTION
Fixes 3 bugs with demon helmet quest walls.

1: A console error at onStepIn due iterating a loop inside another loop with the same index.
- How to test bug: Step in the each of tiles at time with players.

2: A bug at onStepIn where you was able to open the walls, with 1 creature and 1 player, due was not checking in the 2 tiles there is a player.
- How to test bug: First make a creature step in/stay on one of tiles and after make a player step in/stay in the other tile.

3: A bug at onStepOut due not checking if the walls already exist before create them again causing only work once, due walls were created twice and was not possible to remove them again.
- How to test bug: After step in/stay in the 2 tiles, make both players step out.

Well since seems I dont know explain myself... I added a video:
https://youtu.be/3CsjmxwHZsc

Closes #2180 