### PR TITLE
Fix: Supply stash (crash/hireling)

### DIFF
--- a/data/npc/scripts/hireling.lua
+++ b/data/npc/scripts/hireling.lua
@@ -1034,7 +1034,7 @@ local function creatureSayCallback(cid, type, msg)
 		elseif msgcontains(msg, "stash") then
 			if hireling:hasSkill(HIRELING_SKILLS.STEWARD) then
 				npcHandler:say(GREETINGS.STASH, cid)
-				player:OpenStash()
+				player:openStash(true)
 			else
 				sendSkillNotLearned(cid, HIRELING_SKILLS.STEWARD)
 			end

--- a/data/scripts/movements/others/tiles.lua
+++ b/data/scripts/movements/others/tiles.lua
@@ -38,7 +38,7 @@ function tiles.onStepIn(creature, item, position, fromPosition)
 
 			player:sendTextMessage(MESSAGE_FAILURE, "Your depot contains " .. depotItems .. " item" .. (depotItems > 1 and "s." or ".") .. "\
 			Your supply stash contains " .. player:getStashCount() .. " item" .. (player:getStashCount()	 > 1 and "s." or "."))
-			player:setSpecialContainersAvailable(true)
+			player:setSpecialContainersAvailable(true, true)
 			return true
 		end
 	end
@@ -72,7 +72,7 @@ function tiles.onStepOut(creature, item, position, fromPosition)
 	end
 
 	item:transform(decreasing[item.itemid])
-	player:setSpecialContainersAvailable(false)
+	player:setSpecialContainersAvailable(false, false)
 	return true
 end
 

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -120,6 +120,24 @@ void Container::addItem(Item* item)
 	item->setParent(this);
 }
 
+StashContainerList Container::getStowableItems() const
+{
+	StashContainerList toReturnList;
+	for (auto item : itemlist) {
+		if (item->getContainer() != NULL) {
+			auto subContainer = item->getContainer()->getStowableItems();
+			for (auto subContItem : subContainer) {
+				Item* containerItem = subContItem.first;
+				toReturnList.push_back(std::pair<Item*, uint32_t>(containerItem, static_cast<uint32_t>(containerItem->getItemCount())));
+			}
+		} else if (item->isItemStorable()) {
+			toReturnList.push_back(std::pair<Item*, uint32_t>(item, static_cast<uint32_t>(item->getItemCount())));
+		}
+	}
+
+	return toReturnList;
+}
+
 Attr_ReadValue Container::readAttr(AttrTypes_t attr, PropStream& propStream)
 {
 	if (attr == ATTR_CONTAINER_ITEMS) {

--- a/src/container.h
+++ b/src/container.h
@@ -119,6 +119,7 @@ class Container : public Item, public Cylinder
 
 		bool hasParent() const;
 		void addItem(Item* item);
+		StashContainerList getStowableItems() const;
 		Item* getItemByIndex(size_t index) const;
 		bool isHoldingItem(const Item* item) const;
 

--- a/src/enums.h
+++ b/src/enums.h
@@ -821,7 +821,6 @@ struct CombatDamage
 	}
 };
 
-using StashContainerList = std::map<uint16_t, std::pair<bool, uint32_t>>;
 using StashItemList = std::map<uint16_t, uint32_t>;
 using MarketOfferList = std::list<MarketOffer>;
 using HistoryMarketOfferList = std::list<HistoryMarketOffer>;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1556,7 +1556,7 @@ void Game::playerMoveItem(Player* player, const Position& fromPos,
 	if (toCylinder->getContainer() != NULL &&
 		toCylinder->getItem()->getID() == ITEM_LOCKER1 &&
 		toPos.getZ() == ITEM_SUPPLY_STASH_INDEX) {
-		player->stowContainer(item, count);
+		player->stowItem(item, count, false);
 			return;
 	}
 
@@ -3590,7 +3590,7 @@ void Game::playerBrowseField(uint32_t playerId, const Position& pos)
 	}
 }
 
