### PR TITLE
Fix speed breakpoint

### DIFF
--- a/src/creatures/players/player.h
+++ b/src/creatures/players/player.h
@@ -132,7 +132,7 @@ struct Kill {
 
 using MuteCountMap = std::map<uint32_t, uint32_t>;
 
-static constexpr int32_t PLAYER_MAX_SPEED = 4500;
+static constexpr int32_t PLAYER_MAX_SPEED = 100000;
 static constexpr int32_t PLAYER_MIN_SPEED = 10;
 
 class Player final : public Creature, public Cylinder


### PR DESCRIPTION
# Description

Change maximum player speed in game to breakpoints on tiles. I suggested putting 100k, but on the client the speed will always be half of the number you put. table with the speed needed for "bug speed": [link](https://i.imgur.com/cIBlrZs.png)

## Behaviour
### **Actual**

Do this and that doesn't happens

### **Expected**

Do this and that happens

## Fixes

\# (issue)

## Type of change

Please delete options that are not relevant.

  - [ *] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

## How Has This Been Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  - [*] Test A: [link](https://prnt.sc/1u0p53x)
  - [ ] Test B

**Test Configuration**:

  - Server Version: 12.64
  - Client: tibia 12
  - Operating System: ubuntu 20

## Checklist

  - [ ] My code follows the style guidelines of this project
  - [ ] I have performed a self-review of my own code
  - [ ] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
