### PR TITLE
Fix monsters loot

### DIFF
--- a/data/monster/bosses/ekatrix.lua
+++ b/data/monster/bosses/ekatrix.lua
@@ -68,7 +68,7 @@ monster.loot = {
 	{name = "gold coin", chance = 100000, maxCount = 60},
 	{name = "witch broom", chance = 100000},
 	{name = "cape", chance = 64500},
-	{name = "wolf tooth chain", chance = 41670},
+	{id = 2129, chance = 41670},
 	{name = "broom", chance = 37500},
 	{name = "coat", chance = 37500},
 	{name = "cookie", chance = 25000, maxCount = 10},

--- a/data/monster/bosses/yaga_the_crone.lua
+++ b/data/monster/bosses/yaga_the_crone.lua
@@ -73,7 +73,7 @@ monster.loot = {
 	{name = "cookie", chance = 62500, maxCount = 8},
 	{name = "gold coin", chance = 29170, maxCount = 55},
 	{name = "star herb", chance = 20833},
-	{name = "wolf tooth chain", chance = 20833},
+	{id = 2129, chance = 20833},
 	{name = "garlic necklace", chance = 8333},
 	{name = "spellbook of mind control", chance = 8333},
 	{name = "coat", chance = 4170},

--- a/data/monster/giants/cyclops.lua
+++ b/data/monster/giants/cyclops.lua
@@ -83,7 +83,7 @@ monster.voices = {
 }
 
 monster.loot = {
-	{name = "wolf tooth chain", chance = 190},
+	{id = 2129, chance = 190},
 	{name = "gold coin", chance = 82000, maxCount = 47},
 	{name = "club ring", chance = 90},
 	{name = "halberd", chance = 1003},

--- a/data/monster/humanoids/orc_rider.lua
+++ b/data/monster/humanoids/orc_rider.lua
@@ -79,7 +79,7 @@ monster.voices = {
 
 monster.loot = {
 	{id = 2050, chance = 980},
-	{name = "wolf tooth chain", chance = 10210},
+	{id = 2129, chance = 10210},
 	{name = "gold coin", chance = 46000, maxCount = 81},
 	{name = "obsidian lance", chance = 1100},
 	{name = "orcish axe", chance = 6880},

--- a/data/monster/humans/witch.lua
+++ b/data/monster/humans/witch.lua
@@ -81,7 +81,7 @@ monster.voices = {
 }
 
 monster.loot = {
-	{name = "wolf tooth chain", chance = 10120},
+	{id = 2129, chance = 10120},
 	{name = "gold coin", chance = 64000, maxCount = 40},
 	{name = "necrotic rod", chance = 1140},
 	{name = "garlic necklace", chance = 1000},

--- a/data/monster/magicals/gargoyle.lua
+++ b/data/monster/magicals/gargoyle.lua
@@ -82,7 +82,7 @@ monster.voices = {
 }
 
 monster.loot = {
-	{name = "wolf tooth chain", chance = 1480},
+	{id = 2129, chance = 1480},
 	{name = "gold coin", chance = 88000, maxCount = 30},
 	{name = "club ring", chance = 260},
 	{name = "morning star", chance = 2150},

--- a/data/monster/magicals/rorc.lua
+++ b/data/monster/magicals/rorc.lua
@@ -78,7 +78,7 @@ monster.voices = {
 }
 
 monster.loot = {
-	{name = "wolf tooth chain", chance = 7410},
+	{id = 2129, chance = 7410},
 	{name = "gold coin", chance = 73640, maxCount = 25},
 	{name = "obsidian lance", chance = 930},
 	{name = "orcish axe", chance = 2040},

--- a/data/monster/mammals/gloom_wolf.lua
+++ b/data/monster/mammals/gloom_wolf.lua
@@ -76,7 +76,7 @@ monster.voices = {
 
 monster.loot = {
 	{name = "ham", chance = 20120},
-	{name = "wolf tooth chain", chance = 2000},
+	{id = 2129, chance = 2000},
 	{name = "gold coin", chance = 65000, maxCount = 48},
 	{name = "meat", chance = 55000, maxCount = 2},
 	{name = "wolf paw", chance = 980}

--- a/data/monster/quests/cults_of_tibia/animated_cyclops.lua
+++ b/data/monster/quests/cults_of_tibia/animated_cyclops.lua
@@ -70,7 +70,7 @@ monster.voices = {
 }
 
 monster.loot = {
-	{name = "wolf tooth chain", chance = 190},
+	{id = 2129, chance = 190},
 	{name = "gold coin", chance = 82000, maxCount = 47},
 	{name = "club ring", chance = 90},
 	{name = "halberd", chance = 1003},


### PR DESCRIPTION
Fix non-unique loot item "wolf tooth chain" in monster loot.
```
Non-unique loot item "wolf tooth chain".
Monster: (name) loot could not correctly be load.
```