### PR TITLE
Prevent gold cloning

### DIFF
--- a/data/npc/scripts/custom/cassino.lua
+++ b/data/npc/scripts/custom/cassino.lua
@@ -1,7 +1,7 @@
 local config = {
 	bet = {
-		min = 10000, -- gold coins // 30k
-		max = 10000000000, 
+		min = 100000, -- gold coins // 30k
+		max = 1000000, 
 		win = 180, -- 170% high/low
 		winNum = 500, -- 300% numbers
 	},


### PR DESCRIPTION
High ranges allow players to duplicate money when repeatedly betting on a high or low and doubling the bet when they lose.