### PR TITLE
correction of the feyrist access message

### DIFF
--- a/data/scripts/actions/other/gems.lua
+++ b/data/scripts/actions/other/gems.lua
@@ -113,7 +113,7 @@ function gems.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 					return true
 				end
 			else
-				player:say("When the time comes, 'small amethysts' will be accepted at this shrine.")
+				player:say("When the time comes, '" ..item:getName() .. "' will be accepted at this shrine.")
 				return true
 			end
 		end


### PR DESCRIPTION
Correction of the message that was displayed when using a stone in the shrine, an era of the message always the same for all 4 shrines