### PR TITLE
Fix stamina gain event

### DIFF
--- a/data/events/scripts/creature.lua
+++ b/data/events/scripts/creature.lua
@@ -120,14 +120,7 @@ function Creature:onTargetCombat(target)
 		end
 	end
 
-	if self:isPlayer() then
-		if target and target:getName() == staminaBonus.target then
-			local playerId = self:getId()
-			if not staminaBonus.eventsTrainer[playerId] then
-				staminaBonus.eventsTrainer[playerId] = addEvent(addStamina, staminaBonus.period, playerId)
-			end
-		end
-	end
+	self:addEventStamina(target)
 	return true
 end
 

--- a/data/lib/core/creature.lua
+++ b/data/lib/core/creature.lua
@@ -197,3 +197,13 @@ function Creature.checkCreatureInsideDoor(player, toPosition)
 		creature:teleportTo(toPosition, true)
 	end
 end
+
+function Creature:addEventStamina(player)
+	local getPlayer = player:getPlayer()
+	if getPlayer and getPlayer:getName() == staminaBonus.player then
+		local playerId = getPlayer:getId()
+		if not staminaBonus.eventsTrainer[playerId] then
+			staminaBonus.eventsTrainer[playerId] = addEvent(addStamina, staminaBonus.period, playerId)
+		end
+	end
+end


### PR DESCRIPTION
# Description

The function was returning nil, because instead of validating the target (player), it was validating the self (creature), the same for the "playerId", which was facing the "self", and not the "target", causing the event to never run.

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works