### PR TITLE
Email and password authentication refactor and possibility to login with email on otclient

### DIFF
--- a/src/creatures/players/account/account.cpp
+++ b/src/creatures/players/account/account.cpp
@@ -239,8 +239,8 @@ error_t Account::LoadAccountPlayerDB(Player *player, std::string& characterName)
 		return ERROR_PLAYER_NOT_FOUND;
 	}
 
-	player.name = result->getString("name");
-	player.deletion = result->getNumber<uint64_t>("deletion");
+	player->name = result->getString("name");
+	player->deletion = result->getNumber<uint64_t>("deletion");
 
 	return ERROR_NO;
 }

--- a/src/creatures/players/account/account.cpp
+++ b/src/creatures/players/account/account.cpp
@@ -32,7 +32,7 @@ namespace account {
 
 Account::Account() {
   id_ = 0;
-  name_.clear();
+  email_.clear();
   password_.clear();
   premium_remaining_days_ = 0;
   premium_last_day_ = 0;
@@ -43,7 +43,7 @@ Account::Account() {
 
 Account::Account(uint32_t id) {
   id_ = id;
-  name_.clear();
+  email_.clear();
   password_.clear();
   premium_remaining_days_ = 0;
   premium_last_day_ = 0;
@@ -52,7 +52,7 @@ Account::Account(uint32_t id) {
   db_tasks_ = &g_databaseTasks;
 }
 
-Account::Account(const std::string &name) : name_(name) {
+Account::Account(const std::string &email) : email_(email) {
   id_ = 0;
   password_.clear();
   premium_remaining_days_ = 0;
@@ -185,17 +185,17 @@ error_t Account::RegisterCoinsTransaction(CoinTransactionType type,
 error_t Account::LoadAccountDB() {
   if (id_ != 0) {
     return this->LoadAccountDB(id_);
-  } else if (!name_.empty()) {
-    return this->LoadAccountDB(name_);
+  } else if (!email_.empty()) {
+    return this->LoadAccountDB(email_);
   }
 
   return ERROR_NOT_INITIALIZED;
 }
 
-error_t Account::LoadAccountDB(std::string name) {
+error_t Account::LoadAccountDB(std::string email) {
   std::ostringstream query;
-  query << "SELECT * FROM `accounts` WHERE `name` = "
-      << db_->escapeString(name);
+  query << "SELECT * FROM `accounts` WHERE `email` = "
+      << db_->escapeString(email);
   return this->LoadAccountDB(query);
 }
 
@@ -216,7 +216,7 @@ error_t Account::LoadAccountDB(std::ostringstream &query) {
   }
 
   this->SetID(result->getNumber<uint32_t>("id"));
-  this->SetName(result->getString("name"));
+  this->SetName(result->getString("email"));
   this->SetAccountType(static_cast<AccountType>(
                                           result->getNumber<int32_t>("type")));
   this->SetPassword(result->getString("password"));
@@ -254,7 +254,7 @@ error_t Account::SaveAccountDB() {
   std::ostringstream query;
 
   query << "UPDATE `accounts` SET "
-        << "`name` = " << db_->escapeString(name_) << " , "
+        << "`email` = " << db_->escapeString(email_) << " , "
         << "`type` = " << account_type_ << " , "
         << "`password` = " << db_->escapeString(password_) << " , "
         << "`premdays` = " << premium_remaining_days_ << " , "
@@ -262,8 +262,8 @@ error_t Account::SaveAccountDB() {
 
   if (id_ != 0) {
     query << " WHERE `id` = " << id_;
-  } else if (!name_.empty()) {
-    query << " WHERE `name` = " << name_;
+  } else if (!email_.empty()) {
+    query << " WHERE `email` = " << email_;
   }
 
   if (!db_->executeQuery(query.str())) {
@@ -294,20 +294,20 @@ error_t Account::GetID(uint32_t *id) {
   return ERROR_NO;
 }
 
-error_t Account::SetName(std::string name) {
-  if (name.empty()) {
-    return ERROR_INVALID_ACC_NAME;
+error_t Account::SetName(std::string email) {
+  if (email.empty()) {
+    return ERROR_INVALID_ACCOUNT_EMAIL;
   }
-  name_ = name;
+  email_ = email;
   return ERROR_NO;
 }
 
-error_t Account::GetName(std::string *name) {
-  if (name == nullptr) {
+error_t Account::GetName(std::string *email) {
+  if (email == nullptr) {
     return ERROR_NULLPTR;
   }
 
-  *name = name_;
+  *email = email_;
   return ERROR_NO;
 }
 

--- a/src/creatures/players/account/account.cpp
+++ b/src/creatures/players/account/account.cpp
@@ -239,6 +239,9 @@ error_t Account::LoadAccountPlayerDB(Player *player, std::string& characterName)
 		return ERROR_PLAYER_NOT_FOUND;
 	}
 
+	player.name = result->getString("name");
+	player.deletion = result->getNumber<uint64_t>("deletion");
+
 	return ERROR_NO;
 }
 

--- a/src/creatures/players/account/account.cpp
+++ b/src/creatures/players/account/account.cpp
@@ -216,7 +216,7 @@ error_t Account::LoadAccountDB(std::ostringstream &query) {
   }
 
   this->SetID(result->getNumber<uint32_t>("id"));
-  this->SetName(result->getString("email"));
+  this->SetEmail(result->getString("email"));
   this->SetAccountType(static_cast<AccountType>(
                                           result->getNumber<int32_t>("type")));
   this->SetPassword(result->getString("password"));
@@ -294,7 +294,7 @@ error_t Account::GetID(uint32_t *id) {
   return ERROR_NO;
 }
 
-error_t Account::SetName(std::string email) {
+error_t Account::SetEmail(std::string email) {
   if (email.empty()) {
     return ERROR_INVALID_ACCOUNT_EMAIL;
   }
@@ -302,7 +302,7 @@ error_t Account::SetName(std::string email) {
   return ERROR_NO;
 }
 
-error_t Account::GetName(std::string *email) {
+error_t Account::GetEmail(std::string *email) {
   if (email == nullptr) {
     return ERROR_NULLPTR;
   }

--- a/src/creatures/players/account/account.hpp
+++ b/src/creatures/players/account/account.hpp
@@ -28,7 +28,8 @@ enum Errors : uint8_t {
   ERROR_NOT_INITIALIZED,
   ERROR_NULLPTR,
   ERROR_VALUE_NOT_ENOUGH_COINS,
-  ERROR_VALUE_OVERFLOW
+  ERROR_VALUE_OVERFLOW,
+	ERROR_PLAYER_NOT_FOUND
 };
 
 enum AccountType : uint8_t {
@@ -204,12 +205,14 @@ class Account {
   error_t SetAccountType(AccountType  account_type);
   error_t GetAccountType(AccountType *account_type);
 
-  error_t GetAccountPlayers(std::vector<Player> *players);
+  error_t GetAccountPlayer(Player *player, std::string& characterName);
+	error_t GetAccountPlayers(std::vector<Player> *players);
 
  private:
   error_t SetID(uint32_t id);
   error_t LoadAccountDB(std::ostringstream &query);
   error_t LoadAccountPlayersDB(std::vector<Player> *players);
+	error_t LoadAccountPlayerDB(Player *player, std::string& characterName);
 
   Database *db_;
   DatabaseTasks *db_tasks_;

--- a/src/creatures/players/account/account.hpp
+++ b/src/creatures/players/account/account.hpp
@@ -19,7 +19,7 @@ namespace account {
 enum Errors : uint8_t {
   ERROR_NO = 0,
   ERROR_DB,
-  ERROR_INVALID_ACC_NAME,
+  ERROR_INVALID_ACCOUNT_EMAIL,
   ERROR_INVALID_ACC_PASSWORD,
   ERROR_INVALID_ACC_TYPE,
   ERROR_INVALID_ID,
@@ -215,7 +215,7 @@ class Account {
   DatabaseTasks *db_tasks_;
 
   uint32_t id_;
-  std::string name_;
+  std::string email_;
   std::string password_;
   uint32_t premium_remaining_days_;
   time_t premium_last_day_;

--- a/src/creatures/players/account/account.hpp
+++ b/src/creatures/players/account/account.hpp
@@ -29,7 +29,7 @@ enum Errors : uint8_t {
   ERROR_NULLPTR,
   ERROR_VALUE_NOT_ENOUGH_COINS,
   ERROR_VALUE_OVERFLOW,
-	ERROR_PLAYER_NOT_FOUND
+  ERROR_PLAYER_NOT_FOUND
 };
 
 enum AccountType : uint8_t {
@@ -206,13 +206,13 @@ class Account {
   error_t GetAccountType(AccountType *account_type);
 
   error_t GetAccountPlayer(Player *player, std::string& characterName);
-	error_t GetAccountPlayers(std::vector<Player> *players);
+  error_t GetAccountPlayers(std::vector<Player> *players);
 
  private:
   error_t SetID(uint32_t id);
   error_t LoadAccountDB(std::ostringstream &query);
   error_t LoadAccountPlayersDB(std::vector<Player> *players);
-	error_t LoadAccountPlayerDB(Player *player, std::string& characterName);
+  error_t LoadAccountPlayerDB(Player *player, std::string& characterName);
 
   Database *db_;
   DatabaseTasks *db_tasks_;

--- a/src/creatures/players/account/account.hpp
+++ b/src/creatures/players/account/account.hpp
@@ -189,8 +189,8 @@ class Account {
 
   error_t GetID(uint32_t *id);
 
-  error_t SetName(std::string  name);
-  error_t GetName(std::string *name);
+  error_t SetEmail(std::string  name);
+  error_t GetEmail(std::string *name);
 
   error_t SetPassword(std::string  password);
   error_t GetPassword(std::string *password);

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -6801,7 +6801,7 @@ bool save = false;
 	time_t last_day;
 	account.GetPremiumRemaningDays(&rem_days);
 	account.GetPremiumLastDay(&last_day);
-	std::string name;
+	std::string email;
 	if (rem_days != 0) {
 		if (last_day == 0) {
 			account.SetPremiumLastDay(timeNow);
@@ -6811,9 +6811,9 @@ bool save = false;
 			if (days > 0) {
 				if (days >= rem_days) {
 					if(!account.SetPremiumRemaningDays(0) || !account.SetPremiumLastDay(0)) {
-						account.GetName(&name);
-						SPDLOG_ERROR("Failed to set account premium days, account name: {}",
-							name);
+						account.GetEmail(&email);
+						SPDLOG_ERROR("Failed to set account premium days, account email: {}",
+							email);
 					}
 				} else {
 					account.SetPremiumRemaningDays((rem_days - days));
@@ -6824,17 +6824,15 @@ bool save = false;
 				save = true;
 			}
 		}
-  }
-  else if (last_day != 0)
-  {
-    account.SetPremiumLastDay(0);
+	}
+	else if (last_day != 0) {
+		account.SetPremiumLastDay(0);
 		save = true;
-  }
+	}
 
 	if (save && !account.SaveAccountDB()) {
-		account.GetName(&name);
-		SPDLOG_ERROR("Failed to save account: {}",
-			name);
+		account.GetEmail(&email);
+		SPDLOG_ERROR("Failed to save account: {}", email);
 	}
 }
 

--- a/src/io/iologindata.cpp
+++ b/src/io/iologindata.cpp
@@ -58,12 +58,10 @@ uint32_t IOLoginData::gameworldAuthentication(const std::string& email, const st
 
   Database& db = Database::getInstance();
   std::ostringstream query;
-  query << "SELECT `id`, `password` FROM `accounts` WHERE `email` = " << db.escapeString(email);
+  query << "SELECT `id` FROM `accounts` WHERE `email` = " << db.escapeString(email);
   DBResult_ptr result = db.storeQuery(query.str());
-  if (!result) {
-    SPDLOG_ERROR("Wrong email");
-    return 0;
-  }
+
+  uint32_t accountId = result->getNumber<uint32_t>("id");
 
   query.str(std::string());
   query << "SELECT `account_id`, `name`, `deletion` FROM `players` WHERE `name` = " << db.escapeString(characterName);
@@ -73,7 +71,6 @@ uint32_t IOLoginData::gameworldAuthentication(const std::string& email, const st
     return 0;
   }
 
-  uint32_t accountId = result->getNumber<uint32_t>("id");
   if (result->getNumber<uint32_t>("account_id") != accountId || result->getNumber<uint64_t>("deletion") != 0) {
     SPDLOG_ERROR("Account mismatch or account has been marked as deleted");
     return 0;

--- a/src/io/iologindata.cpp
+++ b/src/io/iologindata.cpp
@@ -38,8 +38,9 @@ uint32_t IOLoginData::authenticateAccountPassword(const std::string& email, cons
     std::ostringstream query;
     query << "SELECT `id`, `password` FROM `accounts` WHERE `email` = " << db.escapeString(email);
     DBResult_ptr result = db.storeQuery(query.str());
+    uint32_t accountId = result->getNumber<uint32_t>("id");
     if (!result) {
-        SPDLOG_ERROR("Wrong email");
+        SPDLOG_ERROR("Wrong email for account id: {}", accountId);
         return 0;
     }
 
@@ -47,7 +48,8 @@ uint32_t IOLoginData::authenticateAccountPassword(const std::string& email, cons
         SPDLOG_ERROR("Wrong password {} != {}", transformToSHA1(password), result->getString("password"));
         return 0;
     }
-    return 1;
+
+    return accountId;
 }
 
 uint32_t IOLoginData::gameworldAuthentication(const std::string& email, const std::string& password, std::string& characterName)

--- a/src/io/iologindata.cpp
+++ b/src/io/iologindata.cpp
@@ -56,8 +56,8 @@ bool IOLoginData::gameWorldAuthentication(const std::string& email, const std::s
 	}
 
 	account::Player player;
-  if (account::ERROR_NO != account.GetAccountPlayer(&player, characterName)) {
-    SPDLOG_ERROR("Player not found or deleted for account.");
+	if (account::ERROR_NO != account.GetAccountPlayer(&player, characterName)) {
+		SPDLOG_ERROR("Player not found or deleted for account.");
 		return false;
 	}
 

--- a/src/io/iologindata.cpp
+++ b/src/io/iologindata.cpp
@@ -41,7 +41,7 @@ bool IOLoginData::authenticateAccountPassword(const std::string& email, const st
 	std::string accountPassword;
 	account->GetPassword(&accountPassword);
 	if (transformToSHA1(password) != accountPassword) {
-			SPDLOG_ERROR("Wrong password {} != {}", transformToSHA1(password), accountPassword);
+			SPDLOG_ERROR("Password '{}' doesn't match any account", transformToSHA1(password));
 			return false;
 	}
 
@@ -62,16 +62,16 @@ bool IOLoginData::gameWorldAuthentication(const std::string& email, const std::s
   query << "SELECT `account_id`, `name`, `deletion` FROM `players` WHERE `name` = " << db.escapeString(characterName);
 
 	DBResult_ptr result = db.storeQuery(query.str());
-  if (!result) {
-    SPDLOG_ERROR("Not able to find player: {}", characterName);
+	if (!result) {
+		SPDLOG_ERROR("Not able to find player: {}", characterName);
 		return false;
-  }
+	}
 
 	account.GetID(accountId);
-  if (result->getNumber<uint32_t>("account_id") != *accountId || result->getNumber<uint64_t>("deletion") != 0) {
-    SPDLOG_ERROR("Account mismatch or account has been marked as deleted");
+	if (result->getNumber<uint32_t>("account_id") != *accountId || result->getNumber<uint64_t>("deletion") != 0) {
+		SPDLOG_ERROR("Account mismatch or has been marked as deleted");
 		return false;
-  }
+	}
 
 	return true;
 }

--- a/src/io/iologindata.cpp
+++ b/src/io/iologindata.cpp
@@ -47,6 +47,7 @@ uint32_t IOLoginData::authenticateAccountPassword(const std::string& email, cons
         SPDLOG_ERROR("Wrong password {} != {}", transformToSHA1(password), result->getString("password"));
         return 0;
     }
+    return 1;
 }
 
 uint32_t IOLoginData::gameworldAuthentication(const std::string& email, const std::string& password, std::string& characterName)

--- a/src/io/iologindata.cpp
+++ b/src/io/iologindata.cpp
@@ -55,23 +55,13 @@ bool IOLoginData::gameWorldAuthentication(const std::string& email, const std::s
 		return false;
 	}
 
-	Database& db = Database::getInstance();
-	std::ostringstream query;
-
-	query.str(std::string());
-  query << "SELECT `account_id`, `name`, `deletion` FROM `players` WHERE `name` = " << db.escapeString(characterName);
-
-	DBResult_ptr result = db.storeQuery(query.str());
-	if (!result) {
-		SPDLOG_ERROR("Not able to find player: {}", characterName);
+	Player player;
+  if (account::ERROR_NO != account.LoadAccountPlayerDB(&player, characterName)) {
+    SPDLOG_ERROR("Player not found or deleted for account.");
 		return false;
 	}
 
 	account.GetID(accountId);
-	if (result->getNumber<uint32_t>("account_id") != *accountId || result->getNumber<uint64_t>("deletion") != 0) {
-		SPDLOG_ERROR("Account mismatch or has been marked as deleted");
-		return false;
-	}
 
 	return true;
 }

--- a/src/io/iologindata.cpp
+++ b/src/io/iologindata.cpp
@@ -55,7 +55,7 @@ bool IOLoginData::gameWorldAuthentication(const std::string& email, const std::s
 		return false;
 	}
 
-	Player player;
+	account::Player player;
   if (account::ERROR_NO != account.LoadAccountPlayerDB(&player, characterName)) {
     SPDLOG_ERROR("Player not found or deleted for account.");
 		return false;

--- a/src/io/iologindata.cpp
+++ b/src/io/iologindata.cpp
@@ -56,7 +56,7 @@ bool IOLoginData::gameWorldAuthentication(const std::string& email, const std::s
 	}
 
 	account::Player player;
-  if (account::ERROR_NO != account.LoadAccountPlayerDB(&player, characterName)) {
+  if (account::ERROR_NO != account.GetAccountPlayer(&player, characterName)) {
     SPDLOG_ERROR("Player not found or deleted for account.");
 		return false;
 	}

--- a/src/io/iologindata.h
+++ b/src/io/iologindata.h
@@ -29,10 +29,11 @@ using ItemBlockList = std::list<std::pair<int32_t, Item*>>;
 class IOLoginData
 {
 	public:
-
-		static bool LoginServerAuthentication(const std::string& name,
-                                          const std::string& password);
-		static uint32_t gameworldAuthentication(const std::string& accountName, const std::string& password, std::string& characterName);
+		static uint32_t authenticateAccountPassword(const std::string& email,
+                                                    const std::string& password);
+		static uint32_t gameworldAuthentication(const std::string& accountName,
+                                                const std::string& password,
+                                                std::string& characterName);
 		static account::AccountType getAccountType(uint32_t accountId);
 		static void setAccountType(uint32_t accountId, account::AccountType accountType);
 		static void updateOnlineStatus(uint32_t guid, bool login);

--- a/src/io/iologindata.h
+++ b/src/io/iologindata.h
@@ -29,11 +29,13 @@ using ItemBlockList = std::list<std::pair<int32_t, Item*>>;
 class IOLoginData
 {
 	public:
-		static uint32_t authenticateAccountPassword(const std::string& email,
-                                                    const std::string& password);
-		static uint32_t gameworldAuthentication(const std::string& accountName,
+		static bool authenticateAccountPassword(const std::string& email,
+                                                    const std::string& password,
+																										account::Account *account);
+		static bool gameWorldAuthentication(const std::string& accountName,
                                                 const std::string& password,
-                                                std::string& characterName);
+                                                std::string& characterName,
+																								uint32_t *accountId);
 		static account::AccountType getAccountType(uint32_t accountId);
 		static void setAccountType(uint32_t accountId, account::AccountType accountType);
 		static void updateOnlineStatus(uint32_t guid, bool login);

--- a/src/io/iologindata.h
+++ b/src/io/iologindata.h
@@ -30,12 +30,12 @@ class IOLoginData
 {
 	public:
 		static bool authenticateAccountPassword(const std::string& email,
-                                                    const std::string& password,
-																										account::Account *account);
-		static bool gameWorldAuthentication(const std::string& accountName,
                                                 const std::string& password,
-                                                std::string& characterName,
-																								uint32_t *accountId);
+                                                account::Account *account);
+		static bool gameWorldAuthentication(const std::string& accountName,
+                                            const std::string& password,
+                                            std::string& characterName,
+                                            uint32_t *accountId);
 		static account::AccountType getAccountType(uint32_t accountId);
 		static void setAccountType(uint32_t accountId, account::AccountType accountType);
 		static void updateOnlineStatus(uint32_t guid, bool login);

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -498,8 +498,8 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage &msg)
 		msg.getString();
 	}
 
-	std::string accountName = sessionKey.substr(0, pos);
-	if (accountName.empty())
+	std::string email = sessionKey.substr(1, pos);
+	if (email.empty())
 	{
 		disconnectClient("You must enter your account name.");
 		return;
@@ -551,7 +551,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage &msg)
 		return;
 	}
 
-	uint32_t accountId = IOLoginData::gameworldAuthentication(accountName, password, characterName);
+	uint32_t accountId = IOLoginData::gameworldAuthentication(email, password, characterName);
 	if (accountId == 0)
 	{
 		disconnectClient("Account name or password is not correct.");

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -554,7 +554,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage &msg)
 	uint32_t accountId = IOLoginData::gameworldAuthentication(email, password, characterName);
 	if (accountId == 0)
 	{
-		disconnectClient("Account name or password is not correct.");
+		disconnectClient("Email or password is not correct.");
 		return;
 	}
 

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -498,7 +498,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage &msg)
 		msg.getString();
 	}
 
-	std::string email = sessionKey.substr(1, pos);
+	std::string email = sessionKey.substr(0, pos);
 	if (email.empty())
 	{
 		disconnectClient("You must enter your account name.");

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -487,7 +487,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage &msg)
 	size_t pos = sessionKey.find('\n');
 	if (pos == std::string::npos)
 	{
-		disconnectClient("You must enter your account name.");
+		disconnectClient("You must enter your email.");
 		return;
 	}
 
@@ -501,7 +501,7 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage &msg)
 	std::string email = sessionKey.substr(0, pos);
 	if (email.empty())
 	{
-		disconnectClient("You must enter your account name.");
+		disconnectClient("You must enter your email.");
 		return;
 	}
 

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -551,9 +551,8 @@ void ProtocolGame::onRecvFirstMessage(NetworkMessage &msg)
 		return;
 	}
 
-	uint32_t accountId = IOLoginData::gameworldAuthentication(email, password, characterName);
-	if (accountId == 0)
-	{
+	uint32_t accountId;
+	if (!IOLoginData::gameWorldAuthentication(email, password, characterName, &accountId)) {
 		disconnectClient("Email or password is not correct.");
 		return;
 	}

--- a/src/server/network/protocol/protocollogin.cpp
+++ b/src/server/network/protocol/protocollogin.cpp
@@ -50,17 +50,11 @@ void ProtocolLogin::disconnectClient(const std::string& message, uint16_t versio
 
 void ProtocolLogin::getCharacterList(const std::string& email, const std::string& password, uint16_t version)
 {
-	// Load Account Information
-	int result = 0;
 	account::Account account;
-	result = account.LoadAccountDB(email);
-
-	// Check Login Password
-	if (!IOLoginData::authenticateAccountPassword(email, password)) {
+	if (!IOLoginData::authenticateAccountPassword(email, password, &account)) {
 		disconnectClient("Email or password is not correct", version);
 		return;
 	}
-
 
 	// Update premium days
 	Game::updatePremium(account);

--- a/src/server/network/protocol/protocollogin.cpp
+++ b/src/server/network/protocol/protocollogin.cpp
@@ -54,10 +54,6 @@ void ProtocolLogin::getCharacterList(const std::string& email, const std::string
 	int result = 0;
 	account::Account account;
 	result = account.LoadAccountDB(email);
-	if (result) {
-		SPDLOG_ERROR("Loaded account email");
-		return;
-	}
 
 	// Check Login Password
 	if (!IOLoginData::authenticateAccountPassword(email, password)) {

--- a/src/server/network/protocol/protocollogin.cpp
+++ b/src/server/network/protocol/protocollogin.cpp
@@ -177,9 +177,9 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 		return;
 	}
 
-	std::string accountName = msg.getString();
-	if (accountName.empty()) {
-		disconnectClient("Invalid account name.", version);
+	std::string email = msg.getString();
+	if (email.empty()) {
+		disconnectClient("Invalid email.", version);
 		return;
 	}
 
@@ -190,5 +190,5 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 	}
 
 	auto thisPtr = std::static_pointer_cast<ProtocolLogin>(shared_from_this());
-	g_dispatcher.addTask(createTask(std::bind(&ProtocolLogin::getCharacterList, thisPtr, accountName, password, version)));
+	g_dispatcher.addTask(createTask(std::bind(&ProtocolLogin::getCharacterList, thisPtr, email, password, version)));
 }

--- a/tests/account_test.cpp
+++ b/tests/account_test.cpp
@@ -126,7 +126,7 @@ TEST_CASE("Set Name - Empty", "[UnitTest]") {
   error_t result;
   std::string new_name;
   result = account.SetName(new_name);
-  REQUIRE(result == account::ERROR_INVALID_ACC_NAME);
+  REQUIRE(result == account::ERROR_INVALID_ACCOUNT_EMAIL);
 }
 
 TEST_CASE("Get Name - Nullptr", "[UnitTest]") {

--- a/tests/account_test.cpp
+++ b/tests/account_test.cpp
@@ -16,10 +16,10 @@ TEST_CASE("Default Constructor", "[UnitTest]") {
     CHECK(id == 0);
   }
 
-	SECTION("Default Name") {
-    std::string name;
-    normal.GetName(&name);
-    CHECK(name.empty() == true);
+	SECTION("@DefaultEmail") {
+    std::string email;
+    normal.GetEmail(&email);
+    CHECK(email.empty() == true);
   }
 
 	SECTION("Default Password") {
@@ -48,11 +48,11 @@ TEST_CASE("Constructor ID", "[UnitTest]") {
   CHECK(id == 14);
 }
 
-TEST_CASE("Constructor Name", "[UnitTest]") {
-	account::Account with_name("Test");
-  std::string name;
-  with_name.GetName(&name);
-  CHECK(name == "Test");
+TEST_CASE("Constructor Email", "[UnitTest]") {
+	account::Account with_email("@test");
+  std::string email;
+  with_email.GetEmail(&email);
+  CHECK(email == "@test");
 }
 
 TEST_CASE("Set Database Interface", "[UnitTest]") {
@@ -109,37 +109,32 @@ TEST_CASE("Get ID - Nullptr", "[UnitTest]") {
   REQUIRE(result == account::ERROR_NULLPTR);
 }
 
-TEST_CASE("Set/Get Name", "[UnitTest]") {
+TEST_CASE("Set/Get Email", "[UnitTest]") {
 	account::Account account;
   error_t result;
-  result = account.SetName("Rick Maru");
+  result = account.SetEmail("@RickMaru");
   REQUIRE(result == account::ERROR_NO);
 
-  std::string new_name;
-  result = account.GetName(&new_name);
+  std::string new_email;
+  result = account.GetEmail(&new_email);
   REQUIRE(result == account::ERROR_NO);
-  REQUIRE(new_name == "Rick Maru");
+  REQUIRE(new_email == "@RickMaru");
 }
 
-TEST_CASE("Set Name - Empty", "[UnitTest]") {
+TEST_CASE("Set Email - Empty", "[UnitTest]") {
 	account::Account account;
   error_t result;
-  std::string new_name;
-  result = account.SetName(new_name);
+  std::string new_email;
+  result = account.SetEmail(new_email);
   REQUIRE(result == account::ERROR_INVALID_ACCOUNT_EMAIL);
 }
 
-TEST_CASE("Get Name - Nullptr", "[UnitTest]") {
+TEST_CASE("Get Email - Nullptr", "[UnitTest]") {
 	account::Account account;
   error_t result;
-  result = account.GetName(nullptr);
+  result = account.GetEmail(nullptr);
   REQUIRE(result == account::ERROR_NULLPTR);
 }
-
-
-
-
-
 
 TEST_CASE("Set/Get Password", "[UnitTest]") {
 	account::Account account;
@@ -511,10 +506,10 @@ TEST_CASE("Load Account Using ID From Constructor", "[IntegrationTest]") {
   CHECK(result == account::ERROR_NO);
   CHECK(id == 1);
 
-  std::string name;
-  result = account.GetName(&name);
+  std::string email;
+  result = account.GetEmail(&email);
   CHECK(result == account::ERROR_NO);
-  CHECK(name == "GOD");
+  CHECK(email == "@GOD");
 
   std::string password;
   result = account.GetPassword(&password);
@@ -537,8 +532,8 @@ TEST_CASE("Load Account Using ID From Constructor", "[IntegrationTest]") {
   CHECK(account_type == account::ACCOUNT_TYPE_GOD);
 }
 
-TEST_CASE("Load Account Using Name From Constructor", "[IntegrationTest]") {
-	account::Account account("GOD");
+TEST_CASE("Load Account Using Email From Constructor", "[IntegrationTest]") {
+	account::Account account("@GOD");
   std::string db_ip("127.0.0.1");
   std::string db_user("otserver");
   std::string db_password("otserver");
@@ -563,10 +558,10 @@ TEST_CASE("Load Account Using Name From Constructor", "[IntegrationTest]") {
   CHECK(result == account::ERROR_NO);
   CHECK(id == 1);
 
-  std::string name;
-  result = account.GetName(&name);
+  std::string email;
+  result = account.GetEmail(&email);
   CHECK(result == account::ERROR_NO);
-  CHECK(name == "GOD");
+  CHECK(email == "@GOD");
 
   std::string password;
   result = account.GetPassword(&password);
@@ -615,10 +610,10 @@ TEST_CASE("Load Account Using ID", "[IntegrationTest]") {
   CHECK(result == account::ERROR_NO);
   CHECK(id == 1);
 
-  std::string name;
-  result = account.GetName(&name);
+  std::string email;
+  result = account.GetEmail(&email);
   CHECK(result == account::ERROR_NO);
-  CHECK(name == "GOD");
+  CHECK(email == "@GOD");
 
   std::string password;
   result = account.GetPassword(&password);
@@ -641,7 +636,7 @@ TEST_CASE("Load Account Using ID", "[IntegrationTest]") {
   CHECK(account_type == account::ACCOUNT_TYPE_GOD);
 }
 
-TEST_CASE("Load Account Using Name", "[IntegrationTest]") {
+TEST_CASE("Load Account Using Email", "[IntegrationTest]") {
 	account::Account account;
   std::string db_ip("127.0.0.1");
   std::string db_user("otserver");
@@ -659,7 +654,7 @@ TEST_CASE("Load Account Using Name", "[IntegrationTest]") {
   }
 
   error_t result;
-  result = account.LoadAccountDB("GOD");
+  result = account.LoadAccountDB("@GOD");
   REQUIRE(result == account::ERROR_NO);
 
   uint32_t id;
@@ -667,10 +662,10 @@ TEST_CASE("Load Account Using Name", "[IntegrationTest]") {
   CHECK(result == account::ERROR_NO);
   CHECK(id == 1);
 
-  std::string name;
-  result = account.GetName(&name);
+  std::string email;
+  result = account.GetEmail(&email);
   CHECK(result == account::ERROR_NO);
-  CHECK(name == "GOD");
+  CHECK(email == "@GOD");
 
   std::string password;
   result = account.GetPassword(&password);
@@ -723,10 +718,10 @@ TEST_CASE("Save Account", "[IntegrationTest]") {
   CHECK(result == account::ERROR_NO);
   CHECK(id == 1);
 
-  std::string name;
-  result = account.GetName(&name);
+  std::string email;
+  result = account.GetEmail(&email);
   CHECK(result == account::ERROR_NO);
-  CHECK(name == "GOD");
+  CHECK(email == "@GOD");
 
   std::string password;
   result = account.GetPassword(&password);
@@ -750,8 +745,8 @@ TEST_CASE("Save Account", "[IntegrationTest]") {
 
 
   // Change Account
-  std::string new_name("New Name");
-  result = account.SetName(new_name);
+  std::string new_email("@NewEmail");
+  result = account.SetEmail(new_email);
   CHECK(result == account::ERROR_NO);
 
   std::string new_password("123456789");
@@ -784,9 +779,9 @@ TEST_CASE("Save Account", "[IntegrationTest]") {
   CHECK(result == account::ERROR_NO);
   CHECK(id == 1);
 
-  result = changed_account.GetName(&name);
+  result = changed_account.GetEmail(&email);
   CHECK(result == account::ERROR_NO);
-  CHECK(name == new_name);
+  CHECK(email == new_email);
 
   result = changed_account.GetPassword(&password);
   CHECK(result == account::ERROR_NO);


### PR DESCRIPTION
It was not possible to log into otclient using email.
Minor refactoring in email and password authentication functions.
Account name authentication removed.