### PR TITLE
Fix remove imbuing from item

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -6554,24 +6554,21 @@ void Game::checkImbuements()
 
 		bool needUpdate = false;
 		uint8_t slots = Item::items[item->getID()].imbuingSlots;
+		int32_t index = player ? player->getThingIndex(item) : -1;
 		for (uint8_t slot = 0; slot < slots; slot++) {
 			uint32_t info = item->getImbuement(slot);
 			int32_t duration = info >> 8;
 			int32_t newDuration = std::max(0, (duration - (EVENT_IMBUEMENTINTERVAL * EVENT_IMBUEMENT_BUCKETS) / 690));
 			if (duration > 0 && newDuration == 0) {
 				needUpdate = true;
-			}
-		}
-
-		int32_t index = player ? player->getThingIndex(item) : -1;
-		needUpdate = needUpdate && index != -1;
-
-		if (needUpdate) {
-			player->postRemoveNotification(item, player, index);
-			ReleaseItem(item);
-			it = imbuedItems[bucket].erase(it);
-			for (uint8_t slot = 0; slot < slots; slot++) {
-				item->setImbuement(slot, 0);
+				if (index != -1)
+				{
+					needUpdate = true;
+					player->postRemoveNotification(item, player, index);
+					ReleaseItem(item);
+					it = imbuedItems[bucket].erase(it);
+					item->setImbuement(slot, 0);
+				}
 			}
 		}
 


### PR DESCRIPTION
# Description

Fix remove imbuing from item

## Behaviour
### **Actual**

When one imbuing end, all imbuing from item will be removed

### **Expected**

Only one imbuing removed

## Fixes

#2649

## Type of change

src: Game::checkImbuements()

Please delete options that are not relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested
Equip imbuing item and wait(for fast test set in imbuements.xml duration to 60(1min)