### PR TITLE
Remove lua version debugging

### DIFF
--- a/data/lib/debugging/lua_version.lua
+++ b/data/lib/debugging/lua_version.lua
@@ -1,5 +1,0 @@
-if type(jit) == 'table' then
-	print('>> Using ' .. jit.version)  --LuaJIT 2.0.2
-else
-	print('>> Using ' .. _VERSION)
-end

--- a/data/lib/lib.lua
+++ b/data/lib/lib.lua
@@ -6,7 +6,6 @@ dofile('data/lib/compat/compat.lua')
 
 -- Debugging helper function for Lua developers
 dofile('data/lib/debugging/dump.lua')
-dofile('data/lib/debugging/lua_version.lua')
 
 -- Tables library
 dofile('data/lib/tables/table.lua')


### PR DESCRIPTION
There is already a check on the source, at otserv.cpp, here: https://github.com/opentibiabr/otservbr-global/blob/develop/src/otserv.cpp#L140-#L146
![image](https://user-images.githubusercontent.com/8551443/108458430-69ee2980-7253-11eb-85a5-762b30c1b15a.png)
