### PR TITLE
Exercise training & vip status

### DIFF
--- a/config.lua.dist
+++ b/config.lua.dist
@@ -75,6 +75,8 @@ staminaPz = false
 staminaOrangeDelay = 1
 staminaGreenDelay = 5
 staminaPzGain = 1
+-- Max players allowed on a dummy.
+maxAllowedOnADummy = 1
 
 -- Deaths
 -- NOTE: Leave deathLosePercent as -1 if you want to use the default

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -508,7 +508,7 @@ function Player:onItemMoved(item, count, fromPosition, toPosition, fromCylinder,
 end
 
 function Player:onMoveCreature(creature, fromPosition, toPosition)
-	if creature:isPlayer() and creature:getStorageValue(Storage.isTraining) == 1 and self:getGroup():hasFlag(PlayerFlag_CanPushAllCreatures) == false then
+	if creature:isPlayer() and onExerciseTraining[creature:getId()] and self:getGroup():hasFlag(PlayerFlag_CanPushAllCreatures) == false then
 		self:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
 	return false
 	end

--- a/data/global.lua
+++ b/data/global.lua
@@ -222,3 +222,6 @@ function addStamina(name, ...)
 	end
 	return false
 end
+
+-- Exercise Training
+onExerciseTraining = {}

--- a/data/scripts/actions/other/exercise_training.lua
+++ b/data/scripts/actions/other/exercise_training.lua
@@ -166,23 +166,26 @@ function exerciseTraining.onUse(player, item, fromPosition, target, toPosition, 
 			return true
 		end
 
-		local playersOnDummy = 0
 		local targePos = target:getPosition()
-		for _, playerTraining in pairs(onExerciseTraining) do
-			if playerTraining.dummyPos == targePos then
-				playersOnDummy = playersOnDummy + 1
-			end
 
-			if playersOnDummy == maxAllowedOnADummy then
-				player:sendTextMessage(MESSAGE_FAILURE, "That exercise dummy is busy.")
-				return true
+		if isInArray(houseDummies, targetId) then
+			local playersOnDummy = 0
+			for _, playerTraining in pairs(onExerciseTraining) do
+				if playerTraining.dummyPos == targePos then
+					playersOnDummy = playersOnDummy + 1
+				end
+	
+				if playersOnDummy == maxAllowedOnADummy then
+					player:sendTextMessage(MESSAGE_FAILURE, "That exercise dummy is busy.")
+					return true
+				end
 			end
 		end
 
 		local vocation = player:getVocation()
 		onExerciseTraining[playerId] = {}
-		onExerciseTraining[playerId].event = addEvent(exerciseEvent, vocation:getAttackSpeed(), playerId, target:getPosition(), item.itemid, targetId)
-		onExerciseTraining[playerId].dummyPos = target:getPosition()
+		onExerciseTraining[playerId].event = addEvent(exerciseEvent, vocation:getAttackSpeed(), playerId, targePos, item.itemid, targetId)
+		onExerciseTraining[playerId].dummyPos = targePos
 		player:sendTextMessage(MESSAGE_FAILURE, "You started training.")
 		player:setTraining(true)
 		return true

--- a/data/scripts/actions/other/exercise_training.lua
+++ b/data/scripts/actions/other/exercise_training.lua
@@ -1,178 +1,194 @@
-local skills = {
-    [32384] = {id=SKILL_SWORD,voc=4}, -- KNIGHT
-    [32385] = {id=SKILL_AXE,voc=4}, -- KNIGHT
-    [32386] = {id=SKILL_CLUB,voc=4}, -- KNIGHT
-    [32387] = {id=SKILL_DISTANCE,voc=3,range=CONST_ANI_SIMPLEARROW}, -- PALADIN
-    [32388] = {id=SKILL_MAGLEVEL,voc=2,range=CONST_ANI_SMALLICE}, -- DRUID
-    [32389] = {id=SKILL_MAGLEVEL,voc=1,range=CONST_ANI_FIRE}, -- SORCERER
-    [32124] = {id=SKILL_SWORD,voc=4}, -- KNIGHT
-    [32125] = {id=SKILL_AXE,voc=4}, -- KNIGHT
-    [32126] = {id=SKILL_CLUB,voc=4}, -- KNIGHT
-    [32127] = {id=SKILL_DISTANCE,voc=3,range=CONST_ANI_SIMPLEARROW}, -- PALADIN
-    [32128] = {id=SKILL_MAGLEVEL,voc=2,range=CONST_ANI_SMALLICE}, -- DRUID
-    [32129] = {id=SKILL_MAGLEVEL,voc=1,range=CONST_ANI_FIRE}, -- SORCERER
-    [40114] = {id=SKILL_SWORD,voc=4}, -- KNIGHT
-    [40115] = {id=SKILL_AXE,voc=4}, -- KNIGHT
-    [40116] = {id=SKILL_CLUB,voc=4}, -- KNIGHT
-    [40117] = {id=SKILL_DISTANCE,voc=3,range=CONST_ANI_SIMPLEARROW}, -- PALADIN
-    [40118] = {id=SKILL_MAGLEVEL,voc=2,range=CONST_ANI_SMALLICE}, -- DRUID
-    [40119] = {id=SKILL_MAGLEVEL,voc=1,range=CONST_ANI_FIRE}, -- SORCERER
-    [40120] = {id=SKILL_SWORD,voc=4}, -- KNIGHT
-    [40121] = {id=SKILL_AXE,voc=4}, -- KNIGHT
-    [40122] = {id=SKILL_CLUB,voc=4}, -- KNIGHT
-    [40123] = {id=SKILL_DISTANCE,voc=3,range=CONST_ANI_SIMPLEARROW}, -- PALADIN
-    [40124] = {id=SKILL_MAGLEVEL,voc=2,range=CONST_ANI_SMALLICE}, -- DRUID
-    [40125] = {id=SKILL_MAGLEVEL,voc=1,range=CONST_ANI_FIRE} -- SORCERER
+local exerciseWeapons = {
+	-- MELE
+	[32124] = { skill = SKILL_SWORD },
+	[32384] = { skill = SKILL_SWORD },
+	[40114] = { skill = SKILL_SWORD },
+	[40120] = { skill = SKILL_SWORD },
+	[32385] = { skill = SKILL_AXE },
+	[32125] = { skill = SKILL_AXE },
+	[40115] = { skill = SKILL_AXE },
+	[40121] = { skill = SKILL_AXE },
+	[32386] = { skill = SKILL_CLUB },
+	[32126] = { skill = SKILL_CLUB },
+	[40116] = { skill = SKILL_CLUB },
+	[40122] = { skill = SKILL_CLUB },
+	-- ROD
+	[32128] = { skill = SKILL_MAGLEVEL, effect = CONST_ANI_SMALLICE, allowFarUse = true },
+	[32388] = { skill = SKILL_MAGLEVEL, effect = CONST_ANI_SMALLICE, allowFarUse = true },
+	[40118] = { skill = SKILL_MAGLEVEL, effect = CONST_ANI_SMALLICE, allowFarUse = true },
+	[40124] = { skill = SKILL_MAGLEVEL, effect = CONST_ANI_SMALLICE, allowFarUse = true },
+	-- RANGE
+	[32127] = { skill = SKILL_DISTANCE, effect = CONST_ANI_SIMPLEARROW, allowFarUse = true },
+	[32387] = { skill = SKILL_DISTANCE, effect = CONST_ANI_SIMPLEARROW, allowFarUse = true },
+	[40117] = { skill = SKILL_DISTANCE, effect = CONST_ANI_SIMPLEARROW, allowFarUse = true },
+	[40123] = { skill = SKILL_DISTANCE, effect = CONST_ANI_SIMPLEARROW, allowFarUse = true },
+	-- WAND
+	[32129] = { skill = SKILL_MAGLEVEL, effect = CONST_ANI_FIRE, allowFarUse = true },
+	[32389] = { skill = SKILL_MAGLEVEL, effect = CONST_ANI_FIRE, allowFarUse = true },
+	[40119] = { skill = SKILL_MAGLEVEL, effect = CONST_ANI_FIRE, allowFarUse = true },
+	[40125] = { skill = SKILL_MAGLEVEL, effect = CONST_ANI_FIRE, allowFarUse = true }
 }
 
+local exerciseTraining = Action()
 local houseDummies = {32143, 32144, 32145, 32146, 32147, 32148}
 local freeDummies = {32142, 32149}
-local skillRateDefault = configManager.getNumber(configKeys.RATE_SKILL)
-local magicRateDefault = configManager.getNumber(configKeys.RATE_MAGIC)
 
-local function removeExerciseWeapon(player, exercise)
-    exercise:remove(1)
-    player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your training weapon vanished.")
-    stopEvent(training)
-    player:setStorageValue(Storage.isTraining,0)
-    player:setTraining(false)
+local maxAllowedOnADummy = configManager.getNumber(configKeys.MAX_ALLOWED_ON_A_DUMMY)
+local magicLevelRate = configManager.getNumber(configKeys.RATE_MAGIC)
+local skillLevelRate = configManager.getNumber(configKeys.RATE_SKILL)
+
+for weaponId, weapon in pairs(exerciseWeapons) do
+	exerciseTraining:id(weaponId)
+	if weapon.allowFarUse then
+		exerciseTraining:allowFarUse(true)
+	end
 end
 
-local function startTraining(playerId, startPosition, itemid, tilePosition, bonusDummy, dummyId)
-    local player = Player(playerId)
-    if player ~= nil then
-        if Tile(tilePosition):getItemById(dummyId) then
-            local playerPosition = player:getPosition()
-            if startPosition:getDistance(playerPosition) == 0 and getTilePzInfo(playerPosition) then
-                if player:getItemCount(itemid) >= 1 then
-                    local exercise = player:getItemById(itemid,true)
-                    if exercise:isItem() then
-                        if exercise:hasAttribute(ITEM_ATTRIBUTE_CHARGES) then
-                            local charges_n = exercise:getAttribute(ITEM_ATTRIBUTE_CHARGES)
-                            if charges_n >= 1 then
-                                exercise:setAttribute(ITEM_ATTRIBUTE_CHARGES,(charges_n-1))
+local function leaveTraining(playerId)
+	if onExerciseTraining[playerId] then
+		stopEvent(onExerciseTraining[playerId].event)
+		onExerciseTraining[playerId] = nil
+	end
 
-                                local voc = player:getVocation()
-
-                                if skills[itemid].id == SKILL_MAGLEVEL then
-                                    local magicRate = getRateFromTable(magicLevelStages, player:getBaseMagicLevel(), magicRateDefault)
-                                    if not bonusDummy then
-                                        player:addManaSpent(math.ceil(500*magicRate))
-                                    else
-                                        player:addManaSpent(math.ceil(500*magicRate)*1.1) -- 10%
-                                    end
-                                else
-                                    local skillRate = getRateFromTable(skillsStages, player:getSkillLevel(skills[itemid].id), skillRateDefault)
-                                    if not bonusDummy then
-                                        player:addSkillTries(skills[itemid].id, 7*skillRate)
-                                    else
-                                        player:addSkillTries(skills[itemid].id, (7*skillRate)*1.1) -- 10%
-                                    end
-                                end
-                                    tilePosition:sendMagicEffect(CONST_ME_HITAREA)
-                                if skills[itemid].range then
-                                    playerPosition:sendDistanceEffect(tilePosition, skills[itemid].range)
-                                end
-                                if exercise:getAttribute(ITEM_ATTRIBUTE_CHARGES) == 0 then
-                                    removeExerciseWeapon(player, exercise)
-                                else
-                                    local training = addEvent(startTraining, voc:getAttackSpeed(), playerId,startPosition,itemid,tilePosition,bonusDummy,dummyId)
-                                    player:setStorageValue(Storage.isTraining,1)
-                                    player:setTraining(true)
-                                end
-                            else
-                                removeExerciseWeapon(player, exercise)
-                            end
-                        end
-                    end
-                end
-            else
-                player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your training has stopped.")
-                stopEvent(training)
-                player:setStorageValue(Storage.isTraining,0)
-                player:setTraining(false)
-            end
-        else
-            stopEvent(training)
-            player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your training has stopped.")
-            player:setStorageValue(Storage.isTraining, 0)
-            player:setTraining(false)
-        end
-    else
-        stopEvent(training)
-        if player then
-            player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your training has stopped.")
-            player:setStorageValue(Storage.isTraining,0)
-            player:setTraining(false)
-        end
-    end
-    return true
+	local player = Player(playerId)
+	if player then
+		player:setTraining(false)
+	end
+	return
 end
 
-local exerciseTraining = Action()
+local function exerciseEvent(playerId, tilePosition, weaponId, dummyId)
+	local player = Player(playerId)
+	if not player then
+		leaveTraining(playerId)
+		return
+	end
+
+	if player:isTraining() == 0 then
+		player:sendTextMessage(MESSAGE_FAILURE, "Your training has stopped.")
+		leaveTraining(playerId)
+		return
+	end
+
+	if not Tile(tilePosition):getItemById(dummyId) then
+		player:sendTextMessage(MESSAGE_FAILURE, "Someone has moved the dummy, the training has stopped.")
+		leaveTraining(playerId)
+		return
+	end
+
+	local playerPosition = player:getPosition()
+	if not getTilePzInfo(playerPosition) then
+		player:sendTextMessage(MESSAGE_FAILURE, "You are no longer in a protection zone, the training has stopped.")
+		leaveTraining(playerId)
+		return
+	end
+
+	if player:getItemCount(weaponId) <= 0 then
+		player:sendTextMessage(MESSAGE_FAILURE, "You need the training weapon in the backpack, the training has stopped.")
+		leaveTraining(playerId)
+		return
+	end
+
+	local weapon = player:getItemById(weaponId, true)
+	if not weapon:isItem() or not weapon:hasAttribute(ITEM_ATTRIBUTE_CHARGES) then
+		player:sendTextMessage(MESSAGE_FAILURE, "The selected item is not a training weapon, the training has stopped.")
+		leaveTraining(playerId)
+		return
+	end
+
+	local weaponCharges = weapon:getAttribute(ITEM_ATTRIBUTE_CHARGES)
+	if not weaponCharges or weaponCharges <= 0 then
+		weapon:remove(1) -- ??
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your training weapon has disappeared.")
+		leaveTraining(playerId)
+		return
+	end
+
+	local isMagic = false
+	local bonusDummy = isInArray(houseDummies, weaponId) or nil
+	local skillToTraining = skillsStages or nil
+	local skillRateDefault = skillLevelRate
+	local skillLevel = player:getSkillLevel(exerciseWeapons[weaponId].skill)
+
+	if exerciseWeapons[weaponId].skill == SKILL_MAGLEVEL then
+		skillToTraining = magicLevelStages or nil
+		skillRateDefault = magicLevelRate
+		skillLevel = player:getBaseMagicLevel()
+		isMagic = true
+	end
+
+	local expRate = getRateFromTable(skillToTraining, skillLevel, skillRateDefault)
+	if bonusDummy then bonusDummy = 1.1 else bonusDummy = 1 end
+
+	if isMagic then
+		player:addManaSpent(math.ceil(500 * expRate) * bonusDummy)
+	else
+		player:addSkillTries(exerciseWeapons[weaponId].skill, (7 * expRate) * bonusDummy)
+	end
+
+	weapon:setAttribute(ITEM_ATTRIBUTE_CHARGES, (weaponCharges - 1))
+	tilePosition:sendMagicEffect(CONST_ME_HITAREA)
+
+	if exerciseWeapons[weaponId].effect then
+		playerPosition:sendDistanceEffect(tilePosition, exerciseWeapons[weaponId].effect)
+	end
+
+	if weapon:getAttribute(ITEM_ATTRIBUTE_CHARGES) <= 0 then
+		weapon:remove(1)
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your training weapon has disappeared.")
+		leaveTraining(playerId)
+		return
+	end
+
+	local vocation = player:getVocation()
+	onExerciseTraining[playerId].event = addEvent(exerciseEvent, vocation:getAttackSpeed(), playerId, tilePosition, weaponId, dummyId)
+	return
+end
 
 function exerciseTraining.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-    local startPos = player:getPosition()
-    if player:getStorageValue(Storage.isTraining) == 1 then
-        player:sendTextMessage(MESSAGE_FAILURE, "You are already training.")
-        return false
-    end
-    if target:isItem() then
-        if isInArray(houseDummies,target:getId()) then
-            if not skills[item.itemid].range and (startPos:getDistance(target:getPosition()) > 1) then
-                player:sendTextMessage(MESSAGE_FAILURE, "Get closer to the dummy.")
-                stopEvent(training)
-                return true
-            end
-            player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You started training.")
-            startTraining(player:getId(),startPos,item.itemid,target:getPosition(), true, target:getId())
-        elseif isInArray(freeDummies, target:getId()) then
-            if not skills[item.itemid].range and (startPos:getDistance(target:getPosition()) > 1) then
-                player:sendTextMessage(MESSAGE_FAILURE, "Get closer to the dummy.")
-                stopEvent(training)
-                return true
-            end
-            player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You started training.")
-            startTraining(player:getId(),startPos,item.itemid,target:getPosition(), false, target:getId())
-        end
-    end
-    return true
-end
+	local playerId = player:getId()
+	local targetId = target:getId()
 
-for id = 32124, 32126 do
-    exerciseTraining:id(id)
-end
+	if target:isItem() and (isInArray(houseDummies, targetId) or isInArray(freeDummies, targetId)) then
+		if onExerciseTraining[playerId] then
+			player:sendTextMessage(MESSAGE_FAILURE, "You are already training.")
+			return true
+		end
 
-for id = 32127, 32129 do
-    exerciseTraining:id(id)
-    exerciseTraining:allowFarUse(true)
-end
+		local playerPos = player:getPosition()
+		if not exerciseWeapons[item.itemid].allowFarUse and (playerPos:getDistance(target:getPosition()) > 1) then
+			player:sendTextMessage(MESSAGE_FAILURE, "Get closer to the dummy.")
+			return true
+		end
 
-for id = 32384, 32386 do
-    exerciseTraining:id(id)
-end
+		if not getTilePzInfo(playerPos) then
+			player:sendTextMessage(MESSAGE_FAILURE, "You need to be in a protection zone.")
+			return true
+		end
 
-for id = 32387, 32389 do
-    exerciseTraining:id(id)
-    exerciseTraining:allowFarUse(true)
-end
+		local playersOnDummy = 0
+		local targePos = target:getPosition()
+		for _, playerTraining in pairs(onExerciseTraining) do
+			if playerTraining.dummyPos == targePos then
+				playersOnDummy = playersOnDummy + 1
+			end
 
-for id = 40114, 40116 do
-    exerciseTraining:id(id)
-end
+			if playersOnDummy == maxAllowedOnADummy then
+				player:sendTextMessage(MESSAGE_FAILURE, "That exercise dummy is busy.")
+				return true
+			end
+		end
 
-for id = 40117, 40119 do
-    exerciseTraining:id(id)
-    exerciseTraining:allowFarUse(true)
-end
+		local vocation = player:getVocation()
+		onExerciseTraining[playerId] = {}
+		onExerciseTraining[playerId].event = addEvent(exerciseEvent, vocation:getAttackSpeed(), playerId, target:getPosition(), item.itemid, targetId)
+		onExerciseTraining[playerId].dummyPos = target:getPosition()
+		player:sendTextMessage(MESSAGE_FAILURE, "You started training.")
+		player:setTraining(true)
+		return true
+	end
 
-for id = 40120, 40122 do
-    exerciseTraining:id(id)
-end
-
-for id = 40123, 40125 do
-    exerciseTraining:id(id)
-    exerciseTraining:allowFarUse(true)
+	return
 end
 
 exerciseTraining:register()

--- a/data/scripts/creaturescripts/others/login.lua
+++ b/data/scripts/creaturescripts/others/login.lua
@@ -206,8 +206,10 @@ function playerLogin.onLogin(player)
 	player:setStaminaXpBoost(staminaBonus)
 	player:setBaseXpGain(baseExp)
 
-	if player:getStorageValue(Storage.isTraining) == 1 then --Reset exercise weapon storage
-		player:setStorageValue(Storage.isTraining,0)
+	if onExerciseTraining[player:getId()] then -- onLogin & onLogout
+		stopEvent(onExerciseTraining[player:getId()].event)
+		onExerciseTraining[player:getId()] = nil
+		player:setTraining(false)
 	end
 	return true
 end

--- a/data/scripts/creaturescripts/others/logout.lua
+++ b/data/scripts/creaturescripts/others/logout.lua
@@ -1,9 +1,11 @@
 local playerLogout = CreatureEvent("PlayerLogout")
 function playerLogout.onLogout(player)
 	local playerId = player:getId()
+
 	if nextUseStaminaTime[playerId] ~= nil then
 		nextUseStaminaTime[playerId] = nil
 	end
+
 	player:saveSpecialStorage()
 	player:setStorageValue(Storage.ExerciseDummyExhaust, 0)
 
@@ -19,6 +21,13 @@ function playerLogout.onLogout(player)
 			stats.stamina = player:getStamina()
 		end
 	end
+
+	if onExerciseTraining[playerId] then
+		stopEvent(onExerciseTraining[playerId].event)
+		onExerciseTraining[playerId] = nil
+		player:setTraining(false)
+	end
+
 	player:setStorageValue(17101,0)
 	return true
 end

--- a/src/config/configmanager.cpp
+++ b/src/config/configmanager.cpp
@@ -239,6 +239,7 @@ bool ConfigManager::load()
 	integer[STAMINA_PZ_GAIN] = getGlobalNumber(L, "staminaPzGain", 1);
 	integer[STAMINA_TRAINER_DELAY] = getGlobalNumber(L, "staminaTrainerDelay", 5);
 	integer[STAMINA_TRAINER_GAIN] = getGlobalNumber(L, "staminaTrainerGain", 1);
+	integer[MAX_ALLOWED_ON_A_DUMMY] = getGlobalNumber(L, "maxAllowedOnADummy", 1);
 
 	integer[PARTY_LIST_MAX_DISTANCE] = getGlobalNumber(L, "partyListMaxDistance", 0);
 

--- a/src/config/configmanager.h
+++ b/src/config/configmanager.h
@@ -152,6 +152,7 @@ class ConfigManager
 			STAMINA_TRAINER_DELAY,
 			STAMINA_PZ_GAIN,
 			STAMINA_TRAINER_GAIN,
+			MAX_ALLOWED_ON_A_DUMMY,
 
 			LAST_INTEGER_CONFIG /* this must be the last one */
 		};

--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -507,6 +507,12 @@ void Creature::onCreatureMove(Creature* creature, const Tile* newTile, const Pos
 			}
 		}
 
+		if (Player* player = creature->getPlayer()) {
+			if (player->isExerciseTraining()){
+				player->setTraining(false);
+			}
+		}
+
 		if (newTile->getZone() != oldTile->getZone()) {
 			onChangeZone(getZone());
 		}

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -480,6 +480,8 @@ void Player::setTraining(bool value) {
 			it.second->notifyStatusChange(this, value ? VIPSTATUS_TRAINING : VIPSTATUS_ONLINE, false);
 		}
 	}
