### PR TITLE
Lady Tenebris spell fix

### DIFF
--- a/data/monster/quests/forgotten_knowledge/bosses/lady_tenebris.lua
+++ b/data/monster/quests/forgotten_knowledge/bosses/lady_tenebris.lua
@@ -112,7 +112,7 @@ monster.attacks = {
 	{name ="combat", interval = 6000, chance = 13, type = COMBAT_DEATHDAMAGE, minDamage = -1200, maxDamage = -1500, length = 8, spread = 3, effect = CONST_ME_MORTAREA, target = false},
 	{name ="combat", interval = 2000, chance = 13, type = COMBAT_DEATHDAMAGE, minDamage = -400, maxDamage = -600, radius = 4, shootEffect = CONST_ANI_DEATH, effect = CONST_ME_SMALLCLOUDS, target = true},
 	{name ="tenebris summon", interval = 2000, chance = 14, target = false},
-	{name ="tenebris ultimate", interval = 2000, chance = 30, target = false}
+	{name ="tenebris ultimate", interval = 15000, chance = 30, target = false}
 }
 
 monster.defenses = {

--- a/data/spells/scripts/monster/tenebris ultimate.lua
+++ b/data/spells/scripts/monster/tenebris ultimate.lua
@@ -71,6 +71,7 @@ local function delayedCastSpell(cid, var)
 		return
 	end
 	if creature:getHealth() >= 1 then
+        creature:setMoveLocked(false)
 		return combat:execute(creature, positionToVariant(creature:getPosition()))
 	end
 	return
@@ -84,9 +85,10 @@ function onCastSpell(creature, var)
 			spec:teleportTo(Position(32912, 31599, 14))
 		elseif spec:getName():lower() == 'lady tenebris' then
 			spec:teleportTo(Position(32912, 31599, 14))
+            spec:setMoveLocked(true)
 		end
 	end
 	creature:say("LADY TENEBRIS BEGINS TO CHANNEL A POWERFULL SPELL! TAKE COVER!", TALKTYPE_MONSTER_YELL)
-	addEvent(delayedCastSpell, 900, creature:getId(), var)
+	addEvent(delayedCastSpell, 4000, creature:getId(), var)
 	return true
 end

--- a/data/spells/scripts/monster/tenebris ultimate.lua
+++ b/data/spells/scripts/monster/tenebris ultimate.lua
@@ -71,7 +71,7 @@ local function delayedCastSpell(cid, var)
 		return
 	end
 	if creature:getHealth() >= 1 then
-        creature:setMoveLocked(false)
+		creature:setMoveLocked(false)
 		return combat:execute(creature, positionToVariant(creature:getPosition()))
 	end
 	return
@@ -85,7 +85,7 @@ function onCastSpell(creature, var)
 			spec:teleportTo(Position(32912, 31599, 14))
 		elseif spec:getName():lower() == 'lady tenebris' then
 			spec:teleportTo(Position(32912, 31599, 14))
-            spec:setMoveLocked(true)
+			spec:setMoveLocked(true)
 		end
 	end
 	creature:say("LADY TENEBRIS BEGINS TO CHANNEL A POWERFULL SPELL! TAKE COVER!", TALKTYPE_MONSTER_YELL)


### PR DESCRIPTION
- Lady Tenebris now doesn't move between the ultimate message and casting the spell.
- Lady Tenebris Ultimate spell doesn't happen now so fast (sometimes every 2 seconds).
- There is more time to run from the spell as it should like RL tibia.