### PR TITLE
Update spellbooks

### DIFF
--- a/data/scripts/actions/spellbook.lua
+++ b/data/scripts/actions/spellbook.lua
@@ -52,5 +52,5 @@ function spellbook.onUse(player, item, fromPosition, target, toPosition, isHotke
 end
 
 
-spellbook:id(2175, 6120, 8900, 8901, 8902, 8903, 8904, 8918, 16112, 18401, 22422, 23771, 25411, 29004, 34069, 22423, 22424, 38988)
+spellbook:id(2175, 6120, 8900, 8901, 8902, 8903, 8904, 8918, 12647, 16112, 18401, 22422, 23771, 25411, 29004, 34069, 22423, 22424, 38988)
 spellbook:register()

--- a/data/scripts/actions/spellbook.lua
+++ b/data/scripts/actions/spellbook.lua
@@ -52,5 +52,5 @@ function spellbook.onUse(player, item, fromPosition, target, toPosition, isHotke
 end
 
 
-spellbook:id(2175, 6120, 8900, 8901, 8902, 8903, 8904, 8918, 12647, 16112, 18401, 22422, 23771)
+spellbook:id(2175, 6120, 8900, 8901, 8902, 8903, 8904, 8918, 16112, 18401, 22422, 23771, 25411, 29004, 34069, 22423, 22424, 38988)
 spellbook:register()


### PR DESCRIPTION
some spellbooks were not possible to use and see the list of spells.

removing the **Snake God's Wristguard** which is not a speelbook is considered a shield. (I don't know how it is originally in the global version)

addition of other items that were missing:

Spellbook of Vigilance
Wooden Spellbook
Book of Lies
Umbral Spellbook
Spirit Guide
Lion Spellbook
Umbral Master Spellbook

FLP