+
+	this->statusVipList = VIPSTATUS_TRAINING;
 	setExerciseTraining(value);
 }
 
@@ -2516,7 +2518,7 @@ void Player::removeList()
 void Player::addList()
 {
 	for (const auto& it : g_game.getPlayers()) {
-		it.second->notifyStatusChange(this, VIPSTATUS_ONLINE);
+		it.second->notifyStatusChange(this, this->statusVipList);
 	}
 
 	g_game.addPlayer(this);

--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -2153,9 +2153,9 @@ class Player final : public Creature, public Cylinder
 		BlockType_t lastAttackBlockType = BLOCK_NONE;
 		tradestate_t tradeState = TRADE_NONE;
 		fightMode_t fightMode = FIGHTMODE_ATTACK;
-		account::AccountType accountType =
-		account::AccountType::ACCOUNT_TYPE_NORMAL;
+		account::AccountType accountType = account::AccountType::ACCOUNT_TYPE_NORMAL;
 		QuickLootFilter_t quickLootFilter;
+		VipStatus_t statusVipList = VIPSTATUS_ONLINE;
 
 		bool chaseMode = false;
 		bool secureMode = true;

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -4792,7 +4792,7 @@ void Game::playerRequestAddVip(uint32_t playerId, const std::string& name)
 		}
 
 		if (!vipPlayer->isInGhostMode() || player->isAccessPlayer()) {
-			player->addVIP(vipPlayer->getGUID(), vipPlayer->getName(), VIPSTATUS_ONLINE);
+			player->addVIP(vipPlayer->getGUID(), vipPlayer->getName(), vipPlayer->statusVipList);
 		} else {
 			player->addVIP(vipPlayer->getGUID(), vipPlayer->getName(), VIPSTATUS_OFFLINE);
 		}

