### PR TITLE
Fixes a potential crash by checking if tile is not a null pointer in Player::getClientIcons function

### DIFF
--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -435,7 +435,7 @@ uint32_t Player::getClientIcons() const
 		icons |= ICON_REDSWORDS;
 	}
 
-	if (tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
+	if (tile && tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
 		icons |= ICON_PIGEON;
 		client->sendRestingStatus(1);
 


### PR DESCRIPTION
Fixes a potential crash by checking if tile is not a null pointer in Player::getClientIcons

Co-Authored-By: @dbjorkholm
https://github.com/otland/forgottenserver/pull/3662