### PR TITLE
Fix faceless bane access

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -44830,6 +44830,9 @@
 	<item id="34588" article="an" name="acid resistant fishing rod">
 		<attribute key="weight" value="850" />
 	</item>
+	<item id="34592" article="a" name="book about spells">
+		<attribute key="description" value="This book contains descriptions of spells and what they do. Some of it does not sound very likely at all." />
+	</item>
 	<item id="34606" article="a" name="tree"/>
 	<item id="34607" article="a" name="sun fruit bush"/>
 	<item id="34608" article="a" name="sun fruit bush"/>

--- a/data/monster/quests/the_dream_courts/bosses/faceless_bane.lua
+++ b/data/monster/quests/the_dream_courts/bosses/faceless_bane.lua
@@ -90,7 +90,7 @@ monster.loot = {
 	{name = "Ectoplasmic Shield", chance = 600},
 	{name = "Book Backpack", chance = 550},
 	{name = "Spirit Guide", chance = 530},
-	{id = 34982, chance = 500}, --- Enchanted Pendulet
+	{id = 34983, chance = 500}, --- Enchanted Pendulet
 }
 
 monster.attacks = {

--- a/data/monster/quests/the_dream_courts/bosses/faceless_bane.lua
+++ b/data/monster/quests/the_dream_courts/bosses/faceless_bane.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Faceless Bane")
 local monster = {}
 
 monster.description = "a Faceless Bane"
-monster.experience = 14000
+monster.experience = 30000
 monster.outfit = {
 	lookType = 1122,
 	lookHead = 0,
@@ -13,8 +13,8 @@ monster.outfit = {
 	lookMount = 0
 }
 
-monster.health = 17000
-monster.maxHealth = 17000
+monster.health = 35000
+monster.maxHealth = 35000
 monster.race = "blood"
 monster.corpse = 34651
 monster.speed = 250
@@ -64,15 +64,42 @@ monster.voices = {
 	chance = 10,
 }
 
+
 monster.loot = {
-	{name = "Book Backpack", chance = 100000},
-	{name = "Ectoplasmic Shield", chance = 100000},
-	{name = "Spirit Guide", chance = 100000},
-	{id = 34983, chance = 100000}
+	{name = "platinum coin", minCount = 1, maxCount = 10, chance = 100000},
+	{name = "Combat Knife", chance = 50000},
+	{name = "Crowbar", chance = 45000},
+	{name = "Ice Rapier", chance = 42000},
+	{name = "Hailstorm Rod", chance = 42000},
+	{name = "Violet Crystal Shard", chance = 22000},
+	{name = "Red Gem", chance = 22000},
+	{name = "Red Crystal Fragment", chance = 18000},
+	{name = "Small Sapphire", minCount = 1, maxCount = 3, chance = 25000},
+	{name = "Knife", chance = 19000},
+	{name = "Snakebite Rod", chance = 18500},
+	{name = "Necrotic Rod", chance = 18500},
+	{name = "Life Crystal", chance = 16800},
+	{name = "Violet Gem", chance = 15200},
+	{name = "Underworld Rod", chance = 15200},
+	{name = "Spear", minCount = 0, maxCount = 3, chance = 18000},
+	{name = "Dagger", chance = 18200},
+	{name = "Moonlight Rod", chance = 12000},
+	{name = "Terra Rod", chance = 12000},
+	{name = "Cyan Crystal Fragment", chance = 5500},
+	{name = "Green Crystal Shard", chance = 1300},
+	{name = "Ectoplasmic Shield", chance = 600},
+	{name = "Book Backpack", chance = 550},
+	{name = "Spirit Guide", chance = 530},
+	{id = 34982, chance = 500}, --- Enchanted Pendulet
 }
 
 monster.attacks = {
-	{name ="melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -5}
+    {name = "melee", type = COMBAT_PHYSICALDAMAGE, interval = 2000, minDamage = 0, maxDamage = -575},
+	{name ="combat", interval = 2000, chance = 65, type = COMBAT_FIREDAMAGE, minDamage = -350, maxDamage = -500, radius = 3, Effect = CONST_ANI_FIRE, effect = CONST_ME_FIREAREA, target = false},
+	{name ="combat", interval = 2000, chance = 45, type = COMBAT_DEATHDAMAGE, minDamage = -335, maxDamage = -450, radius = 4, Effect = CONST_ANI_SUDDENDEATH, effect = CONST_ME_MORTAREA, target = false},
+	{name ="combat", interval = 2000, chance = 25, type = COMBAT_PHYSICALDAMAGE, minDamage = -330, maxDamage = -380, length = 7, effect = CONST_ME_EXPLOSIONAREA, target = false},
+	{name ="combat", interval = 2000, chance = 35, type = COMBAT_FIREDAMAGE, minDamage = -300, maxDamage = -410, range = 4, radius = 4, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREAREA, target = true},
+	{name ="combat", interval = 2000, chance = 20, type = COMBAT_ENERGYDAMAGE, minDamage = -385, maxDamage = -535, range = 4, radius = 1, shootEffect = CONST_ANI_ENERGY, effect = CONST_ME_ENERGYAREA, target = true}
 }
 
 monster.defenses = {
@@ -81,16 +108,16 @@ monster.defenses = {
 }
 
 monster.elements = {
-	{type = COMBAT_PHYSICALDAMAGE, percent = 0},
+	{type = COMBAT_PHYSICALDAMAGE, percent = 100},
 	{type = COMBAT_ENERGYDAMAGE, percent = 0},
 	{type = COMBAT_EARTHDAMAGE, percent = 0},
-	{type = COMBAT_FIREDAMAGE, percent = 0},
+	{type = COMBAT_FIREDAMAGE, percent = -20},
 	{type = COMBAT_LIFEDRAIN, percent = 0},
 	{type = COMBAT_MANADRAIN, percent = 0},
 	{type = COMBAT_DROWNDAMAGE, percent = 0},
 	{type = COMBAT_ICEDAMAGE, percent = 0},
 	{type = COMBAT_HOLYDAMAGE , percent = 0},
-	{type = COMBAT_DEATHDAMAGE , percent = 1}
+	{type = COMBAT_DEATHDAMAGE , percent = 99}
 }
 
 monster.heals = {

--- a/data/scripts/actions/quests/threatened_dreams/lever.lua
+++ b/data/scripts/actions/quests/threatened_dreams/lever.lua
@@ -1,53 +1,97 @@
-local setting = {
+local config = {
+	bossName = "Faceless Bane",
+	requiredLevel = 250,
+	leverId = 10030,
 	timeToFightAgain = 20, -- In hour
-	clearRoomTime = 60, -- In hour
-	centerRoom = {x = 33617, y = 32562, z = 13},
-	range = 10,
-	exitPosition = {x = 33618, y = 32520, z = 15},
-	storage = Storage.ThreatenedDreams.FacelessBaneTime,
-	bossName = "faceless bane",
-	bossPosition = {x = 33528, y = 32333, z = 12}
-}
-
-local playerPositions = {
-	{fromPos = {x = 33638, y = 32562, z = 13}, toPos = {x = 33615, y = 32567, z = 13}},
-	{fromPos = {x = 33639, y = 32362, z = 13}, toPos = {x = 33616, y = 32567, z = 13}},
-	{fromPos = {x = 33640, y = 32362, z = 13}, toPos = {x = 33617, y = 32567, z = 13}},
-	{fromPos = {x = 33641, y = 32362, z = 13}, toPos = {x = 33618, y = 32567, z = 13}},
-	{fromPos = {x = 33642, y = 32362, z = 13}, toPos = {x = 33619, y = 32567, z = 13}}
+	timeToDefeatBoss = 20, -- In minutes
+	clearRoomTime = 60, -- In minutes
+	daily = true,
+	centerRoom = Position(33617, 32562, 13),
+	playerPositions = {
+		Position(33638, 32562, 13),
+		Position(33639, 32562, 13),
+		Position(33640, 32562, 13),
+		Position(33641, 32562, 13),
+		Position(33642, 32562, 13)
+	},
+	teleportPosition = Position(33617, 32567, 13),
+	bossPosition = Position(33617, 32561, 13),
+	specPos = Position(33618, 32520, 15)
 }
 
 local threatenedLever = Action()
-function threatenedLever.onUse(player, item, fromPosition, target, toPosition, monster, isHotkey)
-	if item.itemid == 9825 then
-		if player:getPosition() ~= Position(33638, 32562, 13) then
-			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You need 5 players to fight with this boss.")
-			item:transform(9826)
+function threatenedLever.onUse(player, item, fromPosition, target, toPosition, isHotkey)
+	if item.itemid == config.leverId then
+		-- Check if the player that pulled the lever is on the correct position
+		if player:getPosition() ~= config.playerPositions[1] then
+			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You can\'t start the battle.")
 			return true
 		end
+		
+		local team, participant = {}
 
-		if roomIsOccupied(setting.centerRoom, setting.range, setting.range) then
-			player:say("Someone is fighting against the boss! You need wait awhile.", TALKTYPE_MONSTER_SAY)
-			return true
-		end
-
-		for i = 1, #playerPositions do
-			local creature = Tile(playerPositions[i].fromPos):getTopCreature()
-			if creature then
-				if creature:getStorageValue(setting.storage) >= os.time() then
-					creature:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have faced this boss in the last " .. setting.timeToFightAgain .. " hours.")
+		for i = 1, #config.playerPositions do
+			participant = Tile(config.playerPositions[i]):getTopCreature()
+			
+			-- Check there is a participant player
+			if participant and participant:isPlayer() then
+				-- Check participant level
+				if participant:getLevel() < config.requiredLevel then
+					player:sendTextMessage(MESSAGE_EVENT_ADVANCE,
+						"All the players need to be level ".. config.requiredLevel .." or higher.")
 					return true
 				end
-				if creature:getStorageValue(setting.storage) < os.time() then
-					creature:setStorageValue(setting.storage, os.time() + setting.timeToFightAgain * 60 * 60)
-					creature:teleportTo(playerPositions[i].toPos)
-					creature:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+
+				-- Check participant boss timer
+				if config.daily and participant:getStorageValue(Storage.ThreatenedDreams.FacelessBaneTime) > os.time() then
+					player:getPosition():sendMagicEffect(CONST_ME_POFF)
+					player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 
+						"You or a member in your team have to wait ".. config.timeToFightAgain .."  hours to face Faceless Bane again!")
+					return true
 				end
+
+				team[#team + 1] = participant
 			end
 		end
+
+		-- Check if a team currently inside the boss room
+		local specs, spec = Game.getSpectators(config.centerRoom, false, false, 14, 14, 13, 13)
+		for i = 1, #specs do
+			spec = specs[i]
+			if spec:isPlayer() then
+				player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "There's someone fighting with Faceless Bane.")
+				return true
+			end
+
+			spec:remove()
+		end
+
 		-- One hour for clean the room
-		addEvent(clearRoom, setting.clearRoomTime * 60 * 1000, setting.centerRoom, setting.range, setting.range, setting.exitPosition)
-		Game.createMonster(setting.bossName, setting.bossPosition)
+		addEvent(clearRoom, config.clearRoomTime * 60 * 1000, config.centerRoom)
+		Game.createMonster(config.bossName, config.bossPosition)
+
+		-- Teleport team participants
+		for i = 1, #team do
+			team[i]:getPosition():sendMagicEffect(CONST_ME_POFF)
+			team[i]:teleportTo(config.teleportPosition)
+			team[i]:sendTextMessage(MESSAGE_EVENT_ADVANCE, 
+					"You have ".. config.timeToDefeatBoss .." minutes to kill and loot this boss. Otherwise you will lose that chance and will be kicked out.")
+			-- Assign boss timer
+			team[i]:setStorageValue(Storage.ThreatenedDreams.FacelessBaneTime, os.time() + config.timeToFightAgain * 60 * 60) -- 20 hours
+			item:transform(config.leverId)
+			
+				addEvent(function()
+					local specs, spec = Game.getSpectators(config.centerRoom, false, false, 14, 14, 13, 13)
+						for i = 1, #specs do
+							spec = specs[i]
+							if spec:isPlayer() then
+								spec:teleportTo(config.specPos)
+								spec:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+								spec:say('Time out! You were teleported out by strange forces.', TALKTYPE_MONSTER_SAY)
+							end
+						end
+				end, config.timeToDefeatBoss * 60 * 1000)
+		end
 	end
 	return true
 end

--- a/data/scripts/actions/quests/threatened_dreams/lever.lua
+++ b/data/scripts/actions/quests/threatened_dreams/lever.lua
@@ -81,7 +81,7 @@ function threatenedLever.onUse(player, item, fromPosition, target, toPosition, i
 							if spec:isPlayer() then
 								spec:teleportTo(config.specPos)
 								spec:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
-								spec:say('Time out! You were teleported out by strange forces.', TALKTYPE_MONSTER_SAY)
+								spec:say("Time out! You were teleported out by strange forces.", TALKTYPE_MONSTER_SAY)
 							end
 						end
 				end, config.timeToDefeatBoss * 60 * 1000)

--- a/data/scripts/actions/quests/threatened_dreams/lever.lua
+++ b/data/scripts/actions/quests/threatened_dreams/lever.lua
@@ -29,7 +29,6 @@ function threatenedLever.onUse(player, item, fromPosition, target, toPosition, i
 		end
 		
 		local team, participant = {}
-
 		for i = 1, #config.playerPositions do
 			participant = Tile(config.playerPositions[i]):getTopCreature()
 			
@@ -49,7 +48,6 @@ function threatenedLever.onUse(player, item, fromPosition, target, toPosition, i
 						"You or a member in your team have to wait ".. config.timeToFightAgain .."  hours to face Faceless Bane again!")
 					return true
 				end
-
 				team[#team + 1] = participant
 			end
 		end
@@ -62,7 +60,6 @@ function threatenedLever.onUse(player, item, fromPosition, target, toPosition, i
 				player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "There's someone fighting with Faceless Bane.")
 				return true
 			end
-
 			spec:remove()
 		end
 

--- a/data/scripts/actions/quests/threatened_dreams/lever.lua
+++ b/data/scripts/actions/quests/threatened_dreams/lever.lua
@@ -27,25 +27,23 @@ function threatenedLever.onUse(player, item, fromPosition, target, toPosition, i
 			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You can\'t start the battle.")
 			return true
 		end
-		
+
 		local team, participant = {}
 		for i = 1, #config.playerPositions do
 			participant = Tile(config.playerPositions[i]):getTopCreature()
-			
+
 			-- Check there is a participant player
 			if participant and participant:isPlayer() then
 				-- Check participant level
 				if participant:getLevel() < config.requiredLevel then
-					player:sendTextMessage(MESSAGE_EVENT_ADVANCE,
-						"All the players need to be level ".. config.requiredLevel .." or higher.")
+					player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "All the players need to be level ".. config.requiredLevel .." or higher.")
 					return true
 				end
 
 				-- Check participant boss timer
 				if config.daily and participant:getStorageValue(Storage.ThreatenedDreams.FacelessBaneTime) > os.time() then
 					player:getPosition():sendMagicEffect(CONST_ME_POFF)
-					player:sendTextMessage(MESSAGE_EVENT_ADVANCE, 
-						"You or a member in your team have to wait ".. config.timeToFightAgain .."  hours to face Faceless Bane again!")
+					player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You or a member in your team have to wait ".. config.timeToFightAgain .."  hours to face Faceless Bane again!")
 					return true
 				end
 				team[#team + 1] = participant
@@ -71,8 +69,7 @@ function threatenedLever.onUse(player, item, fromPosition, target, toPosition, i
 		for i = 1, #team do
 			team[i]:getPosition():sendMagicEffect(CONST_ME_POFF)
 			team[i]:teleportTo(config.teleportPosition)
-			team[i]:sendTextMessage(MESSAGE_EVENT_ADVANCE, 
-					"You have ".. config.timeToDefeatBoss .." minutes to kill and loot this boss. Otherwise you will lose that chance and will be kicked out.")
+			team[i]:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have ".. config.timeToDefeatBoss .." minutes to kill and loot this boss. Otherwise you will lose that chance and will be kicked out.")
 			-- Assign boss timer
 			team[i]:setStorageValue(Storage.ThreatenedDreams.FacelessBaneTime, os.time() + config.timeToFightAgain * 60 * 60) -- 20 hours
 			item:transform(config.leverId)

--- a/data/scripts/actions/quests/threatened_dreams/lever.lua
+++ b/data/scripts/actions/quests/threatened_dreams/lever.lua
@@ -16,7 +16,7 @@ local config = {
 	},
 	teleportPosition = Position(33617, 32567, 13),
 	bossPosition = Position(33617, 32561, 13),
-	specPos = Position(33618, 32520, 15)
+	specPos = Position(33618, 32523, 15)
 }
 
 local threatenedLever = Action()

--- a/data/startup/tables/teleport.lua
+++ b/data/startup/tables/teleport.lua
@@ -319,10 +319,17 @@ TeleportUnique = {
 		destination = {x = 32608, y = 32978, z = 8},
 		effect = CONST_ME_TELEPORT
 	},
-	-- Faceless Bane exit teleport
+	-- Faceless Bane room exit teleport
 	[39007] = {
 		itemId = 1397,
 		itemPos = {x = 33617, y = 32569, z = 13},
+		destination = {x = 33618, y = 32523, z = 15},
+		effect = CONST_ME_TELEPORT
+	},
+	-- Faceless Bane lever room exit teleport
+	[39008] = {
+		itemId = 1397,
+		itemPos = {x = 33640, y = 32559, z = 13},
 		destination = {x = 33618, y = 32523, z = 15},
 		effect = CONST_ME_TELEPORT
 	}

--- a/data/startup/tables/teleport.lua
+++ b/data/startup/tables/teleport.lua
@@ -318,5 +318,12 @@ TeleportUnique = {
 		itemPos = {x = 32610, y = 32979, z = 9},
 		destination = {x = 32608, y = 32978, z = 8},
 		effect = CONST_ME_TELEPORT
+	},
+	-- Faceless Bane exit teleport
+	[39007] = {
+		itemId = 1397,
+		itemPos = {x = 33617, y = 32569, z = 13},
+		destination = {x = 33618, y = 32523, z = 15},
+		effect = CONST_ME_TELEPORT
 	}
 }

--- a/data/startup/tables/teleport_item.lua
+++ b/data/startup/tables/teleport_item.lua
@@ -69,5 +69,12 @@ TeleportItemUnique = {
 		itemPos = {x = 33918, y = 31471, z = 7},
 		destination = {x = 33916, y = 31466, z = 8},
 		effect = CONST_ME_TELEPORT
+	},
+	-- Faceless Bane entrance
+	[15004] = {
+		itemId = 34592,
+		itemPos = {x = 33619, y = 32518, z = 15},
+		destination = {x = 33640, y = 32561, z = 13},
+		effect = CONST_ME_TELEPORT
 	}
 }


### PR DESCRIPTION
Thanks to @lucaszrocha for the help.

How to test:
- You just need to edit configs in:
```
local config = {
	bossName = "Faceless Bane",
	requiredLevel = 250,
	leverId = 10030,
	timeToFightAgain = 20, -- In hour
	timeToDefeatBoss = 20, -- In minutes
	clearRoomTime = 60, -- In minutes
	daily = true,
	centerRoom = Position(33617, 32562, 13),
	playerPositions = {
		Position(33638, 32562, 13),
		Position(33639, 32562, 13),
		Position(33640, 32562, 13),
		Position(33641, 32562, 13),
		Position(33642, 32562, 13)
	},
	teleportPosition = Position(33617, 32567, 13),
	bossPosition = Position(33617, 32561, 13),
	specPos = Position(33618, 32520, 15)
}
```

