### PR TITLE
Some improvements in PVP.

### DIFF
--- a/data/global.lua
+++ b/data/global.lua
@@ -2,7 +2,7 @@ math.randomseed(os.time())
 dofile('data/lib/lib.lua')
 
 NOT_MOVEABLE_ACTION = 100
-PARTY_PROTECTION = 1 -- Set to 0 to disable.
+PARTY_PROTECTION = 0 -- Set to 1 to enable.
 ADVANCED_SECURE_MODE = 1 -- Set to 0 to disable.
 
 STORAGEVALUE_PROMOTION = 30018

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -641,7 +641,7 @@ void Creature::onDeath()
 	Creature* lastHitCreature = g_game.getCreatureByID(lastHitCreatureId);
 	Creature* lastHitCreatureMaster;
 	if (lastHitCreature) {
-		lastHitUnjustified = lastHitCreature->onKilledCreature(this, true);
+		lastHitUnjustified = lastHitCreature->onKilledCreature(this, true, false);
 		lastHitCreatureMaster = lastHitCreature->getMaster();
 	} else {
 		lastHitCreatureMaster = nullptr;
@@ -690,7 +690,7 @@ void Creature::onDeath()
 		if (mostDamageCreature != lastHitCreature && mostDamageCreature != lastHitCreatureMaster) {
 			Creature* mostDamageCreatureMaster = mostDamageCreature->getMaster();
 			if (lastHitCreature != mostDamageCreatureMaster && (lastHitCreatureMaster == nullptr || mostDamageCreatureMaster != lastHitCreatureMaster)) {
-				mostDamageUnjustified = mostDamageCreature->onKilledCreature(this, false);
+				mostDamageUnjustified = mostDamageCreature->onKilledCreature(this, false, true);
 			}
 		}
 	}
@@ -1125,10 +1125,10 @@ void Creature::onAttackedCreatureKilled(Creature* target)
 	}
 }
 
-bool Creature::onKilledCreature(Creature* target, bool lastHit)
+bool Creature::onKilledCreature(Creature* target, bool lastHit, bool mostDamage)
 {
 	if (master) {
-		master->onKilledCreature(target, lastHit);
+		master->onKilledCreature(target, lastHit, mostDamage);
 	}
 
 	//scripting event - onKill

--- a/src/creature.h
+++ b/src/creature.h
@@ -410,7 +410,7 @@ class Creature : virtual public Thing
 		virtual void onAttackedCreatureDrainHealth(Creature* target, int32_t points);
 		virtual void onTargetCreatureGainHealth(Creature*, int32_t) {}
 		void onAttackedCreatureKilled(Creature* target);
-		virtual bool onKilledCreature(Creature* target, bool lastHit = true);
+		virtual bool onKilledCreature(Creature* target, bool lastHit = true, bool mostDamage = true);
 		virtual void onGainExperience(uint64_t gainExp, Creature* target);
 		virtual void onAttackedCreatureBlockHit(BlockType_t) {}
 		virtual void onBlockHit() {}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6989,7 +6989,7 @@ void Game::playerCyclopediaCharacterInfo(Player* player, uint32_t characterID, C
 						cause << cause1;
 					}
 
-					if (!cause2.empty()) {
+					if (!cause2.empty() && cause2.compare(cause1) != 0) {
 						if (!cause1.empty()) {
 							cause << " and ";
 						}

--- a/src/player.h
+++ b/src/player.h
@@ -890,7 +890,7 @@ class Player final : public Creature, public Cylinder
 		void onAttacked() override;
 		void onAttackedCreatureDrainHealth(Creature* target, int32_t points) override;
 		void onTargetCreatureGainHealth(Creature* target, int32_t points) override;
-		bool onKilledCreature(Creature* target, bool lastHit = true) override;
+		bool onKilledCreature(Creature* target, bool lastHit = true, bool mostDamage = true) override;
 		void onGainExperience(uint64_t gainExp, Creature* target) override;
 		void onGainSharedExperience(uint64_t gainExp, Creature* source);
 		void onAttackedCreatureBlockHit(BlockType_t blockType) override;


### PR DESCRIPTION
Adjusted some functions for the Retro PVP system.

1. Now the player that causes the most damage will also be considered as unjustified death.
2. Party damage is set as the default.
3. Adjusted display of the character's death history in the cyclopedia. If the creature that caused the last hit and the creature that did the most damage are the same, it will be displayed only once.
4. Included in the corpse description is the name of the creature that did the most damage.

Source: https://www.tibiawiki.com.br/wiki/Retro_Open_PvP