### PR TITLE
Fix blockTeleportTrashing

### DIFF
--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -335,6 +335,16 @@ function Player:onMoveItem(item, count, fromPosition, toPosition, fromCylinder, 
 		return false
 	end
 
+	-- Players cannot throw items on teleports
+	if blockTeleportTrashing and toPosition.x ~= CONTAINER_POSITION then
+		local thing = Tile(toPosition):getItemByType(ITEM_TYPE_TELEPORT)
+		if thing then
+			self:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+			self:getPosition():sendMagicEffect(CONST_ME_POFF)
+			return false
+		end
+	end
+
 	-- Cults of Tibia begin
 	local frompos = Position(33023, 31904, 14) -- Checagem
 	local topos = Position(33052, 31932, 15) -- Checagem
@@ -479,16 +489,6 @@ function Player:onMoveItem(item, count, fromPosition, toPosition, fromCylinder, 
 		self:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
 		self:getPosition():sendMagicEffect(CONST_ME_POFF)
 		return false
-	end
-
-	-- Players cannot throw items on teleports
-	if blockTeleportTrashing and toPosition.x ~= CONTAINER_POSITION then
-		local thing = Tile(toPosition):getItemByType(ITEM_TYPE_TELEPORT)
-		if thing then
-			self:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
-			self:getPosition():sendMagicEffect(CONST_ME_POFF)
-			return false
-		end
 	end
 
 	if tile and tile:getItemById(370) then -- Trapdoor


### PR DESCRIPTION
# description
Relocating the part of the code that blocks putting items in teleports. This closes issue #2637 

## Behaviour
### **Actual**
When the blockTeleportTrashing = true was set, items could still be thrown in the teleports.

### **Expected**
When the blockTeleportTrashing is true it will block throwing items in the teleports.

  - [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested
-Go to data/events/scripts/player.lua and in blockTeleportTrashing = false change it to true. Then try putting items in the teleports, you won't be able to do it anymore.

**Test Configuration**:
  - Server Version: Latest
  - Client: 10 and 12
  - Operating System: Windows OS

## Checklist
  - [x] My code follows the style guidelines of this project
  - [x ] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] My changes generate no new warnings