-void Game::playerStowItem(Player* player, const Position& pos, uint16_t spriteId, uint8_t stackpos, uint32_t count)
+void Game::playerStowItem(Player* player, const Position& pos, uint16_t spriteId, uint8_t stackpos, uint8_t count, bool allItems)
 {
 	if (!player->isPremium()) {
 		player->sendCancelMessage(RETURNVALUE_YOUNEEDPREMIUMACCOUNT);
@@ -3598,12 +3598,11 @@ void Game::playerStowItem(Player* player, const Position& pos, uint16_t spriteId
 	}
 
 	Thing* thing = internalGetThing(player, pos, stackpos, 0, STACKPOS_TOPDOWN_ITEM);
-	if (!thing || count == 0) {
+	if (!thing)
 		return;
-	}
 
 	Item* item = thing->getItem();
-	if (!item || (item->getClientID() != spriteId && static_cast<uint32_t>(item->getItemCount()) >= count)) {
+	if (!item || item->getClientID() != spriteId || item->getItemCount() < count) {
 		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		return;
 	}
@@ -3612,37 +3611,7 @@ void Game::playerStowItem(Player* player, const Position& pos, uint16_t spriteId
 		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		return;
 	}
-	player->stowContainer(item, count);
-}
-
-void Game::playerStowAllItems(Player* player, const Position& pos, uint16_t spriteId, uint8_t stackpos)
-{
-	if (!player->isPremium()) {
-		player->sendCancelMessage(RETURNVALUE_YOUNEEDPREMIUMACCOUNT);
-		return;
-	}
-
-	Thing* thing = internalGetThing(player, pos, stackpos, 0, STACKPOS_TOPDOWN_ITEM);
-	if (!thing) {
-		return;
-	}
-
-	Item* item = thing->getItem();
-	if (!item || item->getClientID() != spriteId) {
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
-		return;
-	}
-
-	if (pos.x != 0xFFFF && !Position::areInRange<1, 1, 0>(pos, player->getPosition())) {
-		// moving towards stow items means we'll loose supply stash availability
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
-		return;
-	}
-
-	auto itemCID = Item::items.getItemIdByClientId(spriteId).id;
-	uint16_t allitems = player->getItemTypeCount(itemCID, -1);
-
-	player->stowContainer(item, static_cast<uint32_t>(allitems));
+	player->stowItem(item, count, allItems);
 }
 
 void Game::playerStashWithdraw(Player* player, uint16_t spriteId, uint32_t count, uint8_t)
@@ -3700,41 +3669,13 @@ void Game::playerStashWithdraw(Player* player, uint16_t spriteId, uint32_t count
 		ss << "Retrieved " << WithdrawCount << "x " << it.name << '.';
 	}
 
-	std::string stringResult = ss.str();
-	player->sendCancelMessage(stringResult);
+	player->sendTextMessage(MESSAGE_STATUS, ss.str());
 
 	if (player->withdrawItem(spriteId, WithdrawCount)) {
 		player->addItemFromStash(it.id, WithdrawCount);
 	} else {
 		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 	}
-}
-
-void Game::playerStowContainer(Player* player, const Position& pos, uint16_t spriteId, uint8_t stackpos)
-{
-	if (!player->isPremium()) {
-		player->sendCancelMessage(RETURNVALUE_YOUNEEDPREMIUMACCOUNT);
-		return;
-	}
-
-	Thing* thing = internalGetThing(player, pos, stackpos, 0, STACKPOS_TOPDOWN_ITEM);
-	if (!thing) {
-		return;
-	}
-
-	Item* item = thing->getItem();
-	if (!item || item->getClientID() != spriteId) {
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
-		return;
-	}
-
-	if (pos.x != 0xFFFF && !Position::areInRange<1, 1, 0>(pos, player->getPosition())) {
-		// moving towards stow items means we'll loose supply stash availability
-		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
-		return;
-	}
-
-	player->stowContainer(item, static_cast<uint32_t>(item->getItemCount()));
 }
 
 void Game::playerSeekInContainer(uint32_t playerId, uint8_t containerId, uint16_t index)

--- a/src/game.h
+++ b/src/game.h
@@ -390,10 +390,7 @@ class Game
 		void playerOpenChannel(uint32_t playerId, uint16_t channelId);
 		void playerCloseChannel(uint32_t playerId, uint16_t channelId);
 		void playerOpenPrivateChannel(uint32_t playerId, std::string& receiver);
-		void playerStowItem(Player* player, Item* item, uint32_t count);
-		void playerStowItem(Player* player, const Position& pos, uint16_t spriteId, uint8_t stackpos, uint32_t count);
-		void playerStowContainer(Player* player, const Position& pos, uint16_t spriteId, uint8_t stackpos);
-		void playerStowAllItems(Player* player, const Position& pos, uint16_t spriteId, uint8_t stackpos);
+		void playerStowItem(Player* player, const Position& pos, uint16_t spriteId, uint8_t stackpos, uint8_t count, bool allItems);
 		void playerStashWithdraw(Player* player, uint16_t spriteId, uint32_t count, uint8_t stackpos);
 		void playerCloseNpcChannel(uint32_t playerId);
 		void playerReceivePing(uint32_t playerId);

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -382,6 +382,12 @@ Player* Item::getHoldingPlayer() const
 	return nullptr;
 }
 
