### PR TITLE
Fix supply stash exploit

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -6687,6 +6687,11 @@ void ProtocolGame::sendOpenStash()
 
 void ProtocolGame::parseStashWithdraw(NetworkMessage &msg)
 {
+	if (!player->isSupplyStashMenuAvailable()) {
+		player->sendCancelMessage("You can't use supply stash right now.");
+		return;
+	}
+
 	if (player->isStashExhausted()) {
 		player->sendCancelMessage("You need to wait to do this again.");
 		return;


### PR DESCRIPTION
# Description

Without this check, one could just send packets to stow/withdraw items while hunting and it would work. You wouldn't have to be in depo or anywhere near it to make it work.

## Behaviour
### **Actual**

You can stow/withdraw an item while not standing on depo tile.

### **Expected**

You should receive error message when trying to stow/withdraw item from stash while not standing on depo tile.