### PR TITLE
Fixes gold pouch as loot container.

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4493,7 +4493,7 @@ void Game::playerSetLootContainer(uint32_t playerId, ObjectCategory_t category, 
 	}
 
 	Container* container = thing->getContainer();
-	if (!container) {
+	if (!container || (container->getID() == ITEM_GOLD_POUCH && category != OBJECTCATEGORY_GOLD)) {
 		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		return;
 	}


### PR DESCRIPTION
- Prevent gold pouch be set as loot container, except for coins.

Before
![image](https://user-images.githubusercontent.com/9365346/108137458-a6c2f080-709a-11eb-82ec-c500953ba62d.png)

Now
![image](https://user-images.githubusercontent.com/9365346/108137542-d4a83500-709a-11eb-9f54-e67ba79cf0d8.png)
