### PR TITLE
Fix druid and sorc first wand

### DIFF
--- a/data/npc/scripts/alexander.lua
+++ b/data/npc/scripts/alexander.lua
@@ -29,9 +29,9 @@ local function creatureSayCallback(cid, type, msg)
 	end
 
 	local player = Player(cid)
+	local itemId = items[player:getVocation():getClientId()]
 	if msgcontains(msg, 'first rod') or msgcontains(msg, 'first wand') then
 		if player:isMage() then
-			local itemId = items[player:getVocation():getClientId()]
 			if player:getStorageValue(Storage.firstMageWeapon) == -1 then
 				npcHandler:say('So you ask me for a {' .. ItemType(itemId):getName() .. '} to begin your adventure?', cid)
 				npcHandler.topic[cid] = 1

--- a/data/npc/scripts/asima.lua
+++ b/data/npc/scripts/asima.lua
@@ -26,9 +26,9 @@ local function creatureSayCallback(cid, type, msg)
 	end
 
 	local player = Player(cid)
+	local itemId = items[player:getVocation():getClientId()]
 	if msgcontains(msg, 'first rod') or msgcontains(msg, 'first wand') then
 		if player:isMage() then
-			local itemId = items[player:getVocation():getClientId()]
 			if player:getStorageValue(Storage.firstMageWeapon) == -1 then
 				npcHandler:say('So you ask me for a {' .. ItemType(itemId):getName() .. '} to begin your adventure?', cid)
 				npcHandler.topic[cid] = 1

--- a/data/npc/scripts/fenech.lua
+++ b/data/npc/scripts/fenech.lua
@@ -29,9 +29,9 @@ local function creatureSayCallback(cid, type, msg)
 	end
 
 	local player = Player(cid)
+	local itemId = items[player:getVocation():getClientId()]
 	if msgcontains(msg, 'first rod') or msgcontains(msg, 'first wand') then
 		if player:isMage() then
-			local itemId = items[player:getVocation():getClientId()]
 			if player:getStorageValue(Storage.firstMageWeapon) == -1 then
 				npcHandler:say('So you ask me for a {' .. ItemType(itemId):getName() .. '} to begin your adventure?', cid)
 				npcHandler.topic[cid] = 1

--- a/data/npc/scripts/inkaef.lua
+++ b/data/npc/scripts/inkaef.lua
@@ -26,9 +26,9 @@ local function creatureSayCallback(cid, type, msg)
 	end
 
 	local player = Player(cid)
+	local itemId = items[player:getVocation():getClientId()]
 	if msgcontains(msg, 'first rod') or msgcontains(msg, 'first wand') then
 		if player:isMage() then
-			local itemId = items[player:getVocation():getClientId()]
 			if player:getStorageValue(Storage.firstMageWeapon) == -1 then
 				npcHandler:say('So you ask me for a {' .. ItemType(itemId):getName() .. '} to begin your adventure?', cid)
 				npcHandler.topic[cid] = 1

--- a/data/npc/scripts/khanna.lua
+++ b/data/npc/scripts/khanna.lua
@@ -26,9 +26,9 @@ local function creatureSayCallback(cid, type, msg)
 	end
 
 	local player = Player(cid)
+	local itemId = items[player:getVocation():getClientId()]
 	if msgcontains(msg, 'first rod') or msgcontains(msg, 'first wand') then
 		if player:isMage() then
-			local itemId = items[player:getVocation():getClientId()]
 			if player:getStorageValue(Storage.firstMageWeapon) == -1 then
 				npcHandler:say('So you ask me for a {' .. ItemType(itemId):getName() .. '} to begin your adventure?', cid)
 				npcHandler.topic[cid] = 1

--- a/data/npc/scripts/rachel.lua
+++ b/data/npc/scripts/rachel.lua
@@ -33,9 +33,9 @@ local function creatureSayCallback(cid, type, msg)
 	end
 
 	local player = Player(cid)
+	local itemId = items[player:getVocation():getClientId()]
 	if msgcontains(msg, "first rod") or msgcontains(msg, "first wand") then
 		if player:isMage() then
-			local itemId = items[player:getVocation():getClientId()]
 			if player:getStorageValue(Storage.firstMageWeapon) == -1 then
 				npcHandler:say("So you ask me for a {" .. ItemType(itemId):getName() .. "} to begin your adventure?", cid)
 				npcHandler.topic[cid] = 1

--- a/data/npc/scripts/topsy.lua
+++ b/data/npc/scripts/topsy.lua
@@ -29,9 +29,9 @@ local function creatureSayCallback(cid, type, msg)
 	end
 
 	local player = Player(cid)
+	local itemId = items[player:getVocation():getClientId()]
 	if msgcontains(msg, "first rod") or msgcontains(msg, "first wand") then
 		if player:isMage() then
-			local itemId = items[player:getVocation():getClientId()]
 			if player:getStorageValue(Storage.firstMageWeapon) == -1 then
 				npcHandler:say("So you ask me for a {" .. ItemType(itemId):getName() .. "} to begin your adventure?", cid)
 				npcHandler.topic[cid] = 1

--- a/data/npc/scripts/xodet.lua
+++ b/data/npc/scripts/xodet.lua
@@ -26,9 +26,9 @@ local function creatureSayCallback(cid, type, msg)
 	end
 
 	local player = Player(cid)
+	local itemId = items[player:getVocation():getClientId()]
 	if msgcontains(msg, 'first rod') or msgcontains(msg, 'first wand') then
 		if player:isMage() then
-			local itemId = items[player:getVocation():getClientId()]
 			if player:getStorageValue(Storage.firstMageWeapon) == -1 then
 				npcHandler:say('So you ask me for a {' .. ItemType(itemId):getName() .. '} to begin your adventure?', cid)
 				npcHandler.topic[cid] = 1


### PR DESCRIPTION
Magic shop NPCs currently do not give the first Rod/Wand when asked, because the additem string calls for itemId, but local itemId is ending before reaching it. Moving local itemId declaration higher in the file fixes this.

I reported it in the discord but didn't get any feedback so I learned how to use github to make a pull request for you as I should've done in the first place. Just happy to contribute!

I hope I did it right.