+bool Item::isItemStorable() const
+{
+	auto isContainerAndHasSomethingInside = (getContainer() != NULL) && (getContainer()->getItemList().size() > 0);
+	return (isStowable() || isContainerAndHasSomethingInside);
+}
+
 void Item::setSubType(uint16_t n)
 {
 	const ItemType& it = items[id];

--- a/src/item.h
+++ b/src/item.h
@@ -1002,6 +1002,7 @@ class Item : virtual public Thing
 
 		void setDefaultSubtype();
 		uint16_t getSubType() const;
+		bool isItemStorable() const;
 		void setSubType(uint16_t n);
 
 		void setUniqueId(uint16_t n);
@@ -1089,5 +1090,6 @@ class Item : virtual public Thing
 
 using ItemList = std::list<Item*>;
 using ItemDeque = std::deque<Item*>;
+using StashContainerList = std::vector<std::pair<Item*, uint32_t>>;
 
 #endif

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -9837,13 +9837,16 @@ int LuaScriptInterface::luaPlayerSetOfflineTrainingSkill(lua_State* L)
 
 int LuaScriptInterface::luaPlayerOpenStash(lua_State* L)
 {
-	// player:openStash()
+	// player:openStash(isNpc)
 	Player* player = getUserdata<Player>(L, 1);
-	if (!player) {
-		return 1;
+	bool isNpc = getBoolean(L, 2, false);
+	if (player) {
+		player->sendOpenStash(isNpc);
+		pushBoolean(L, true);
+	} else {
+		lua_pushnil(L);
 	}
 
-	player->sendOpenStash();
 	return 1;
 }
 
@@ -10162,12 +10165,12 @@ int LuaScriptInterface::luaPlayerSetGroup(lua_State* L)
 
 int LuaScriptInterface::luaPlayerSetSpecialContainersAvailable(lua_State* L)
 {
-	// player:setSpecialContainersAvailable(supplyStashAvailable)
-	bool supplyStashAvailable = getBoolean(L, 2);
+	// player:setSpecialContainersAvailable(stashMenu, marketMenu)
+	bool supplyStashMenu = getBoolean(L, 2, false);
+	bool marketMenu = getBoolean(L, 3, false);
 	Player* player = getUserdata<Player>(L, 1);
 	if (player) {
-		player->setSupplyStashAvailable(supplyStashAvailable);
-		player->sendSpecialContainersAvailable(supplyStashAvailable);
+		player->setSpecialMenuAvailable(supplyStashMenu, marketMenu);
 		pushBoolean(L, true);
 	} else {
 		lua_pushnil(L);

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -6034,12 +6034,15 @@ void ProtocolGame::AddWorldLight(NetworkMessage &msg, LightInfo lightInfo)
 	msg.addByte(lightInfo.color);
 }
 
-void ProtocolGame::sendSpecialContainersAvailable(bool supplyStashAvailable)
+void ProtocolGame::sendSpecialContainersAvailable()
 {
+	if (!player)
+		return;
+
 	NetworkMessage msg;
 	msg.addByte(0x2A);
-	msg.addByte(supplyStashAvailable ? 0x01 : 0x00);
-	msg.addByte(0x00); // 0x00 if player can use 'show in market' option. TO DO
+	msg.addByte(player->isSupplyStashMenuAvailable() ? 0x01 : 0x00);
+	msg.addByte(player->isMarketMenuAvailable() ? 0x01 : 0x00);
 	writeToOutputBuffer(msg);
 }
 
@@ -6328,64 +6331,60 @@ void ProtocolGame::sendOpenStash()
 {
 	NetworkMessage msg;
 	msg.addByte(0x29);
-	AddPlayerStowedItems(msg);
-	writeToOutputBuffer(msg);
-}
-
-void ProtocolGame::AddPlayerStowedItems(NetworkMessage &msg)
-{
 	StashItemList list = player->getStashItems();
-
 	msg.add<uint16_t>(list.size());
-
-	for (auto item : list)
-	{
+	for (auto item : list) {
 		msg.add<uint16_t>(item.first);
 		msg.add<uint32_t>(item.second);
 	}
 	msg.add<uint16_t>(g_config.getNumber(ConfigManager::STASH_ITEMS) - getStashSize(list));
+	writeToOutputBuffer(msg);
 }
 
 void ProtocolGame::parseStashWithdraw(NetworkMessage &msg)
 {
+	if (player->isStashExhausted()) {
+		player->sendCancelMessage("You need to wait to do this again.");
+		return;
+	}
+
 	Supply_Stash_Actions_t action = static_cast<Supply_Stash_Actions_t>(msg.getByte());
-	switch (action)
-	{
-	case SUPPLY_STASH_ACTION_STOW_ITEM:
-	{
-		Position pos = msg.getPosition();
-		uint16_t spriteId = msg.get<uint16_t>();
-		uint8_t stackpos = msg.getByte();
-		uint32_t count = static_cast<uint32_t>(msg.getByte());
-		g_game.playerStowItem(player, pos, spriteId, stackpos, count);
-		break;
+	switch (action)	{
+		case SUPPLY_STASH_ACTION_STOW_ITEM: {
+			Position pos = msg.getPosition();
+			uint16_t spriteId = msg.get<uint16_t>();
+			uint8_t stackpos = msg.getByte();
+			uint32_t count = msg.getByte();
+			addGameTask(&Game::playerStowItem, player, pos, spriteId, stackpos, count, false);
+			break;
+		}
+		case SUPPLY_STASH_ACTION_STOW_CONTAINER: {
+			Position pos = msg.getPosition();
+			uint16_t spriteId = msg.get<uint16_t>();
+			uint8_t stackpos = msg.getByte();
+			addGameTask(&Game::playerStowItem, player, pos, spriteId, stackpos, 0, false);
+			break;
+		}
+		case SUPPLY_STASH_ACTION_STOW_STACK: {
+			Position pos = msg.getPosition();
+			uint16_t spriteId = msg.get<uint16_t>();
+			uint8_t stackpos = msg.getByte();
+			addGameTask(&Game::playerStowItem, player, pos, spriteId, stackpos, 0, true);
+			break;
+		}
+		case SUPPLY_STASH_ACTION_WITHDRAW: {
+			uint16_t spriteId = msg.get<uint16_t>();
+			uint32_t count = msg.get<uint32_t>();
+			uint8_t stackpos = msg.getByte();
+			addGameTask(&Game::playerStashWithdraw, player, spriteId, count, stackpos);
+			break;
+		}
+		default:
+			std::cout << "[ProtocolGame::parseStashWithdraw] Unknown 'supply stash' action switch: " << action << std::endl;
+			break;
 	}
-	case SUPPLY_STASH_ACTION_STOW_CONTAINER:
-	{
-		Position pos = msg.getPosition();
-		uint16_t spriteId = msg.get<uint16_t>();
-		uint8_t stackpos = msg.getByte();
-		g_game.playerStowContainer(player, pos, spriteId, stackpos);
-		break;
-	}
-	case SUPPLY_STASH_ACTION_STOW_STACK:
-	{
-		Position pos = msg.getPosition();
-		uint16_t spriteId = msg.get<uint16_t>();
-		uint8_t stackpos = msg.getByte();
-		g_game.playerStowAllItems(player, pos, spriteId, stackpos);
-		break;
-	}
-	case SUPPLY_STASH_ACTION_WITHDRAW:
-	{
-		uint16_t spriteId = msg.get<uint16_t>();
-		uint32_t count = msg.get<uint32_t>();
-		uint8_t stackpos = msg.getByte();
-		g_game.playerStashWithdraw(player, spriteId, count, stackpos);
-		sendOpenStash();
-		break;
-	}
-	}
+
+	player->updateStashExhausted();
 }
 
 void ProtocolGame::sendLockerItems(std::map<uint16_t, uint16_t> itemMap, uint16_t count)

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -2379,6 +2379,7 @@ void ProtocolGame::parseMarketBrowse(NetworkMessage &msg)
 	}
 	else
 	{
+    player->sendMarketEnter(player->getLastDepotId());
 		addGameTask(&Game::playerBrowseMarket, player->getID(), browseId);
 	}
 }

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -469,9 +469,8 @@ private:
 	void sendInventory();
 
 	void sendOpenStash();
-	void AddPlayerStowedItems(NetworkMessage &msg);
 	void parseStashWithdraw(NetworkMessage &msg);
-	void sendSpecialContainersAvailable(bool supplyStashAvailable);
+	void sendSpecialContainersAvailable();
 };
 
 #endif


### PR DESCRIPTION
Resolves #2441, Resolves #2384
Fix stash crashs, hireling errors and improving supply stash system.
- Added a exaust on supply stash actions. (Prevent exploits)
- Added 'show in market' option on menu. (When a player step on depot tile the option 'show in market' will be on the item menu)

To-Do:
- [x] Enable 'show in market' tag effect.