### PR TITLE
Fix npc message find bug (resolves #2736)

### DIFF
--- a/data/npc/lib/npc.lua
+++ b/data/npc/lib/npc.lua
@@ -5,12 +5,12 @@ dofile('data/npc/lib/npcsystem/customModules.lua')
 isPlayerPremiumCallback = Player.isPremium
 
 function msgcontains(message, keyword)
-	local message, keyword = message:lower(), keyword:lower()
-	if message == keyword then
+	local lowerMessage, lowerKeyword = message:lower(), keyword:lower()
+	if lowerMessage == lowerKeyword then
 		return true
 	end
 
-	return message:find(keyword) and not message:find('(%w+)' .. keyword)
+	return string.find(lowerMessage, lowerKeyword) and string.find(lowerMessage, lowerKeyword.. '(%w+)')
 end
 
 function doNpcSellItem(cid, itemId, amount, subType, ignoreCap, inBackpacks, backpack)

--- a/data/npc/lib/npcsystem/modules.lua
+++ b/data/npc/lib/npcsystem/modules.lua
@@ -349,7 +349,7 @@ if Modules == nil then
 	function FocusModule.messageMatcher(keywords, message)
 		for i, word in pairs(keywords) do
 			if type(word) == "string" then
-				if string.find(message, word) and not string.find(message, "[%w+]" .. word) and not string.find(message, word .. "[%w+]") then
+				if string.find(message, word) and not string.find(message, "[%w+]" .. word) and string.find(message, word .. "[%w+]") then
 					return true
 				end
 			end


### PR DESCRIPTION
# Description

This solves the problem that a keyword that contains two or more words can be confused with a keyword that contains only one word of the same type in the string.

## Behaviour
### **Actual**

![image](https://user-images.githubusercontent.com/8551443/132971931-7f5be294-6e63-407e-9f07-ce809812f95f.png)

### **Expected**

![image](https://user-images.githubusercontent.com/8551443/132971895-cef2821a-9432-4db3-93b4-c59dfc467f77.png)

## Fixes

Resolves #2736

## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
