### PR TITLE
The Rookie Guard Quest - Bug fixes

### DIFF
--- a/data/scripts/quests/the_rookie_guard/mission09_rock_troll.lua
+++ b/data/scripts/quests/the_rookie_guard/mission09_rock_troll.lua
@@ -70,7 +70,10 @@ function tunnelHole.onStepIn(creature, item, position, fromPosition)
 		return true
 	end
 	local missionState = player:getStorageValue(Storage.TheRookieGuard.Mission09)
-	if missionState == -1 or missionState >= 7 then
+	if missionState == -1 then
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have no business down there.")
+		player:teleportTo(fromPosition, true)
+	elseif missionState >= 7 then
 		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The cave has collapsed. It's not safe to go down there anymore.")
 		player:teleportTo(fromPosition, true)
 	end

--- a/data/scripts/quests/the_rookie_guard/mission10_tomb_raiding.lua
+++ b/data/scripts/quests/the_rookie_guard/mission10_tomb_raiding.lua
@@ -84,7 +84,7 @@ function sarcophagus.onUse(player, item, frompos, item2, topos)
 	if missionState == -1 then
 		return true
 	end
-	if missionState == 1 then
+	if missionState >= 1 then
 		local sarcophagusState = player:getStorageValue(Storage.TheRookieGuard.Sarcophagus)
 		if sarcophagusState == -1 then
 			local reward = Game.createItem(13830, 1)

--- a/data/scripts/quests/the_rookie_guard/mission12_into_fortress.lua
+++ b/data/scripts/quests/the_rookie_guard/mission12_into_fortress.lua
@@ -355,13 +355,15 @@ function bossLairTeleport.onStepIn(creature, item, position, fromPosition)
 	if missionState == -1 then
 		return true
 	end
-	if missionState >= 9 then
+	if missionState >= 8 then
 		local spectators = Game.getSpectators(position, false, false, 2, 2, 2, 2)
 		for i = 1, #spectators do
 			if not spectators[i]:isPlayer() and spectators[i]:getName() == "Furious Orc Berserker" then
 				player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "As long as the orc berserker is near that teleporter, you can't enter.")
 				player:teleportTo(fromPosition, true)
-				return false
+				position:sendMagicEffect(CONST_ME_TELEPORT)
+				fromPosition:sendMagicEffect(CONST_ME_TELEPORT)
+				return true
 			end
 		end
 		if missionState == 9 then

--- a/data/spells/scripts/monster/spider_queen_wrap.lua
+++ b/data/spells/scripts/monster/spider_queen_wrap.lua
@@ -23,8 +23,8 @@ function onCastSpell(creature, var)
 	if target and target:isPlayer() then
 		if combat:execute(creature, var) then
 			target:addCondition(conditionOutfit)
-			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The spider queen caught you in her net and paralysed you!")
-			player:setStorageValue(Storage.TheRookieGuard.Mission05, 4)
+			target:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The spider queen caught you in her net and paralysed you!")
+			target:setStorageValue(Storage.TheRookieGuard.Mission05, 4)
 			addEvent(moveToSpiderNest, 4500, target:getId())
 			return true
 		end


### PR DESCRIPTION
Fixed issue with Spider Queen spell spider_queen_wrap.lua causing an error and not updating mission state.

Fixed a missing message on trolls dug tunnel when not started the quest.

Fixed not showing empty sarcophagus message after finish the mission.

Fixed issue not checking nearby Furious Orc Berserker before throw him the tarantula trap.