### PR TITLE
Fix gameIsDay function

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6530,7 +6530,7 @@ bool Game::gameIsDay()
 	if (lightHour >= (6 * 60) && lightHour <= (18 * 60)) {
 		isDay = true;
 	} else {
-	isDay = false;
+		isDay = false;
 	}
 
 	return isDay;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6527,8 +6527,12 @@ LightInfo Game::getWorldLightInfo() const
 
 bool Game::gameIsDay()
 {
-	if (lightHour >= ((6 * 60) + 30) && lightHour <= ((17 * 60) + 30))
-		isDay = true;
+  if (lightHour >= (6 * 60) && lightHour <= (18 * 60)) {
+    isDay = true;
+  }
+  else {
+    isDay = false;
+  }
 
 	return isDay;
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6527,12 +6527,11 @@ LightInfo Game::getWorldLightInfo() const
 
 bool Game::gameIsDay()
 {
-  if (lightHour >= (6 * 60) && lightHour <= (18 * 60)) {
-    isDay = true;
-  }
-  else {
-    isDay = false;
-  }
+	if (lightHour >= (6 * 60) && lightHour <= (18 * 60)) {
+		isDay = true;
+	} else {
+	isDay = false;
+	}
 
 	return isDay;
 }


### PR DESCRIPTION
- Fixed gameIsDay function not returning false (night).

- Corrected the times considered day and night. (Day = 06:00 a.m. to 06:00 p.m.) (Night: 06:00 p.m. to 06:00 a.m.)

Known affected things: Spawns not spawning night monsters at night and not despawning day monsters at night.

Closes #2418
Closes #311 

Night:
![2021-02-22_030129166_TKT_Hotkey](https://user-images.githubusercontent.com/31188201/108650857-d0c44a80-74c0-11eb-981f-19d947c80702.png)
Day:
![2021-02-22_033822179_TKT_Hotkey](https://user-images.githubusercontent.com/31188201/108650892-e6d20b00-74c0-11eb-8f3b-afef8df0b1a1.png)