--- a/src/lua/scripts/luascript.cpp
+++ b/src/lua/scripts/luascript.cpp
@@ -2141,6 +2141,7 @@ void LuaScriptInterface::registerFunctions()
 	registerEnumIn("configKeys", ConfigManager::STAMINA_TRAINER_DELAY)
 	registerEnumIn("configKeys", ConfigManager::STAMINA_PZ_GAIN)
 	registerEnumIn("configKeys", ConfigManager::STAMINA_TRAINER_GAIN)
+	registerEnumIn("configKeys", ConfigManager::MAX_ALLOWED_ON_A_DUMMY)
 
 	registerEnumIn("configKeys", ConfigManager::SERVER_SAVE_NOTIFY_MESSAGE)
 	registerEnumIn("configKeys", ConfigManager::SERVER_SAVE_NOTIFY_DURATION)
@@ -2593,8 +2594,9 @@ void LuaScriptInterface::registerFunctions()
 	registerMethod("Player", "getCapacity", LuaScriptInterface::luaPlayerGetCapacity);
 	registerMethod("Player", "setCapacity", LuaScriptInterface::luaPlayerSetCapacity);
 
+	registerMethod("Player", "isTraining", LuaScriptInterface::luaPlayerGetIsTraining);
 	registerMethod("Player", "setTraining", LuaScriptInterface::luaPlayerSetTraining);
