### PR TITLE
Fix boss reward bug and hungry conditions

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -2860,7 +2860,7 @@ void ProtocolGame::sendCyclopediaCharacterGeneralStats()
 	msg.addByte(player->getSoul());
 	msg.add<uint16_t>(player->getStaminaMinutes());
 
-	Condition *condition = player->getCondition(CONDITION_REGENERATION);
+	Condition *condition = player->getCondition(CONDITION_REGENERATION, CONDITIONID_DEFAULT);
 	msg.add<uint16_t>(condition ? condition->getTicks() / 1000 : 0x00);
 	msg.add<uint16_t>(player->getOfflineTrainingTime() / 60 / 1000);
 	msg.add<uint16_t>(player->getSpeed() / 2);
@@ -6188,7 +6188,7 @@ void ProtocolGame::AddPlayerStats(NetworkMessage &msg)
 
 	msg.add<uint16_t>(player->getBaseSpeed() / 2);
 
-	Condition *condition = player->getCondition(CONDITION_REGENERATION);
+	Condition *condition = player->getCondition(CONDITION_REGENERATION, CONDITIONID_DEFAULT);
 	msg.add<uint16_t>(condition ? condition->getTicks() / 1000 : 0x00);
 
 	msg.add<uint16_t>(player->getOfflineTrainingTime() / 60 / 1000);


### PR DESCRIPTION
# Description

Fix on bug [https://github.com/opentibiabr/otservbr-global/issues/2513](url)

## Behaviour
### **Actual**
After player dies/logout after giving damage to a boss, reward wouldn't goes to his reward inventory.

### **Expected**
Player dies/logout, boss dies, itens goes to his inventory


## Fixes

\# First issue was on line 21, on insertItems, using a method that does not exist. Second, i had to change how reward is saved on database. Before it was just saving all data on database, without reordering sid's. Now the reward container is saved correctly, all references are updated, and new loots are inserted in the end.

## Type of change

Please delete options that are not relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [x] Test 1: without any reward on chest: hit, logout, kill the boss with other char, login again and check reward
  - [x] Test 2: with rewards on chest: hit, logout, kill the boss with other char, login again and check reward

**Test Configuration**:

  - Server Version: last
  - Client: 12.6
  - Operating System: Windows

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
