### PR TITLE
Fix monster loot items stages display on bestiary 

### DIFF
--- a/src/io/iobestiary.cpp
+++ b/src/io/iobestiary.cpp
@@ -406,15 +406,15 @@ std::list<uint16_t> IOBestiary::getBestiaryFinished(Player* player) const
 
 int8_t IOBestiary::calculateDifficult(uint32_t chance) const
 {
-	chance = chance / 1000;
+	float chanceInPercent = chance / 1000;
 
-	if (chance < 0.2) {
+	if (chanceInPercent < 0.2) {
 		return 4;
-	} else if (chance < 1) {
+	} else if (chanceInPercent < 1) {
 		return 3;
-	} else if (chance < 5) {
+	} else if (chanceInPercent < 5) {
 		return 2;
-	} else if (chance < 25) {
+	} else if (chanceInPercent < 25) {
 		return 1;
 	}
 	return 0;

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -1828,11 +1828,36 @@ void ProtocolGame::parseBestiarysendMonsterData(NetworkMessage &msg)
 	newmsg.addByte(lootList.size());
 	for (LootBlock loot : lootList)
 	{
-		newmsg.addItemId(currentLevel > 1 ? loot.id : 0);
 		int8_t difficult = g_bestiary.calculateDifficult(loot.chance);
+		bool shouldAddItem = false;
+
+		switch (currentLevel)
+		{
+			case 1:
+				shouldAddItem = false;
+			break;
+			case 2:
+				if (difficult < 2)
+				{
+					shouldAddItem = true;
+				}
+				break;
+			case 3:
+				if (difficult < 3)
+				{
+					shouldAddItem = true;
+				}
+				break;
+			case 4:
+				shouldAddItem = true;
+				break;
+		}
+		
+
+		newmsg.addItemId(shouldAddItem == true ? loot.id : 0);
 		newmsg.addByte(difficult);
 		newmsg.addByte(0); // 1 if special event - 0 if regular loot (?)
-		if (currentLevel > 1)
+		if (shouldAddItem == true)
 		{
 			newmsg.addString(loot.name);
 			newmsg.addByte(loot.countmax > 0 ? 0x1 : 0x0);

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -1852,7 +1852,6 @@ void ProtocolGame::parseBestiarysendMonsterData(NetworkMessage &msg)
 				shouldAddItem = true;
 				break;
 		}
-		
 
 		newmsg.addItemId(shouldAddItem == true ? loot.id : 0);
 		newmsg.addByte(difficult);


### PR DESCRIPTION
https://tibia.fandom.com/wiki/Cyclopedia#Bestiary
Image show how its work, before this fix all loot is added without regard to the monster discovery level
Missing: very rare loot not being discovered when droped by monster, instead i move the thresholds for uncommon, semi rare, very rare will be fully discovered on complete bestiary
![bestiary](https://user-images.githubusercontent.com/17506599/130831163-07281659-1ada-47bc-9768-c8aa24b97555.png)