-
+	
 	registerMethod("Player", "getFreeCapacity", LuaScriptInterface::luaPlayerGetFreeCapacity);
 
 	registerMethod("Player", "getKills", LuaScriptInterface::luaPlayerGetKills);
@@ -9258,6 +9260,18 @@ int LuaScriptInterface::luaPlayerSetTraining(lua_State* L) {
 	return 1;
 }
 
+int LuaScriptInterface::luaPlayerGetIsTraining(lua_State* L)
+{
+	// player:isTraining()
+	Player* player = getUserdata<Player>(L, 1);
+	if (player) {
+		lua_pushnumber(L, player->isExerciseTraining());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
 int LuaScriptInterface::luaPlayerGetFreeCapacity(lua_State* L)
 {
 	// player:getFreeCapacity()
@@ -11998,7 +12012,7 @@ int LuaScriptInterface::luaPlayerSetGhostMode(lua_State* L)
 	} else {
 		for (const auto& it : g_game.getPlayers()) {
 			if (!it.second->isAccessPlayer()) {
-				it.second->notifyStatusChange(player, VIPSTATUS_ONLINE);
+				it.second->notifyStatusChange(player, player->statusVipList);
 			}
 		}
 		IOLoginData::updateOnlineStatus(player->getGUID(), true);

--- a/src/lua/scripts/luascript.h
+++ b/src/lua/scripts/luascript.h
@@ -895,6 +895,7 @@ class LuaScriptInterface
 		static int luaPlayerSetCapacity(lua_State* L);
 
 		static int luaPlayerSetTraining(lua_State* L);
+		static int luaPlayerGetIsTraining(lua_State* L);
 
 		static int luaPlayerGetKills(lua_State* L);
 		static int luaPlayerSetKills(lua_State* L);

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -5211,7 +5211,7 @@ void ProtocolGame::sendAddCreature(const Creature *creature, const Position &pos
 			}
 			else
 			{
-				vipStatus = VIPSTATUS_ONLINE;
+				vipStatus = vipPlayer->statusVipList;
 			}
 
 			sendVIP(entry.guid, entry.name, entry.description, entry.icon, entry.notify, vipStatus);
@@ -5230,7 +5230,7 @@ void ProtocolGame::sendAddCreature(const Creature *creature, const Position &pos
 			}
 			else
 			{
-				vipStatus = VIPSTATUS_ONLINE;
+				vipStatus = vipPlayer->statusVipList;
 			}
 
 			sendVIP(entry.guid, entry.name, entry.description, entry.icon, entry.notify, vipStatus);


### PR DESCRIPTION
# Description
The whole `exercise_training` file was modified to make it more readable and now when you train, if you move or disconnect, the training stops.

## Behaviour
### **Actual**
Start training with someone already training on that dummy.
If someone is training and you connect to the game, that user appears as `connected` .
If someone is training, send request to add this player on vip list, that user appears as `connected`.
When you are training, disconnect from the game and reconnect, you will continue training and you can do double training(can stack).

### **Expected**
Start training with someone already training on that dummy (NOT_POSSIBLE or "That exercise dummy is busy.")??
If someone is training and you connect to the game, that user appears as `Exercise Dummy Training` .
If someone is training, send request to add this player on vip list, that user appears as `Exercise Dummy Training`.
When you are training, disconnect from the game and reconnect, the training stopped.

## Fixes
- opentibiabr/otservbr-global#1040
- opentibiabr/otservbr-global#1245
- opentibiabr/otservbr-global#2645

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested
Everything testing below was done mainly with a normal character, but it was also tested with a `god` character.

- [x] Start training in pz, take a god character(other client), take him(training char) out of the protection zone.
      Expected: "Your training has stopped."/"You are no longer in a protection zone, the training has stopped."
- [x] Start training and drop the exercise weapon.
      Expected: "You need the training weapon in the backpack, the training has stopped."
- [x] Start training after other player on same dummy. (2 normal characters, 1 God)
      (`maxAllowedOnADummy=2`). Expected: "That exercise dummy is busy."
- [x] Start training after other player on same dummy.
      (`maxAllowedOnADummy=1`). Expected: "That exercise dummy is busy."
- [x] Start training, use `Ctrl + G or Ctrl + Q` and enter with the same character
      Expected: a normal login, without being training on a dummy.
- [x] Start training, someone move the dummy.
      Expected: "Someone has moved the dummy, the training has stopped."
- [x] Try to start training outside the protection zone
      Expected: "You need to be in a protection zone."
- [x] Start training with the melee exercise weapon from afar.
      Expected: "Get closer to the dummy."
- [x] Start training and try start training again.
      Expected: "You are already training."
- [x] Start training and move.
      Expected: "Your training has stopped."
----------------------------------------------------------------------------
- [x] Start training and connect with other character(in other client).
      Expected: Status in vip list -> `Exercise Dummy Training`.
- [x] Start training and use another character to add him to your vip list.
      Expected: Status in vip list -> `Exercise Dummy Training`.

####  Test Configuration
  - Server Version: 3cd7ba82672460bebc77bf2e1a4d28dbd3e563a3
  - Client: 12.64
  - Operating System: Windows

## Checklist
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings ??
  - [ ] I have added tests that prove my fix is effective or that my feature works

## Files
### global.lua
- `onExerciseTraining` added.

### config.lua.dist
- `maxAllowedOnADummy` added.

### configmanager.cpp & configmanager.h
- `MAX_ALLOWED_ON_A_DUMMY` added.

### exercise_training.lua
- almost the entire file structure was renewed.
- now count the `playersOnDummy`.

### login & logout (lua)
- fixed issue opentibiabr/otservbr-global#2645

### player.lua
- now `onExerciseTraining` is used instead of `Storage.isTraining`

### creature.cpp
- when the player moves, the training is canceled

### luascript.cpp & luascript.h
- `luaPlayerGetIsTraining (isTraining)` added.
- `MAX_ALLOWED_ON_A_DUMMY & isTraining`.
- `VIPSTATUS_ONLINE` -> `player->statusVipList`.

### player.h
- added the new value `statusVipList` to player.
- line weird? [2156]

### player.cpp
- now `this->statusVipList` is used instead of `VIPSTATUS_ONLINE`.
- change status when user start training.

### game.cpp
- `VIPSTATUS_ONLINE` -> `vipPlayer->statusVipList`

### protocolgame.cpp
- `VIPSTATUS_ONLINE` -> `vipPlayer->statusVipList`.