### PR TITLE
Fix decaying items crash in bosses #2709

### DIFF
--- a/data/lib/others/reward_boss_lib.lua
+++ b/data/lib/others/reward_boss_lib.lua
@@ -66,7 +66,7 @@ function MonsterType.createLootItem(self, lootBlock, chance, lootTable)
 	if decayTo and decayTo >= 0 and decayTime and decayTime ~= 0 then
 		local transformDeEquipId = itemType:getTransformDeEquipId()
 		if transformDeEquipId and transformDeEquipId > 0 then
-			print("[Warning - MonsterType.createLootItem] Convert boss '" .. self:name() .. "' reward ID '" .. lootBlock.itemId .. "' to ID " .. transformDeEquipId .. ".")
+			Spdlog.warn("[MonsterType.createLootItem] - Convert boss '" .. self:name() .. "' reward ID '" .. lootBlock.itemId .. "' to ID " .. transformDeEquipId .. ".")
 			lootBlock.itemId = transformDeEquipId
 		else
 			print("[Error - MonsterType.createLootItem] Cannot add item " .. lootBlock.itemId .. " as boss " .. self:name() .. " reward. It has decay.")

--- a/data/lib/others/reward_boss_lib.lua
+++ b/data/lib/others/reward_boss_lib.lua
@@ -69,7 +69,7 @@ function MonsterType.createLootItem(self, lootBlock, chance, lootTable)
 			Spdlog.warn("[MonsterType.createLootItem] - Convert boss '" .. self:name() .. "' reward ID '" .. lootBlock.itemId .. "' to ID " .. transformDeEquipId .. ".")
 			lootBlock.itemId = transformDeEquipId
 		else
-			print("[Error - MonsterType.createLootItem] Cannot add item " .. lootBlock.itemId .. " as boss " .. self:name() .. " reward. It has decay.")
+			Spdlog.error("[MonsterType.createLootItem] Cannot add item " .. lootBlock.itemId .. " as boss " .. self:name() .. " reward. It has decay.")
 			return lootTable
 		end
 	end

--- a/data/lib/others/reward_boss_lib.lua
+++ b/data/lib/others/reward_boss_lib.lua
@@ -60,6 +60,20 @@ function MonsterType.createLootItem(self, lootBlock, chance, lootTable)
 		end
 	end
 
+	local itemType = ItemType(lootBlock.itemId)
+	local decayTo = itemType:getDecayId()
+	local decayTime = itemType:getDecayTime()
+	if decayTo and decayTo >= 0 and decayTime and decayTime ~= 0 then
+		local transformDeEquipId = itemType:getTransformDeEquipId()
+		if transformDeEquipId and transformDeEquipId > 0 then
+			print("[Warning - MonsterType.createLootItem] Convert boss '" .. self:name() .. "' reward ID '" .. lootBlock.itemId .. "' to ID " .. transformDeEquipId .. ".")
+			lootBlock.itemId = transformDeEquipId
+		else
+			print("[Error - MonsterType.createLootItem] Cannot add item " .. lootBlock.itemId .. " as boss " .. self:name() .. " reward. It has decay.")
+			return lootTable
+		end
+	end
+
 	while itemCount > 0 do
 		local n = math.min(itemCount, 100)
 		itemCount = itemCount - n


### PR DESCRIPTION
# Description

Bosses drop decaying items. If you open 'reward container' in boss corpse, not pick decaying items and corpse disappear, it will crash server.

## Behaviour
### **Actual**

Server crash.

### **Expected**

Server does not crash.

## Fixes

#2709

## Type of change

  - Bug fix (non-breaking change which fixes an issue)
Operating System:

