### PR TITLE
Removes lua and ubuntu 16.04 build

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   job:
-    name: ${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}
+    name: ${{ matrix.os }}-${{ matrix.cxx }}-${{ matrix.buildtype }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
@@ -27,7 +27,6 @@ jobs:
       matrix:
         name: [macos-clang]
         buildtype: [Debug, Release]
-        luajit: [on, off]
         include:
           - name: macos-clang
             os: macos
@@ -72,7 +71,6 @@ jobs:
           useVcpkgToolchainFile: true
           buildDirectory: ${{ runner.workspace }}/build
           cmakeBuildType: ${{ matrix.buildtype }}
-          cmakeAppendedArgs: -DUSE_LUAJIT=${{ matrix.luajit }}
 
       - name: dir
         run: find $RUNNER_WORKSPACE
@@ -85,5 +83,5 @@ jobs:
       - name: Upload datapack contents
         uses: actions/upload-artifact@v2
         with:
-          name: otbr-${{ matrix.name }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
+          name: otbr-${{ matrix.name }}-${{ matrix.buildtype }}-${{ github.sha }}
           path: ${{ github.workspace }}

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -19,13 +19,12 @@ on:
 
 jobs:
   job:
-    name: ${{ matrix.os }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}
+    name: ${{ matrix.os }}-${{ matrix.buildtype }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04]
         buildtype: [Debug, Release]
-        luajit: [on, off]
 
     steps:
     - uses: actions/checkout@v2
@@ -33,7 +32,7 @@ jobs:
     - name: Install Dependencies
       run: >
         sudo apt-get update && sudo apt-get install cmake build-essential ca-certificates
-        libcurl4-openssl-dev libjsoncpp-dev liblua5.2-dev libmysqlclient-dev libboost-system-dev
+        libcurl4-openssl-dev libjsoncpp-dev libmysqlclient-dev libboost-system-dev
         libboost-iostreams-dev libboost-filesystem-dev libpugixml-dev
         libcrypto++-dev libspdlog-dev libluajit-5.1-dev libboost-date-time-dev
         unrar zip
@@ -41,7 +40,7 @@ jobs:
     - name: Prepare build Environment
       run: |
         mkdir build && cd build
-        cmake -DCMAKE_BUILD_TYPE=${{ matrix.buildtype }} -DUSE_LUAJIT=${{ matrix.luajit }} ..
+        cmake -DCMAKE_BUILD_TYPE=${{ matrix.buildtype }} ..
 
     - name: Build
       run: |
@@ -65,5 +64,5 @@ jobs:
     - name: Upload binary
       uses: actions/upload-artifact@v2
       with:
-        name: ${{ matrix.os }}-otbr-amd64-${{ matrix.buildtype }}-LUAJIT=${{ matrix.luajit }}-${{ github.sha }}
+        name: ${{ matrix.os }}-otbr-amd64-${{ matrix.buildtype }}-${{ github.sha }}
         path: ${{ runner.workspace }}/otservbr.zip

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -19,14 +19,13 @@ on:
 
 jobs:
   job:
-    name: ${{ matrix.os }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}
+    name: ${{ matrix.os }}-${{ matrix.buildtype }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
         name: [windows]
         buildtype: [Debug, Release]
-        luajit: [on, off]
         include:
           - os: windows
             triplet: x64-windows
@@ -65,7 +64,6 @@ jobs:
           useVcpkgToolchainFile: true
           buildDirectory: ${{ runner.workspace }}/build
           cmakeBuildType: ${{ matrix.buildtype }}
-          cmakeAppendedArgs: -DUSE_LUAJIT=${{ matrix.luajit }}
 
       - name: dir
         run: find $RUNNER_WORKSPACE
@@ -92,6 +90,6 @@ jobs:
       - name: Upload datapack
         uses: actions/upload-artifact@v2
         with:
-          name: otbr-${{ matrix.os }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
+          name: otbr-${{ matrix.os }}-${{ matrix.buildtype }}-${{ github.sha }}
           path: ${{ runner.workspace }}/otservbr.zip
         if: contains( matrix.os, 'windows')

--- a/.gitignore
+++ b/.gitignore
@@ -359,6 +359,7 @@ docker/**/otserver
 # VSCode
 settings.json
 c_cpp_properties.json
+.history
 
 # CLion (JetBrains)
 .idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,20 +68,9 @@ find_package(CURL REQUIRED)
 find_package(jsoncpp REQUIRED)
 
 # Selects LuaJIT if user defines or auto-detected
-if (DEFINED USE_LUAJIT AND NOT USE_LUAJIT)
-    set(FORCE_LUAJIT ${USE_LUAJIT})
-else ()
-    find_package(LuaJIT)
-    set(FORCE_LUAJIT ${LuaJIT_FOUND})
-endif ()
-option(USE_LUAJIT "Use LuaJIT" ${FORCE_LUAJIT})
-
-if (FORCE_LUAJIT)
-    if (APPLE)
-        set(CMAKE_EXE_LINKER_FLAGS "-pagezero_size 10000 -image_base 100000000")
-    endif ()
-else ()
-    find_package(Lua REQUIRED)
+find_package(LuaJIT)
+if (APPLE)
+  set(CMAKE_EXE_LINKER_FLAGS "-pagezero_size 10000 -image_base 100000000")
 endif ()
 
 


### PR DESCRIPTION
- Remove option to select between lua or luajit to use just luajit as it
is faster and there is no need to keep both, we need to focus on just
one.

- Remove ubuntu 16.04 from the build as it is too old and we can't
support it anymore, we need to move on and start to use new things, so
for now it is working properly on ubuntu 18.04 and 20.04.